### PR TITLE
chore: fixing users relation managers

### DIFF
--- a/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/AddressRelationManager.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/AddressRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\User\Filament\Admin\Resources\Users\RelationManagers;
 
 use Filament\Actions\CreateAction;
+use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -23,6 +24,7 @@ class AddressRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->paginated(false)
             ->columns([
                 TextColumn::make('country')
                     ->badge()
@@ -37,8 +39,12 @@ class AddressRelationManager extends RelationManager
                     ->badge()
                     ->searchable(),
             ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
             ->headerActions([
-                CreateAction::make(),
+                CreateAction::make()
+                    ->visible(fn ($livewire) => ! $livewire->ownerRecord->address()->exists()),
             ]);
     }
 }

--- a/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/CharacterRelationManager.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/CharacterRelationManager.php
@@ -15,6 +15,7 @@ class CharacterRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->paginated(false)
             ->columns([
                 TextColumn::make('tenant.name')
                     ->searchable()

--- a/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/InformationRelationManager.php
+++ b/app-modules/user/src/Filament/Admin/Resources/Users/RelationManagers/InformationRelationManager.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\User\Filament\Admin\Resources\Users\RelationManagers;
 
 use Filament\Actions\CreateAction;
+use Filament\Actions\ViewAction;
 use Filament\Resources\RelationManagers\RelationManager;
 use Filament\Schemas\Schema;
 use Filament\Tables\Columns\TextColumn;
@@ -23,6 +24,7 @@ class InformationRelationManager extends RelationManager
     public function table(Table $table): Table
     {
         return $table
+            ->paginated(false)
             ->columns([
                 TextColumn::make('name')
                     ->label('Name')
@@ -40,8 +42,12 @@ class InformationRelationManager extends RelationManager
                     ->label('Name')
                     ->searchable(),
             ])
+            ->recordActions([
+                ViewAction::make(),
+            ])
             ->headerActions([
-                CreateAction::make(),
+                CreateAction::make()
+                    ->visible(fn ($livewire) => ! $livewire->ownerRecord->information()->exists()),
             ]);
     }
 }

--- a/app-modules/user/tests/Feature/Filament/Admin/Resources/User/RelationManagers/AddressRelationManagerTest.php
+++ b/app-modules/user/tests/Feature/Filament/Admin/Resources/User/RelationManagers/AddressRelationManagerTest.php
@@ -59,3 +59,13 @@ it('should be able to register an address for an user', function (): void {
         ->and($address->city)->toBe('tiradentes')
         ->and($address->zip_code)->toBe('091204200');
 });
+
+test('should not be able to register an address twice', function (): void {
+    Address::factory()
+        ->recycle($this->user)
+        ->create();
+    $action = TestAction::make(CreateAction::class)->table();
+    livewire(AddressRelationManager::class, ['ownerRecord' => $this->user, 'pageClass' => EditUser::class])
+        ->assertOk()
+        ->assertActionDisabled($action);
+});

--- a/app-modules/user/tests/Feature/Filament/Admin/Resources/User/RelationManagers/InformationRelationManagerTest.php
+++ b/app-modules/user/tests/Feature/Filament/Admin/Resources/User/RelationManagers/InformationRelationManagerTest.php
@@ -56,3 +56,13 @@ it('should be able to register information about the user', function (): void {
         ->and($information->linkedin_url)->toBe('https://linkedin.com/in/johndoe')
         ->and($information->birthdate)->toBe('2000-01-01');
 });
+
+test('should not be able to register user information twice', function (): void {
+    Information::factory()
+        ->recycle($this->user)
+        ->create();
+    $action = TestAction::make(CreateAction::class)->table();
+    livewire(InformationRelationManager::class, ['ownerRecord' => $this->user, 'pageClass' => EditUser::class])
+        ->assertOk()
+        ->assertActionDisabled($action);
+});


### PR DESCRIPTION
##### I actually made some mistakes, I shouldn't have created relation manager for ```Address``` ,```Character``` and ```Information``` for user resource, 'cause all those 3 guys are 1-1 relationships, but to not refactor too much I decided to stay with, and make sure that after create one it will not be possible to create another one   