### PR TITLE
feat(voice-channel): add command to edit voice channel member limit

### DIFF
--- a/app-modules/bot-discord/src/SlashCommands/EditVoiceChannelLimitCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/EditVoiceChannelLimitCommand.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\BotDiscord\SlashCommands;
+
+use Discord\Parts\Interactions\Command\Option;
+use Discord\Parts\Interactions\Interaction;
+use Exception;
+use Laracord\Commands\SlashCommand;
+
+use function React\Async\await;
+
+class EditVoiceChannelLimitCommand extends SlashCommand
+{
+    protected $name = 'sala-limite';
+
+    protected $description = 'Editar o limite máximo de membros na sala de voz atual';
+
+    protected $admin = false;
+
+    protected $hidden = false;
+
+    public function handle(Interaction $interaction): void
+    {
+        $userId = $interaction->member->id;
+        $channelId = cache()->tags(['voice_tracking'])->get('user_last_channel_'.$userId);
+
+        if (! $channelId) {
+            $this->message()
+                ->content('❌ Você precisa estar em uma sala de voz para usar este comando!')
+                ->reply($interaction, true);
+
+            return;
+        }
+
+        $activeChannels = cache()->tags(['voice_channels'])->get('active_voice_channels_keys', []);
+        $channelDto = collect($activeChannels)->firstWhere('channelId', $channelId);
+
+        if (! $channelDto) {
+            $this->message()
+                ->content('❌ Este comando só funciona em salas criadas com /sala!')
+                ->reply($interaction, true);
+
+            return;
+        }
+
+        if ($channelDto->ownerId !== $userId) {
+            $this->message()
+                ->content('❌ Apenas o dono da sala pode alterar o limite de membros!')
+                ->reply($interaction, true);
+
+            return;
+        }
+
+        $voiceChannel = $interaction->guild->channels->get('id', $channelId);
+
+        if (! $voiceChannel) {
+            $this->message()
+                ->content('❌ Canal de voz não encontrado!')
+                ->reply($interaction, true);
+
+            return;
+        }
+
+        $newLimit = $this->value('limite');
+
+        try {
+            $voiceChannel->user_limit = $newLimit;
+            await($interaction->guild->channels->save($voiceChannel));
+
+            $this->message()
+                ->content(sprintf('✅ Limite da sala atualizado para **%d** membros!', $newLimit))
+                ->reply($interaction, true);
+        } catch (Exception) {
+            $this->message()
+                ->content('❌ Erro ao atualizar o limite da sala. Tente novamente.')
+                ->reply($interaction, true);
+        }
+    }
+
+    public function options(): array
+    {
+        return [
+            [
+                'name' => 'limite',
+                'description' => 'Novo limite máximo de membros (1-99)',
+                'type' => Option::INTEGER,
+                'required' => true,
+                'min_value' => 1,
+                'max_value' => 99,
+            ],
+        ];
+    }
+}


### PR DESCRIPTION
This pull request introduces a new slash command for editing the member limit of a voice channel in Discord. The command ensures only the channel owner can change the limit and provides clear feedback to users in various scenarios.

**New Feature: Voice Channel Member Limit Command**

* Added `EditVoiceChannelLimitCommand` to allow users to update the maximum number of members in their current voice channel, with permission checks to ensure only the channel owner can use it. The command provides user-friendly error messages and supports limits between 1 and 99 members.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a new slash command that enables users to adjust the maximum member limit for their current voice channel, supporting values between 1 and 99 members. The command includes ownership validation and channel membership verification, with comprehensive error handling for failed operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->