### PR TITLE
fix: remove unused import and visibility condition in SeasonForm

### DIFF
--- a/app-modules/season/src/Filament/Resources/Seasons/Schemas/SeasonForm.php
+++ b/app-modules/season/src/Filament/Resources/Seasons/Schemas/SeasonForm.php
@@ -9,7 +9,6 @@ use Filament\Forms\Components\RichEditor;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TextInput;
 use Filament\Schemas\Schema;
-use He4rt\Tenant\Filament\Admin\Resources\Tenants\RelationManagers\SeasonsRelationManager;
 
 class SeasonForm
 {
@@ -19,7 +18,6 @@ class SeasonForm
             ->components([
                 Select::make('tenant_id')
                     ->relationship('tenant', 'name')
-                    ->visible(fn ($livewire) => ! ($livewire instanceof SeasonsRelationManager))
                     ->required(),
                 TextInput::make('name')
                     ->required(),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* The tenant ID field in season forms now displays consistently in all contexts instead of being conditionally hidden.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->