### PR TITLE
fix(user): refactor FilamentPanel usage and add FilamentServiceProvider

### DIFF
--- a/app-modules/user/src/Plugins/AdminUserPanelPlugin.php
+++ b/app-modules/user/src/Plugins/AdminUserPanelPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\User\Plugins;
 
-use App\Providers\Filament\FilamentPanel;
+use App\Enums\FilamentPanel;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 

--- a/app-modules/user/src/Plugins/AppUserPanelPlugin.php
+++ b/app-modules/user/src/Plugins/AppUserPanelPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\User\Plugins;
 
-use App\Providers\Filament\FilamentPanel;
+use App\Enums\FilamentPanel;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 

--- a/app-modules/user/src/Plugins/GuestUserPanelPlugin.php
+++ b/app-modules/user/src/Plugins/GuestUserPanelPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\User\Plugins;
 
-use App\Providers\Filament\FilamentPanel;
+use App\Enums\FilamentPanel;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 

--- a/app-modules/user/src/Plugins/PartnerUserPanelPlugin.php
+++ b/app-modules/user/src/Plugins/PartnerUserPanelPlugin.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\User\Plugins;
 
-use App\Providers\Filament\FilamentPanel;
+use App\Enums\FilamentPanel;
 use Filament\Contracts\Plugin;
 use Filament\Panel;
 

--- a/app-modules/user/src/Providers/UserServiceProvider.php
+++ b/app-modules/user/src/Providers/UserServiceProvider.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\User\Providers;
 
-use App\Providers\Filament\FilamentPanel;
+use App\Enums\FilamentPanel;
 use Filament\Panel;
 use He4rt\User\Contracts\UserRepository;
 use He4rt\User\Plugins\AdminUserPanelPlugin;

--- a/app/Enums/FilamentPanel.php
+++ b/app/Enums/FilamentPanel.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace App\Providers\Filament;
+namespace App\Enums;
 
 enum FilamentPanel: string
 {
     case Admin = 'admin';
     case Partner = 'partner';
-    case User = 'app';
+    case User = 'user';
     case Guest = 'guest';
 
     public function moduleName(string $module): string

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Providers;
 
-use App\Providers\Filament\FilamentPanel;
-use Filament\Panel;
 use Illuminate\Support\ServiceProvider;
 
 final class AppServiceProvider extends ServiceProvider
@@ -16,37 +14,5 @@ final class AppServiceProvider extends ServiceProvider
     public function register(): void
     {
         //
-    }
-
-    /**
-     * Bootstrap any application services.
-     */
-    public function boot(): void
-    {
-        Panel::macro('currentPanel', fn (): FilamentPanel => FilamentPanel::from($this->getId()));
-
-        Panel::macro('discoverResourcesForPanel', function (string $module, FilamentPanel $panel): void {
-            $studlyPanel = str($panel->name)->studly();
-
-            $filamentModulePath = module_path($module, sprintf('src/Filament/%s', $studlyPanel));
-            $filamentModuleNamespace = sprintf('He4rt\\%s\\Filament\\%s', str($module)->studly(), $studlyPanel);
-
-            $in = $filamentModulePath.'/Resources';
-            $for = $filamentModuleNamespace.'\\Resources';
-
-            $this
-                ->discoverResources(
-                    in: $in,
-                    for: $for,
-                )
-                ->discoverWidgets(
-                    in: $filamentModulePath.'/Widgets',
-                    for: $filamentModuleNamespace.'\\Widgets',
-                )
-                ->discoverPages(
-                    in: $filamentModulePath.'/Pages',
-                    for: $filamentModuleNamespace.'\\Pages',
-                );
-        });
     }
 }

--- a/app/Providers/Filament/FilamentServiceProvider.php
+++ b/app/Providers/Filament/FilamentServiceProvider.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Providers\Filament;
+
+use App\Enums\FilamentPanel;
+use Filament\Panel;
+use Illuminate\Support\ServiceProvider;
+
+final class FilamentServiceProvider extends ServiceProvider
+{
+    public function register(): void
+    {
+        Panel::macro('currentPanel', fn (): FilamentPanel => FilamentPanel::from($this->getId()));
+
+        Panel::macro('discoverResourcesForPanel', function (string $module, FilamentPanel $panel): void {
+            $studlyPanel = str($panel->name)->studly();
+
+            $filamentModulePath = module_path($module, sprintf('src/Filament/%s', $studlyPanel));
+            $filamentModuleNamespace = sprintf('He4rt\\%s\\Filament\\%s', str($module)->studly(), $studlyPanel);
+
+            $in = $filamentModulePath.'/Resources';
+            $for = $filamentModuleNamespace.'\\Resources';
+
+            $this
+                ->discoverResources(
+                    in: $in,
+                    for: $for,
+                )
+                ->discoverWidgets(
+                    in: $filamentModulePath.'/Widgets',
+                    for: $filamentModuleNamespace.'\\Widgets',
+                )
+                ->discoverPages(
+                    in: $filamentModulePath.'/Pages',
+                    for: $filamentModuleNamespace.'\\Pages',
+                );
+        });
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use App\Providers\AppServiceProvider;
 use App\Providers\EventServiceProvider;
 use App\Providers\Filament\AdminPanelProvider;
+use App\Providers\Filament\FilamentServiceProvider;
 use App\Providers\Filament\GuestPanelProvider;
 use App\Providers\Filament\PartnerPanelProvider;
 use App\Providers\Filament\UserPanelProvider;
@@ -12,6 +13,7 @@ use App\Providers\RouteServiceProvider;
 
 return [
     AppServiceProvider::class,
+    FilamentServiceProvider::class,
     EventServiceProvider::class,
     AdminPanelProvider::class,
     GuestPanelProvider::class,

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "filament/filament": "^4.0",
+        "filament/filament": "^4.2",
         "guzzlehttp/guzzle": "^7.10.0",
         "he4rt/authentication": ">=1",
         "he4rt/badge": "^1.0.0",
@@ -33,7 +33,7 @@
     },
     "require-dev": {
         "barryvdh/laravel-ide-helper": "^3.6.0",
-        "driftingly/rector-laravel": "^2.1.2",
+        "driftingly/rector-laravel": "^2.1.3",
         "fakerphp/faker": "^1.24.1",
         "larastan/larastan": "^3.8.0",
         "laravel/pail": "^1.2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e984227e3dd65248df6735ec3a6adb28",
+    "content-hash": "fd3082a25b8ba9892fe601a97949dd74",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",


### PR DESCRIPTION
This pull request refactors how the `FilamentPanel` enum is organized and used throughout the codebase, improves the modularity of Filament panel macros, and updates some dependencies. The most significant change is moving `FilamentPanel` from the `App\Providers\Filament` namespace to `App\Enums`, and relocating the Filament panel macros to a new dedicated service provider. This enhances code structure and maintainability.

**Refactoring and Code Organization:**

* Moved `FilamentPanel` from `app/Providers/Filament/FilamentPanel.php` to `app/Enums/FilamentPanel.php`, changing its namespace to `App\Enums` and updating all usages accordingly. Also, the value for the `User` case was changed from `'app'` to `'user'`.
* Removed the Filament panel macros (`currentPanel` and `discoverResourcesForPanel`) from `AppServiceProvider` and moved them into a new `FilamentServiceProvider` in `app/Providers/Filament/FilamentServiceProvider.php` for better separation of concerns.

**Dependency Updates:**

* Updated the `filament/filament` dependency from `^4.0` to `^4.2` and `driftingly/rector-laravel` from `^2.1.2` to `^2.1.3` in `composer.json`.

**Application Bootstrapping:**

* Registered the new `FilamentServiceProvider` in `bootstrap/providers.php` to ensure the new macros are loaded.

These changes collectively improve the maintainability and clarity of the Filament panel-related code and keep dependencies up to date.