### PR TITLE
fix: add `FilamentServiceProvider::viteTheme` to phpstan ignore

### DIFF
--- a/phpstan.ignore.neon
+++ b/phpstan.ignore.neon
@@ -9,3 +9,8 @@ parameters:
           identifier: method.notFound
           count: 1
           path: app/Providers/FilamentServiceProvider.php
+
+        - message: '#^Call to an undefined method App\\Providers\\FilamentServiceProvider::viteTheme\(\)\.$#'
+          identifier: method.notFound
+          count: 1
+          path: app/Providers/FilamentServiceProvider.php


### PR DESCRIPTION
> [!NOTE]
> TL;DR: This is a false positive for now. Filament doesn't provide good support for PHPStan when it comes to macros.

___

This pull request makes a minor update to the static analysis ignore configuration by adding a new rule to suppress a specific method-not-found warning in `FilamentServiceProvider.php`. 

* Added an ignore rule for the undefined method `viteTheme()` in `app/Providers/FilamentServiceProvider.php` to the `phpstan.ignore.neon` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated static analysis configuration to suppress development tooling warnings, improving the development experience without affecting application functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->