### PR TITLE
fix: create a new condition to validate the level of character

### DIFF
--- a/Heart/Character/Domain/Entities/LevelEntity.php
+++ b/Heart/Character/Domain/Entities/LevelEntity.php
@@ -69,6 +69,11 @@ class LevelEntity
         $averageMessageLength = 25;
         $memberStatusMultiplier = $isSupporter ? 0.25 : 0.4;
         $messagePound = ($messageLength / $averageMessageLength);
+
+        if ($this->level === 0) {
+            $this->level += 1;
+        }
+
         $experienceObtained = ($messagePound / ($this->level * $memberStatusMultiplier) * 20);
         $this->addExperience($experienceObtained);
 

--- a/Heart/Character/Domain/Entities/LevelEntity.php
+++ b/Heart/Character/Domain/Entities/LevelEntity.php
@@ -70,14 +70,19 @@ class LevelEntity
         $memberStatusMultiplier = $isSupporter ? 0.25 : 0.4;
         $messagePound = ($messageLength / $averageMessageLength);
 
-        if ($this->level === 0) {
-            $this->level += 1;
-        }
-
-        $experienceObtained = ($messagePound / ($this->level * $memberStatusMultiplier) * 20);
+        $experienceObtained = ($messagePound / ($this->checkLevelEntity($this->level) * $memberStatusMultiplier) * 20);
         $this->addExperience($experienceObtained);
 
         return (int) $experienceObtained;
+    }
+
+    private function checkLevelEntity(int $level): int
+    {
+        if ($this->level !== 0) {
+            return $level;
+        }
+
+        return 1;
     }
 
     public function generateVoiceExperience(VoiceStatesEnum $states, bool $isSupporter = false): int

--- a/tests/Feature/Message/NewMessageTest.php
+++ b/tests/Feature/Message/NewMessageTest.php
@@ -43,7 +43,36 @@ class NewMessageTest extends TestCase
         ]);
     }
 
-    public function testCanCreateAMessageAndReceiveAMeetingCheck()
+    public function testCanCreateAMessageWithLevelZero(): void
+    {
+        Cache::tags(['meetings'])->flush();
+
+        $user = User::factory()
+            ->has(Character::factory(['experience' => 0]), 'character')
+            ->has(Provider::factory(), 'providers')
+            ->create();
+        $provider = $user->providers[0];
+        $payload = [
+            'provider' => $provider->provider,
+            'provider_id' => $provider->provider_id,
+            'provider_message_id' => '12312312',
+            'channel_id' => '312321',
+            'content' => '321312',
+            'sent_at' => now()->toDateTimeString(),
+        ];
+
+        $this
+            ->actingAsAdmin()
+            ->postJson(route('messages.create', ['provider' => $provider->provider]), $payload)
+            ->assertNoContent();
+
+        $this->assertDatabaseMissing('characters', [
+            'user_id' => $user->getKey(),
+            'experience' => 1,
+        ]);
+    }
+
+    public function testCanCreateAMessageAndReceiveAMeetingCheck(): void
     {
         Cache::tags(['meetings'])->flush();
 


### PR DESCRIPTION
## Problem 
A pessoa começa com o level 0, e em um dos processos de gerar a experiencia, ocorre uma divisão usando o level da pessoa. E isso ocasionava no seguinte erro.
![image](https://github.com/he4rt/he4rt-bot-api/assets/80018897/b04c499f-f250-4d59-be10-ac8f14de2ed1)