### PR TITLE
ci: disable CI usage on draft pull requests

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,11 +2,10 @@ name: Continuous Integration
 
 on:
   push:
-    branches:
-      - 3.x
+    branches: [3.x]
   pull_request:
-    branches:
-      - 3.x
+    branches: [3.x]
+    types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -16,6 +15,7 @@ jobs:
   setup:
     name: Setup PHP
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }}
     timeout-minutes: 5
     outputs:
       CACHE_KEY: ${{ steps.cache.outputs.key }}
@@ -61,8 +61,8 @@ jobs:
 
   pint:
     name: Perform Pint format
-    needs:
-      - setup
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/_pint.yml
     with:
       CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
@@ -73,8 +73,8 @@ jobs:
 
   rector:
     name: Perform Rector Check
-    needs:
-      - setup
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/_rector.yml
     with:
       CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
@@ -85,8 +85,8 @@ jobs:
 
   phpstan:
     name: Perform Phpstan Check
-    needs:
-      - setup
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/_phpstan.yml
     with:
       CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
@@ -97,8 +97,8 @@ jobs:
 
   pest:
     name: Perform Pest Tests
-    needs:
-      - setup
+    needs: [setup]
+    if: ${{ !github.event.pull_request.draft }}
     uses: ./.github/workflows/_pest.yml
     with:
       CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow configuration for continuous integration to streamline branch targeting, add more pull request event triggers, and ensure jobs are only run for non-draft pull requests. The changes help avoid unnecessary CI runs for draft PRs and make the workflow definitions more concise.

- Updated the `push` and `pull_request` triggers to use a more compact array syntax for the `3.x` branch and added specific pull request event types (`opened`, `reopened`, `synchronize`, `ready_for_review`) to better control when the workflow runs.
- Added an `if: ${{ !github.event.pull_request.draft }}` condition to the `setup`, `pint`, `rector`, `phpstan`, and `pest` jobs to prevent CI jobs from running on draft pull requests.
- Simplified the `needs` syntax for jobs (`pint`, `rector`, `phpstan`, `pest`) by using array notation instead of multi-line lists.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined CI workflow triggers and job dependency declarations.
  * Jobs now skip automatically for draft pull requests.
  * Setup step exposes additional PHP-related outputs that are propagated to downstream jobs.
  * Consistency and wiring improvements across CI jobs for more reliable and maintainable pipeline behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->