### PR TITLE
fix: add password hash when creating a new user

### DIFF
--- a/app-modules/user/src/Filament/Admin/Resources/Users/Schemas/UserForm.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/Schemas/UserForm.php
@@ -6,6 +6,7 @@ namespace He4rt\User\Filament\Admin\Resources\Users\Schemas;
 
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\Hash;
 
 class UserForm
 {
@@ -16,7 +17,7 @@ class UserForm
                 TextInput::make('name'),
                 TextInput::make('username'),
                 TextInput::make('email'),
-                TextInput::make('password'),
+                TextInput::make('password')->password()->dehydrateStateUsing(fn ($state) => Hash::make($state)),
             ]);
     }
 }


### PR DESCRIPTION
fix: hash user passwords on creation via Filament dashboard

This update enhances user account security by ensuring that passwords created through the Filament admin dashboard are properly hashed before being stored.

Filament User Creation Improvement:

Added automatic password hashing to the password field when creating new users in Filament using:
TextInput::make('password')->password()->dehydrateStateUsing(fn ($state) => Hash::make($state));

This ensures all new users created via the dashboard have securely hashed passwords and prevents accidental storage of plain-text credentials.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced password security in user administration. User passwords are now processed with improved security protocols to ensure proper credential protection during account creation, updates, and all administrative credential management operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->