### PR TITLE
feat(discord): configure bot channels and add service provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,3 +88,7 @@ setup: ## Setup the project
 	@php artisan key:generate --ansi
 	@php artisan storage:link --ansi
 	@composer run-script ide-helper
+
+.PHONY: bot
+bot: ## Run the Discord bot
+	@php artisan bot:boot

--- a/app-modules/bot-discord/config/bot-discord.php
+++ b/app-modules/bot-discord/config/bot-discord.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'channels' => [
+        'presentations' => env('HE4RT_PRESENTATIONS_CHANNEL_ID', '540993663468306433'),
+    ],
+];

--- a/app-modules/bot-discord/src/Events/WelcomeMember.php
+++ b/app-modules/bot-discord/src/Events/WelcomeMember.php
@@ -19,7 +19,7 @@ class WelcomeMember extends Event
 
     public function handle(Member $member, Discord $discord): void
     {
-        $channelId = '756664919709057046'; // TODO: Definir o ID do canal de boas-vindas
+        $channelId = config('bot-discord.channels.presentations');
 
         $tenantProvider = Provider::query()
             ->where('model_type', Tenant::class)

--- a/app-modules/bot-discord/src/Providers/BotDiscordServiceProvider.php
+++ b/app-modules/bot-discord/src/Providers/BotDiscordServiceProvider.php
@@ -9,6 +9,24 @@ use Laracord\LaracordServiceProvider;
 
 class BotDiscordServiceProvider extends LaracordServiceProvider
 {
+    public function register(): void
+    {
+        parent::register();
+
+        $this->mergeConfigFrom(__DIR__.'/../../config/bot-discord.php', 'bot-discord');
+    }
+
+    public function boot(): void
+    {
+        parent::boot();
+
+        if ($this->app->runningInConsole()) {
+            $this->publishes([
+                __DIR__.'/../../config/bot-discord.php' => config_path('bot-discord.php'),
+            ], 'bot-discord-config');
+        }
+    }
+
     public function bot(Laracord $bot): Laracord
     {
         return $bot


### PR DESCRIPTION
This pull request introduces configuration management for the Discord bot, allowing channel IDs and other settings to be managed via configuration files and environment variables. It also adds a new Makefile target to simplify running the bot and refactors the welcome member event to use the new configuration system.

Configuration management improvements:

* Added a new configuration file `bot-discord.php` to centralize Discord bot settings, including channel IDs, and enabled environment variable overrides.
* Updated `BotDiscordServiceProvider` to load and publish the new configuration file, ensuring settings can be customized and distributed.

Code refactoring for maintainability:

* Modified the `WelcomeMember` event to fetch the presentations channel ID from configuration instead of hardcoding it, improving flexibility and maintainability.

Developer experience:

* Added a `.PHONY` Makefile target `bot` to simplify running the Discord bot with a single command.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to run the Discord bot directly
  * Implemented configurable channels for bot messages via environment variables

* **Chores**
  * Established configuration infrastructure for the Discord bot module

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->