### PR TITLE
fix: remove logs

### DIFF
--- a/app-modules/bot-discord/src/Events/DynamicVoiceEvent.php
+++ b/app-modules/bot-discord/src/Events/DynamicVoiceEvent.php
@@ -27,8 +27,6 @@ class DynamicVoiceEvent extends Event
         $channelId = $state->channel_id;
         $userId = $state->user_id;
 
-        $this->logger()->info('Channel Members:'.($state->channel?->members?->count() ?? 0));
-
         resolve(HandleStateChannelAction::class)->execute(
             userId: $userId,
             channelId: $channelId,

--- a/app-modules/bot-discord/src/Events/GreetingsEvent.php
+++ b/app-modules/bot-discord/src/Events/GreetingsEvent.php
@@ -27,8 +27,6 @@ class GreetingsEvent extends Event
             return;
         }
 
-        $this->logger()->notice(sprintf('%s: %s', $message->author->username, $message->content));
-
         $hour = now()->hour;
         $payload = mb_strtolower($message->content);
 


### PR DESCRIPTION
This pull request removes unnecessary logging statements from two event handler classes in the Discord bot module to reduce log verbosity and improve code clarity.

Logging cleanup:

* Removed an info-level log statement that output the number of channel members in the `handle` method of `DynamicVoiceEvent`.
* Removed a notice-level log statement that logged each user's message in the `handle` method of `GreetingsEvent`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal event logging for voice channel and greeting events.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->