### PR TITLE
feat: new commands

### DIFF
--- a/app-modules/bot-discord/config/bot-discord.php
+++ b/app-modules/bot-discord/config/bot-discord.php
@@ -10,7 +10,6 @@ return [
     'roles' => [
         'presentation' => env('HE4RT_PRESENTATION_ROLE_ID', '546150872397119491'),
 
-        // Tecnologias e especialidades disponíveis para seleção
         'technologies' => [
             'basic_english' => '546148708077666315',
             'intermediate_english' => '546148711416332298',

--- a/app-modules/bot-discord/config/bot-discord.php
+++ b/app-modules/bot-discord/config/bot-discord.php
@@ -9,5 +9,25 @@ return [
     ],
     'roles' => [
         'presentation' => env('HE4RT_PRESENTATION_ROLE_ID', '546150872397119491'),
+
+        // Tecnologias e especialidades disponíveis para seleção
+        'technologies' => [
+            'basic_english' => '546148708077666315',
+            'intermediate_english' => '546148711416332298',
+            'advanced_english' => '546148712833875985',
+            'designer' => '547606728179449895',
+            'ux_ui' => '546152565633449995',
+            'javascript' => '540993488410378281',
+            'php' => '540994118634176512',
+            'python' => '540994295541399552',
+            'java' => '540995379538165774',
+            'c_c++_c#' => '541021498064896000',
+            'rust' => '1043325810347606056',
+            'ruby' => '540995627559944207',
+            'perl' => '540995072246939648',
+            'elixir' => '958788344974831687',
+            'gamedev' => '550411669084569602',
+            'he4rt_delas' => '1018009963903328308',
+        ],
     ],
 ];

--- a/app-modules/bot-discord/src/SlashCommands/DelasCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/DelasCommand.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\BotDiscord\SlashCommands;
+
+use Discord\Parts\Guild\Role;
+use Discord\Parts\Interactions\Command\Option;
+use Discord\Parts\Interactions\Interaction;
+use Illuminate\Support\Facades\Log;
+use Laracord\Commands\SlashCommand;
+use Throwable;
+
+class DelasCommand extends SlashCommand
+{
+    protected $name = 'delas';
+
+    protected $description = 'Adiciona role He4rt Delas a um membro da comunidade';
+
+    protected $options = [
+        [
+            'name' => 'user',
+            'description' => 'Usuário para receber a role He4rt Delas',
+            'type' => Option::USER,
+            'required' => true,
+        ],
+    ];
+
+    protected $permissions = [];
+
+    protected $admin = false;
+
+    protected $hidden = false;
+
+    private readonly string $presentationRoleId;
+
+    private readonly string $he4rtDelasRoleId;
+
+    public function __construct()
+    {
+        $this->presentationRoleId = config('bot-discord.roles.presentation');
+        $this->he4rtDelasRoleId = config('bot-discord.roles.technologies.he4rt_delas');
+    }
+
+    public function handle(Interaction $interaction): void
+    {
+        try {
+            $targetUserId = $this->value('user');
+
+            if (! $targetUserId) {
+                $interaction->respondWithMessage('❌ Usuário não especificado.', true);
+
+                return;
+            }
+
+            if (! $this->validateExecutor($interaction)) {
+                return;
+            }
+
+            $targetMember = $this->validateTarget($interaction, $targetUserId);
+            if (! $targetMember) {
+                return;
+            }
+
+            // Verificar se não é ele mesmo
+            if ($interaction->user->id === $targetUserId) {
+                $interaction->respondWithMessage('❌ Você não pode usar este comando em você mesmo.', true);
+
+                return;
+            }
+
+            $this->addHe4rtDelasRole($interaction, $targetMember, $targetUserId);
+
+        } catch (Throwable $throwable) {
+            Log::error('Error in MulherCommand', [
+                'executor_id' => $interaction->user->id,
+                'target_id' => $targetUserId ?? 'unknown',
+                'error' => $throwable->getMessage(),
+                'trace' => $throwable->getTraceAsString(),
+            ]);
+
+            $interaction->respondWithMessage('❌ Erro ao processar comando. Tente novamente.', true);
+        }
+    }
+
+    private function validateExecutor(Interaction $interaction): bool
+    {
+
+        $hasPresentation = $interaction->member->roles
+            ->find(fn (Role $role) => $role->id === $this->presentationRoleId);
+
+        if (! $hasPresentation) {
+            $interaction->respondWithMessage('❌ Você precisa se apresentar primeiro para usar este comando (/apresentar).',
+                true);
+
+            return false;
+        }
+
+        $hasHe4rtDelas = $interaction->member->roles
+            ->find(fn (Role $role) => $role->id === $this->he4rtDelasRoleId);
+
+        if (! $hasHe4rtDelas) {
+            $interaction->respondWithMessage('❌ Você não tem permissão para usar este comando.', true);
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private function validateTarget(Interaction $interaction, string $targetUserId)
+    {
+        $targetMember = $interaction->guild->members->get('id', $targetUserId);
+
+        if (! $targetMember) {
+            $interaction->respondWithMessage('❌ Usuário mencionado não foi encontrado no servidor.', true);
+
+            return null;
+        }
+
+        if ($targetMember->user->bot ?? false) {
+            $interaction->respondWithMessage('❌ Não é possível adicionar roles a bots.', true);
+
+            return null;
+        }
+
+        $targetHasPresentation = $targetMember->roles
+            ->find(fn (Role $role) => $role->id === $this->presentationRoleId);
+
+        if (! $targetHasPresentation) {
+            $username = $targetMember->user->username ?? 'usuário';
+            $interaction->respondWithMessage(sprintf('❌ @%s precisa se apresentar primeiro (/apresentar).', $username), true);
+
+            return null;
+        }
+
+        $targetHasHe4rtDelas = $targetMember->roles
+            ->find(fn (Role $role) => $role->id === $this->he4rtDelasRoleId);
+
+        if ($targetHasHe4rtDelas) {
+            $username = $targetMember->user->username ?? 'usuário';
+            $interaction->respondWithMessage(sprintf('❌ @%s já possui a role He4rt Delas.', $username), true);
+
+            return null;
+        }
+
+        return $targetMember;
+    }
+
+    private function addHe4rtDelasRole(Interaction $interaction, $targetMember, string $targetUserId): void
+    {
+        $currentRoles = [];
+        foreach ($targetMember->roles as $role) {
+            $currentRoles[] = $role->id;
+        }
+
+        $currentRoles[] = $this->he4rtDelasRoleId;
+
+        $currentRoles = array_unique($currentRoles);
+
+        $targetMember->setRoles($currentRoles);
+
+        $interaction->respondWithMessage(
+            "**Role He4rt Delas adicionada com sucesso!**\n\n"
+            .sprintf('<@%s> agora faz parte do He4rt Delas, adicionada por <@%s>!', $targetUserId, $interaction->user->id)
+        );
+    }
+}

--- a/app-modules/bot-discord/src/SlashCommands/DelasCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/DelasCommand.php
@@ -7,7 +7,6 @@ namespace He4rt\BotDiscord\SlashCommands;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
-use Illuminate\Support\Facades\Log;
 use Laracord\Commands\SlashCommand;
 use Throwable;
 
@@ -62,7 +61,6 @@ class DelasCommand extends SlashCommand
                 return;
             }
 
-            // Verificar se não é ele mesmo
             if ($interaction->user->id === $targetUserId) {
                 $interaction->respondWithMessage('❌ Você não pode usar este comando em você mesmo.', true);
 
@@ -71,14 +69,7 @@ class DelasCommand extends SlashCommand
 
             $this->addHe4rtDelasRole($interaction, $targetMember, $targetUserId);
 
-        } catch (Throwable $throwable) {
-            Log::error('Error in MulherCommand', [
-                'executor_id' => $interaction->user->id,
-                'target_id' => $targetUserId ?? 'unknown',
-                'error' => $throwable->getMessage(),
-                'trace' => $throwable->getTraceAsString(),
-            ]);
-
+        } catch (Throwable) {
             $interaction->respondWithMessage('❌ Erro ao processar comando. Tente novamente.', true);
         }
     }

--- a/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
@@ -187,7 +187,7 @@ class IntroductionCommand extends SlashCommand
 
     private function savePersonalInfoAndShowTechSelection(Interaction $interaction, Collection $components): void
     {
-        $sessionKey = 'presentation_data_' . $interaction->user->id;
+        $sessionKey = 'presentation_data_'.$interaction->user->id;
         $personalData = [
             'name' => $components->get('custom_id', 'name')->value,
             'nickname' => $components->get('custom_id', 'nickname')->value,
@@ -226,7 +226,7 @@ class IntroductionCommand extends SlashCommand
 
     private function finalizePresentation(Interaction $interaction, array $selectedTechnologies): void
     {
-        $sessionKey = 'presentation_data_' . $interaction->user->id;
+        $sessionKey = 'presentation_data_'.$interaction->user->id;
         $personalData = Cache::get($sessionKey);
 
         if (! $personalData) {

--- a/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace He4rt\BotDiscord\SlashCommands;
 
-use Discord\Builders\Components\TextInput;
 use Discord\Helpers\Collection;
 use Discord\Parts\Guild\Role;
 use Discord\Parts\Interactions\Interaction;
@@ -15,6 +14,7 @@ use He4rt\User\Actions\InformationUserAction;
 use He4rt\User\DTO\UpsertInformationDTO;
 use He4rt\User\Models\User;
 use He4rt\User\Services\ResolveUserContextService;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Date;
 use Laracord\Commands\SlashCommand;
 use Throwable;
@@ -37,10 +37,106 @@ class IntroductionCommand extends SlashCommand
 
     private readonly string $welcomeChannelId;
 
+    private readonly array $technologyRoles;
+
+    private array $technologyOptions = [
+        'javascript' => [
+            'label' => 'JavaScript',
+            'description' => 'Linguagem de programação versátil',
+            'emoji' => '🟨',
+        ],
+        'php' => [
+            'label' => 'PHP',
+            'description' => 'Linguagem para desenvolvimento web',
+            'emoji' => '🐘',
+        ],
+        'python' => [
+            'label' => 'Python',
+            'description' => 'Linguagem de alto nível',
+            'emoji' => '🐍',
+        ],
+        'java' => [
+            'label' => 'Java',
+            'description' => 'Linguagem orientada a objetos',
+            'emoji' => '☕',
+        ],
+        'c_c++_c#' => [
+            'label' => 'C/C++/C#',
+            'description' => 'Linguagens de sistema e .NET',
+            'emoji' => '⚡',
+        ],
+        'rust' => [
+            'label' => 'Rust',
+            'description' => 'Linguagem de sistema segura',
+            'emoji' => '🦀',
+        ],
+        'ruby' => [
+            'label' => 'Ruby',
+            'description' => 'Linguagem elegante e produtiva',
+            'emoji' => '💎',
+        ],
+        'elixir' => [
+            'label' => 'Elixir',
+            'description' => 'Linguagem funcional e concorrente',
+            'emoji' => '💜',
+        ],
+        'perl' => [
+            'label' => 'Perl',
+            'description' => 'Linguagem de processamento de texto',
+            'emoji' => '🐪',
+        ],
+        'gamedev' => [
+            'label' => 'Game Development',
+            'description' => 'Desenvolvimento de jogos',
+            'emoji' => '🎮',
+        ],
+        'designer' => [
+            'label' => 'Design',
+            'description' => 'Design gráfico e visual',
+            'emoji' => '🎨',
+        ],
+        'ux_ui' => [
+            'label' => 'UX/UI',
+            'description' => 'Experiência e interface do usuário',
+            'emoji' => '📱',
+        ],
+        'basic_english' => [
+            'label' => 'Inglês Básico',
+            'description' => 'Nível iniciante de inglês',
+            'emoji' => '🇺🇸',
+        ],
+        'intermediate_english' => [
+            'label' => 'Inglês Intermediário',
+            'description' => 'Nível intermediário de inglês',
+            'emoji' => '🇬🇧',
+        ],
+        'advanced_english' => [
+            'label' => 'Inglês Avançado',
+            'description' => 'Nível avançado de inglês',
+            'emoji' => '🏴󠁧󠁢󠁥󠁮󠁧󠁿',
+        ],
+        'he4rt_delas' => [
+            'label' => 'He4rt Delas ♀️',
+            'description' => 'Comunidade para mulheres, pessoas não binárias e que se identificam como mulheres',
+            'emoji' => '💖',
+        ],
+    ];
+
     public function __construct()
     {
         $this->roleId = config('bot-discord.roles.presentation');
         $this->welcomeChannelId = config('bot-discord.channels.presentations');
+        $this->technologyRoles = config('bot-discord.roles.technologies');
+    }
+
+    public function interactions(): array
+    {
+        return [
+            'tech_selection' => fn (Interaction $interaction) => $this->finalizePresentation($interaction,
+                $interaction->data->values ?? []),
+
+            'skip_tech' => fn (Interaction $interaction) => $this->finalizePresentation($interaction, []),
+        ];
     }
 
     public function handle(Interaction $interaction): void
@@ -54,57 +150,34 @@ class IntroductionCommand extends SlashCommand
             return;
         }
 
-        $modalId = 'presentation_'.uniqid();
+        $this->showPersonalInfoModal($interaction);
+    }
 
-        $this->modal('Apresentar')
+    private function showPersonalInfoModal(Interaction $interaction): void
+    {
+        $modalId = 'presentation_personal_'.uniqid();
+
+        $this->modal('Apresentar - Informações Pessoais')
             ->id($modalId)
-            ->components([
-                TextInput::new('Nome', TextInput::STYLE_SHORT)
-                    ->setCustomId('name')
-                    ->setMinLength(2)
-                    ->setMaxLength(32)
-                    ->setPlaceholder('Fulano de Tal')
-                    ->setRequired(true),
-
-                TextInput::new('Nickname', TextInput::STYLE_SHORT)
-                    ->setCustomId('nickname')
-                    ->setMinLength(2)
-                    ->setMaxLength(32)
-                    ->setPlaceholder('Fulano123')
-                    ->setRequired(true),
-
-                TextInput::new('Git/Github (Opcional)', TextInput::STYLE_SHORT)
-                    ->setCustomId('github_url')
-                    ->setMinLength(0)
-                    ->setMaxLength(60)
-                    ->setPlaceholder('https://github.com/YOUR_USERNAME')
-                    ->setRequired(false),
-
-                TextInput::new('LinkedIn (Opcional)', TextInput::STYLE_SHORT)
-                    ->setCustomId('linkedin_url')
-                    ->setMinLength(0)
-                    ->setMaxLength(60)
-                    ->setPlaceholder('https://linkedin.com/in/YOUR_USERNAME')
-                    ->setRequired(false),
-
-                TextInput::new('Nos conte um pouco sobre você', TextInput::STYLE_PARAGRAPH)
-                    ->setCustomId('about')
-                    ->setMinLength(5)
-                    ->setMaxLength(1000)
-                    ->setPlaceholder('Entrei de curioso e acabei gostando do servidor!')
-                    ->setRequired(true),
-
-            ])
+            ->text(label: 'Nome', key: 'name', minLength: 2, maxLength: 32, placeholder: 'Fulano de Tal',
+                required: true)
+            ->text(label: 'Nickname', key: 'nickname', minLength: 2, maxLength: 32, placeholder: 'Fulano123',
+                required: true)
+            ->text(label: 'Git/Github (Opcional)', key: 'github_url', maxLength: 60,
+                placeholder: 'https://github.com/YOUR_USERNAME',
+                required: false)
+            ->text(label: 'LinkedIn (Opcional)', key: 'linkedin_url', maxLength: 60,
+                placeholder: 'https://linkedin.com/in/YOUR_USERNAME',
+                required: false)
+            ->paragraph(label: 'Nos conte um pouco sobre você', key: 'about', minLength: 5,
+                maxLength: 1000, placeholder: 'Entrei de curioso e acabei gostando do servidor!', required: true)
             ->submit(function (Interaction $interaction, Collection $components) use ($modalId): void {
                 if ($interaction->data->custom_id !== $modalId) {
                     return;
                 }
 
                 try {
-                    $this->persistData($interaction, $components);
-
-                    $interaction->respondWithMessage("Apresentação enviada com sucesso.\nhttps://heartdevs.com/", true);
-
+                    $this->savePersonalInfoAndShowTechSelection($interaction, $components);
                 } catch (Throwable) {
                     $interaction->respondWithMessage('Ocorreu um erro ao processar sua apresentação.', true);
                 }
@@ -112,7 +185,83 @@ class IntroductionCommand extends SlashCommand
             ->show($interaction);
     }
 
-    private function persistData(Interaction $interaction, Collection $components): void
+    private function savePersonalInfoAndShowTechSelection(Interaction $interaction, Collection $components): void
+    {
+        $sessionKey = 'presentation_data_' . $interaction->user->id;
+        $personalData = [
+            'name' => $components->get('custom_id', 'name')->value,
+            'nickname' => $components->get('custom_id', 'nickname')->value,
+            'github_url' => $components->get('custom_id', 'github_url')?->value,
+            'linkedin_url' => $components->get('custom_id', 'linkedin_url')?->value,
+            'about' => $components->get('custom_id', 'about')->value,
+            'user_id' => $interaction->user->id,
+            'guild_id' => $interaction->guild_id,
+            'timestamp' => now()->toISOString(),
+        ];
+
+        Cache::put($sessionKey, $personalData, 600);
+
+        $this->showTechnologySelection($interaction);
+    }
+
+    private function showTechnologySelection(Interaction $interaction): void
+    {
+        $selectOptions = [];
+        foreach ($this->technologyOptions as $key => $tech) {
+            $selectOptions[$key] = [
+                'label' => $tech['label'],
+                'description' => $tech['description'],
+                'emoji' => $tech['emoji'],
+            ];
+        }
+
+        $this->message('Selecione suas tecnologias')
+            ->title('Etapa 2: Suas Tecnologias')
+            ->content('Selecione as tecnologias que você conhece ou tem interesse. Esta etapa é **opcional** - você pode pular clicando em "Finalizar sem tecnologias".')
+            ->select($selectOptions, placeholder: 'Selecione suas tecnologias (opcional)', minValues: 0, maxValues: 16,
+                route: 'tech_selection')
+            ->button(label: 'Finalizar sem tecnologias', style: 'secondary', route: 'skip_tech')
+            ->reply($interaction, ephemeral: true);
+    }
+
+    private function finalizePresentation(Interaction $interaction, array $selectedTechnologies): void
+    {
+        $sessionKey = 'presentation_data_' . $interaction->user->id;
+        $personalData = Cache::get($sessionKey);
+
+        if (! $personalData) {
+            $interaction->respondWithMessage('Sessão expirada. Por favor, execute o comando novamente.', true);
+
+            return;
+        }
+
+        try {
+            $this->persistData($interaction, $personalData, $selectedTechnologies);
+
+            Cache::forget($sessionKey);
+
+            $techCount = count($selectedTechnologies);
+            $techList = $techCount > 0
+                ? implode(', ', array_map(fn ($tech
+                ) => $this->technologyOptions[$tech]['emoji'].' '.$this->technologyOptions[$tech]['label'],
+                    $selectedTechnologies))
+                : 'Nenhuma selecionada';
+
+            $interaction->respondWithMessage(
+                "**Apresentação enviada com sucesso!**\n\n"
+                ."**Tecnologias selecionadas**: {$techList}\n\n"
+                ."Bem-vindo(a) à comunidade He4rt Developers!\n"
+                .'https://heartdevs.com/',
+                true
+            );
+
+        } catch (Throwable) {
+            Cache::forget($sessionKey);
+            $interaction->respondWithMessage('Ocorreu um erro ao processar sua apresentação. Tente novamente.', true);
+        }
+    }
+
+    private function persistData(Interaction $interaction, array $personalData, array $selectedTechnologies): void
     {
         $tenantProvider = Provider::query()
             ->where('model_type', Tenant::class)
@@ -132,15 +281,33 @@ class IntroductionCommand extends SlashCommand
 
         $informationDto = UpsertInformationDTO::make([
             'user' => $userContext->user,
-            'name' => $components->get('custom_id', 'name')->value,
-            'nickname' => $components->get('custom_id', 'nickname')->value,
-            'about' => $components->get('custom_id', 'about')->value,
-            'linkedin_url' => $components->get('custom_id', 'linkedin_url')?->value,
-            'github_url' => $components->get('custom_id', 'github_url')?->value,
+            'name' => $personalData['name'],
+            'nickname' => $personalData['nickname'],
+            'about' => $personalData['about'],
+            'linkedin_url' => $personalData['linkedin_url'],
+            'github_url' => $personalData['github_url'],
             'birthdate' => null,
         ]);
 
         $userInformation = resolve(InformationUserAction::class)->handle($informationDto);
+
+        $technologiesField = '';
+
+        if ($selectedTechnologies !== []) {
+            $techLabels = array_map(function ($tech): string {
+                $techInfo = $this->technologyOptions[$tech] ?? ['emoji' => '', 'label' => $tech];
+
+                return $techInfo['emoji'].' '.$techInfo['label'];
+            }, $selectedTechnologies);
+            $technologiesField = implode(', ', $techLabels);
+        } else {
+            $technologiesField = 'Nenhuma selecionada';
+        }
+
+        $embedFields = [
+            'Nome' => $userInformation->name,
+            'Nickname' => $userInformation->nickname,
+        ];
 
         $this
             ->message('Nova apresentação')
@@ -150,15 +317,13 @@ class IntroductionCommand extends SlashCommand
                 '<@%s> acabou de se apresentar na comunidade.',
                 $interaction->user->id
             ))
-            ->fields([
-                'Nome' => $userInformation->name,
-                'Nickname' => $userInformation->nickname,
-            ])
+            ->fields($embedFields)
             ->fields(['Sobre' => $userInformation->about], inline: false)
             ->fields([
                 'GitHub' => $userInformation->github_url ?? '-',
                 'LinkedIn' => $userInformation->linkedin_url ?? '-',
             ])
+            ->fields(['Tecnologias' => $technologiesField], inline: false)
             ->footerIcon($interaction->guild->icon)
             ->footerText(Date::now()->format('Y').' © He4rt Developers')
             ->timestamp(now())
@@ -172,6 +337,14 @@ class IntroductionCommand extends SlashCommand
         }
 
         $roles[] = $this->roleId;
+
+        foreach ($selectedTechnologies as $tech) {
+            if (isset($this->technologyRoles[$tech])) {
+                $roles[] = $this->technologyRoles[$tech];
+            }
+        }
+
+        $roles = array_unique($roles);
 
         $interaction->member->setRoles($roles);
     }


### PR DESCRIPTION
This pull request introduces a multi-step flow for the `/apresentar` (Introduction) command and adds a new `/delas` slash command to manage community roles in the Discord bot. The main improvements are the addition of a technology selection step during user introduction, the assignment of technology roles, and a dedicated command for managing the "He4rt Delas" role.

**Major enhancements:**

### Introduction Command Improvements

* Refactored the introduction flow to a multi-step process: after submitting personal information, users are prompted to select their technology interests from a list, or skip this step. Selected technologies are displayed in the welcome embed and corresponding roles are assigned to the user. [[1]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcR40-R139) [[2]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcL57-R264) [[3]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcL135-R311) [[4]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcL153-R326) [[5]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcR341-R348)
* Added a comprehensive list of technology roles and their metadata (labels, descriptions, emojis), and loaded their IDs from configuration for assignment. [[1]](diffhunk://#diff-84a74f3b16353653d01f2462fbecf9082abaf768d8cb0a28e42e60a2db9882a4R12-R30) [[2]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcR40-R139)

### New Slash Command: `/delas`

* Implemented the `DelasCommand`, a new slash command that allows eligible users to assign the "He4rt Delas" role to other members, with proper permission and validation checks (e.g., cannot assign to self, both users must have presented, etc.).

### Supporting Changes

* Updated configuration to include IDs for all technology roles, enabling dynamic assignment.
* Minor cleanup: removed unused imports and added necessary dependencies for caching and other features. [[1]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcL7) [[2]](diffhunk://#diff-cbc48e14fa16e52cb8e482128b498c8856ee99cbd86e653c3fca4094657b2ebcR17)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added '/delas' slash command to assign the He4rt Delas role with validation and user feedback.
  * Redesigned introduction into a two-step flow: personal info modal then optional technology selection.
  * Added session-based persistence for presentation data during the flow.
  * Added technology-based role assignments during introduction.
  * Added a new technology roles configuration block mapping tech choices to roles.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->