### PR TITLE
fix: add missing email column to external_identities table

### DIFF
--- a/app-modules/identity/database/migrations/2026_04_28_121926_add_email_to_external_identities_table.php
+++ b/app-modules/identity/database/migrations/2026_04_28_121926_add_email_to_external_identities_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('external_identities', function (Blueprint $table): void {
+            $table->string('email')->nullable()->after('metadata');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('external_identities', function (Blueprint $table): void {
+            $table->dropColumn('email');
+        });
+    }
+};

--- a/app-modules/identity/src/ExternalIdentity/Models/ExternalIdentity.php
+++ b/app-modules/identity/src/ExternalIdentity/Models/ExternalIdentity.php
@@ -63,6 +63,7 @@ final class ExternalIdentity extends Model
         'connected_at',
         'disconnected_at',
         'metadata',
+        'email',
     ];
 
     protected $appends = [


### PR DESCRIPTION
## Summary
- Adds the missing `email` column to the `external_identities` table via a new migration
- Adds `email` to the model's `$fillable` array

## Context
The `email` column was being set in the `BaseSeeder` (`ExternalIdentity::factory()->create(['email' => ...])`) but the column didn't exist on the table — the original migration moved `email` into the `metadata` JSON column but the seeder and factory still reference it as a top-level column.

## Test plan
- [ ] Run `php artisan migrate:fresh --seed` and verify no SQLite errors
- [ ] Confirm `email` column exists on `external_identities` table