### PR TITLE
feat(introduction): update introduction message format and content

### DIFF
--- a/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
@@ -135,18 +135,6 @@ class IntroductionCommand extends SlashCommand
             $userInformation = resolve(InformationUserAction::class)->handle($informationDto);
 
             $this
-                ->message('Apresentação enviada com sucesso')
-                ->content(
-                    "Agora a comunidade já pode conhecer um pouco mais sobre você!\n"
-                    .'https://heartdevs.com/'
-                )
-                ->color((string) hexdec('4b0080'))
-                ->footerIcon($interaction->guild->icon)
-                ->footerText(Date::now()->format('Y').' © He4rt Developers')
-                ->timestamp(now())
-                ->reply($interaction, true);
-
-            $this
                 ->message('Nova apresentação')
                 ->title('Apresentação de '.$userInformation->nickname)
                 ->thumbnailUrl($interaction->user->avatar)


### PR DESCRIPTION
Removed the `reply()` call after the modal submission because Discord allows only one response per interaction.
Since opening a modal already consumes this response, any additional reply results in the error _interaction has already been responded to._
The flow was kept using only channel messages and the required business logic.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed confirmation message previously displayed to users after submitting an introduction via Discord command. Submission processing and channel notifications remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->