### PR TITLE
chore: minor rector and phpstan fixies

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -16,3 +16,6 @@ indent_size = 2
 
 [{Makefile,**.mk}]
 indent_style = tab
+
+[.neon]
+indent_size = 2

--- a/app-modules/badge/phpstan.ignore.neon
+++ b/app-modules/badge/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/BadgeServiceProvider.php

--- a/app-modules/events/phpstan.ignore.neon
+++ b/app-modules/events/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/EventsServiceProvider.php

--- a/app-modules/events/src/Actions/AttendEventAction.php
+++ b/app-modules/events/src/Actions/AttendEventAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Actions;
 
+use Exception;
 use He4rt\Events\Models\EventModel;
 
 final class AttendEventAction

--- a/app-modules/feedback/phpstan.ignore.neon
+++ b/app-modules/feedback/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/FeedbackServiceProvider.php

--- a/app-modules/meeting/phpstan.ignore.neon
+++ b/app-modules/meeting/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/MeetingServiceProvider.php

--- a/app-modules/message/phpstan.ignore.neon
+++ b/app-modules/message/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/MessageServiceProvider.php

--- a/app-modules/season/phpstan.ignore.neon
+++ b/app-modules/season/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/SeasonServiceProvider.php

--- a/app-modules/sponsors/phpstan.ignore.neon
+++ b/app-modules/sponsors/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/SponsorsServiceProvider.php

--- a/app-modules/tenant/phpstan.ignore.neon
+++ b/app-modules/tenant/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/TenantServiceProvider.php

--- a/app-modules/user/phpstan.ignore.neon
+++ b/app-modules/user/phpstan.ignore.neon
@@ -1,2 +1,6 @@
 parameters:
     ignoreErrors:
+        - message: '#^Call to an undefined method Filament\\Panel::currentPanel\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: src/Providers/UserServiceProvider.php

--- a/app/Livewire/ConnectionHub.php
+++ b/app/Livewire/ConnectionHub.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace App\Livewire;
 
 use He4rt\Authentication\Enums\OAuthProviderEnum;
+use He4rt\Tenant\Models\Tenant;
 use Illuminate\Contracts\View\View;
+use Illuminate\Http\RedirectResponse;
 use Livewire\Attributes\Computed;
 use Livewire\Component;
 
@@ -25,10 +27,13 @@ class ConnectionHub extends Component
         ]);
     }
 
-    public function connect(OAuthProviderEnum $provider)
+    public function connect(OAuthProviderEnum $provider): RedirectResponse
     {
-        session()->put('tenant', filament()->getTenant()->slug);
-        $redirectUri = $provider->getClient()->redirectUrl(filament()->getTenant()->slug);
+        /** @var Tenant $tenant */
+        $tenant = filament()->getTenant();
+
+        session()->put('tenant', $tenant->slug);
+        $redirectUri = $provider->getClient()->redirectUrl($tenant->slug);
 
         return redirect()->away($redirectUri);
     }

--- a/config/app.php
+++ b/config/app.php
@@ -103,7 +103,7 @@ return [
 
     'previous_keys' => [
         ...array_filter(
-            explode(',', env('APP_PREVIOUS_KEYS', ''))
+            explode(',', (string) env('APP_PREVIOUS_KEYS', ''))
         ),
     ],
 

--- a/config/logging.php
+++ b/config/logging.php
@@ -56,7 +56,7 @@ return [
 
         'stack' => [
             'driver' => 'stack',
-            'channels' => explode(',', env('LOG_STACK', 'single')),
+            'channels' => explode(',', (string) env('LOG_STACK', 'single')),
             'ignore_exceptions' => false,
         ],
 

--- a/config/mail.php
+++ b/config/mail.php
@@ -48,7 +48,7 @@ return [
             'username' => env('MAIL_USERNAME'),
             'password' => env('MAIL_PASSWORD'),
             'timeout' => null,
-            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url(env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
+            'local_domain' => env('MAIL_EHLO_DOMAIN', parse_url((string) env('APP_URL', 'http://localhost'), PHP_URL_HOST)),
         ],
 
         'ses' => [

--- a/config/sanctum.php
+++ b/config/sanctum.php
@@ -17,7 +17,7 @@ return [
     |
     */
 
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', sprintf(
+    'stateful' => explode(',', (string) env('SANCTUM_STATEFUL_DOMAINS', sprintf(
         '%s%s',
         'localhost,localhost:3000,127.0.0.1,127.0.0.1:8000,::1',
         Sanctum::currentApplicationUrlWithPort()

--- a/rector.php
+++ b/rector.php
@@ -27,8 +27,6 @@ return RectorConfig::configure()
         __DIR__.'/database',
         __DIR__.'/routes',
         __DIR__.'/tests',
-    ])
-    ->withPaths([
         __DIR__.'/app-modules/*/src',
         __DIR__.'/app-modules/*/config',
         __DIR__.'/app-modules/*/database',


### PR DESCRIPTION
This pull request introduces a few minor code quality improvements and configuration tweaks across the codebase. The main changes involve adding PHPStan ignore rules for a specific method-not-found warning in several app modules, updating some environment variable handling for better type safety, and making minor import and configuration adjustments.

Configuration and static analysis:

* Added PHPStan ignore rules for the `Filament\Panel::currentPanel()` method-not-found warning in multiple module `phpstan.ignore.neon` files, preventing these known issues from blocking static analysis, since it's a custom macro defined inside the project.

Environment variable handling improvements:

* Cast environment variable values to string before using them in `explode()` in several config files (`config/app.php`, `config/logging.php`, `config/mail.php`, `config/sanctum.php`) to avoid potential type issues.

Code and import cleanups:

* Added missing imports in `app/Livewire/ConnectionHub.php` for `Tenant` and `RedirectResponse`, and updated the `connect` method to use a typed `Tenant` variable for clarity.
* Added `Exception` import in `app-modules/events/src/Actions/AttendEventAction.php`.

Editor and tool configuration:

* Added `.editorconfig` rule to set `indent_size = 2` for `.neon` files.
* Minor cleanup in `rector.php` paths configuration.