### PR TITLE
fix(integration-discord): recover duplicated users from import-profiles bug

### DIFF
--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -25,6 +25,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
+use Illuminate\Support\Carbon;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
 
@@ -34,6 +35,8 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  * @property string $username
  * @property string $email
  * @property bool $is_donator
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
  */
 #[ObservedBy(UserObserver::class)]
 final class User extends Authenticatable implements FilamentUser, HasMedia, HasName, HasTenants

--- a/app-modules/integration-discord/src/ETL/Actions/ImportDiscordMessageAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/ImportDiscordMessageAction.php
@@ -461,7 +461,19 @@ final class ImportDiscordMessageAction
 
     private function resolveOrCreateUser(DiscordMessageDTO $dto): User
     {
-        $existing = User::query()->where('username', $dto->authorUsername)->first();
+        $conflictingIds = ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('external_account_id', '!=', $dto->authorDiscordId)
+            ->where('model_type', (new User)->getMorphClass())
+            ->pluck('model_id')
+            ->all();
+
+        $existing = User::query()
+            ->whereIn('username', [$dto->authorUsername, $dto->authorUsername.'#0'])
+            ->when($conflictingIds !== [], fn ($q) => $q->whereNotIn('id', $conflictingIds))
+            ->orderByRaw('CASE WHEN username = ? THEN 0 ELSE 1 END', [$dto->authorUsername])
+            ->first();
+
         if ($existing instanceof User) {
             return $existing;
         }

--- a/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/ImportDiscordProfileAction.php
@@ -9,29 +9,17 @@ use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\ETL\DTOs\ConnectedAccountDTO;
 use He4rt\IntegrationDiscord\ETL\DTOs\DiscordProfileDTO;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Log;
 use Ramsey\Uuid\Uuid;
 
 final class ImportDiscordProfileAction
 {
     public function handle(DiscordProfileDTO $dto, int $tenantId): ExternalIdentity
     {
-        $user = User::query()->where('username', $dto->username)->first();
-
-        if (!$user instanceof User) {
-            $name = User::query()->where('name', $dto->name)->exists()
-                ? $dto->username
-                : $dto->name;
-
-            $user = User::query()->create([
-                'id' => Uuid::uuid4()->toString(),
-                'username' => $dto->username,
-                'name' => $name,
-                'is_donator' => false,
-            ]);
-        }
-
+        $user = $this->resolveUser($dto, $tenantId);
         $user->tenants()->syncWithoutDetaching([$tenantId]);
 
         $discordIdentity = ExternalIdentity::query()->updateOrCreate(
@@ -52,24 +40,109 @@ final class ImportDiscordProfileAction
         );
 
         foreach ($dto->connectedAccounts as $account) {
-            ExternalIdentity::query()->updateOrCreate(
-                [
-                    'provider' => $account->provider,
-                    'external_account_id' => $account->externalAccountId,
-                    'tenant_id' => $tenantId,
-                ],
-                [
-                    'model_type' => (new User)->getMorphClass(),
-                    'model_id' => $user->id,
-                    'type' => $account->provider->getType(),
-                    'credentials_type' => CredentialsType::OAuth2,
-                    'credentials' => ClientAccessManager::make(),
-                    'connected_at' => $dto->joinedAt ? Date::parse($dto->joinedAt) : null,
-                    'metadata' => $account->metadata,
-                ]
-            );
+            $this->upsertConnectedAccount($account, $user, $tenantId, $dto);
         }
 
         return $discordIdentity;
+    }
+
+    private function resolveUser(DiscordProfileDTO $dto, int $tenantId): User
+    {
+        $identity = ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('external_account_id', $dto->discordId)
+            ->where('tenant_id', $tenantId)
+            ->first();
+
+        if ($identity instanceof ExternalIdentity) {
+            $owner = $identity->user;
+            if ($owner instanceof User) {
+                return $this->syncUserAttributes($owner, $dto);
+            }
+        }
+
+        $user = User::query()->where('username', $dto->username)->first();
+        if ($user instanceof User) {
+            return $user;
+        }
+
+        $name = User::query()->where('name', $dto->name)->exists()
+            ? $dto->username
+            : $dto->name;
+
+        return User::query()->create([
+            'id' => Uuid::uuid7(),
+            'username' => $dto->username,
+            'name' => $name,
+            'is_donator' => false,
+        ]);
+    }
+
+    private function syncUserAttributes(User $user, DiscordProfileDTO $dto): User
+    {
+        $changes = [];
+
+        $usernameChanged = $user->username !== $dto->username
+            && !User::query()
+                ->where('username', $dto->username)
+                ->where('id', '!=', $user->id)
+                ->exists();
+
+        if ($usernameChanged) {
+            $changes['username'] = $dto->username;
+        }
+
+        if ($user->name === $user->username && $dto->name !== $dto->username) {
+            $changes['name'] = $dto->name;
+        }
+
+        if ($changes !== []) {
+            $user->update($changes);
+        }
+
+        return $user;
+    }
+
+    private function upsertConnectedAccount(
+        ConnectedAccountDTO $account,
+        User $user,
+        int $tenantId,
+        DiscordProfileDTO $dto,
+    ): void {
+        $existing = ExternalIdentity::query()
+            ->where('provider', $account->provider)
+            ->where('external_account_id', $account->externalAccountId)
+            ->where('tenant_id', $tenantId)
+            ->first();
+
+        if ($existing instanceof ExternalIdentity && (string) $existing->model_id !== (string) $user->id) {
+            Log::warning('discord-profile-import skipped connected account: belongs to other user', [
+                'discord_id' => $dto->discordId,
+                'discord_username' => $dto->username,
+                'provider' => $account->provider->value,
+                'external_account_id' => $account->externalAccountId,
+                'owner_user_id' => $existing->model_id,
+                'tried_user_id' => $user->id,
+            ]);
+
+            return;
+        }
+
+        ExternalIdentity::query()->updateOrCreate(
+            [
+                'provider' => $account->provider,
+                'external_account_id' => $account->externalAccountId,
+                'tenant_id' => $tenantId,
+            ],
+            [
+                'model_type' => (new User)->getMorphClass(),
+                'model_id' => $user->id,
+                'type' => $account->provider->getType(),
+                'credentials_type' => CredentialsType::OAuth2,
+                'credentials' => ClientAccessManager::make(),
+                'connected_at' => $dto->joinedAt ? Date::parse($dto->joinedAt) : null,
+                'metadata' => $account->metadata,
+            ],
+        );
     }
 }

--- a/app-modules/integration-discord/src/ETL/Actions/MergeDuplicateDiscordUserAction.php
+++ b/app-modules/integration-discord/src/ETL/Actions/MergeDuplicateDiscordUserAction.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\ETL\Actions;
+
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final class MergeDuplicateDiscordUserAction
+{
+    /**
+     * Move all identities and FKs from $newUser to $oldUser, then delete $newUser.
+     * Updates $oldUser->username to $targetUsername (current Discord handle).
+     *
+     * @return array{moved_identities: int, moved_fks: array<string, int>}
+     */
+    public function handle(User $oldUser, User $newUser, string $targetUsername): array
+    {
+        return DB::transaction(function () use ($oldUser, $newUser, $targetUsername): array {
+            $movedIdentities = ExternalIdentity::query()
+                ->where('model_id', $newUser->id)
+                ->update(['model_id' => $oldUser->id]);
+
+            ExternalIdentity::query()
+                ->where('connected_by', $newUser->id)
+                ->update(['connected_by' => $oldUser->id]);
+
+            $fkMoves = $this->reassignFkRelations($oldUser, $newUser);
+
+            $this->mergeOneToOneRelations($oldUser, $newUser);
+
+            $this->mergePivotTable('tenant_users', 'tenant_id', $oldUser, $newUser);
+
+            $newUser->delete();
+
+            if ($oldUser->username !== $targetUsername) {
+                $taken = User::query()
+                    ->where('username', $targetUsername)
+                    ->where('id', '!=', $oldUser->id)
+                    ->exists();
+
+                if (!$taken) {
+                    $oldUser->update(['username' => $targetUsername]);
+                }
+            }
+
+            return [
+                'moved_identities' => $movedIdentities,
+                'moved_fks' => $fkMoves,
+            ];
+        });
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function reassignFkRelations(User $old, User $new): array
+    {
+        $simpleUserIdTables = [
+            'characters',
+            'events_talks',
+            'event_submission_speakers',
+            'events_attendees',
+            'meeting_participants',
+        ];
+
+        $stats = [];
+
+        foreach ($simpleUserIdTables as $table) {
+            $stats[$table] = DB::table($table)
+                ->where('user_id', $new->id)
+                ->update(['user_id' => $old->id]);
+        }
+
+        $stats['meetings'] = DB::table('meetings')
+            ->where('admin_id', $new->id)
+            ->update(['admin_id' => $old->id]);
+
+        $stats['tenants'] = DB::table('tenants')
+            ->where('owner_id', $new->id)
+            ->update(['owner_id' => $old->id]);
+
+        $stats['feedbacks_target'] = DB::table('feedbacks')
+            ->where('target_id', $new->id)
+            ->update(['target_id' => $old->id]);
+
+        $stats['feedbacks_sender'] = DB::table('feedbacks')
+            ->where('sender_id', $new->id)
+            ->update(['sender_id' => $old->id]);
+
+        $stats['feedback_reviews'] = DB::table('feedback_reviews')
+            ->where('staff_id', $new->id)
+            ->update(['staff_id' => $old->id]);
+
+        return $stats;
+    }
+
+    private function mergeOneToOneRelations(User $old, User $new): void
+    {
+        foreach (['user_address', 'user_information'] as $table) {
+            $oldHas = DB::table($table)->where('user_id', $old->id)->exists();
+            $newHas = DB::table($table)->where('user_id', $new->id)->exists();
+
+            if ($oldHas && $newHas) {
+                DB::table($table)->where('user_id', $new->id)->delete();
+            } elseif ($newHas) {
+                DB::table($table)->where('user_id', $new->id)->update(['user_id' => $old->id]);
+            }
+        }
+    }
+
+    private function mergePivotTable(string $table, string $otherKey, User $old, User $new): void
+    {
+        $oldKeys = DB::table($table)
+            ->where('user_id', $old->id)
+            ->pluck($otherKey)
+            ->all();
+
+        if ($oldKeys !== []) {
+            DB::table($table)
+                ->where('user_id', $new->id)
+                ->whereIn($otherKey, $oldKeys)
+                ->delete();
+        }
+
+        DB::table($table)
+            ->where('user_id', $new->id)
+            ->update(['user_id' => $old->id]);
+    }
+}

--- a/app-modules/integration-discord/src/ETL/Console/ImportDiscordMessagesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/ImportDiscordMessagesCommand.php
@@ -179,7 +179,7 @@ class ImportDiscordMessagesCommand extends Command
                         }
                     }
 
-                    foreach (array_chunk($dtos, 100) as $dtoBatch) {
+                    foreach (array_chunk($dtos, 250) as $dtoBatch) {
                         if ($limit !== null && $stats['messages'] >= $limit) {
                             break;
                         }

--- a/app-modules/integration-discord/src/ETL/Console/ImportDiscordProfilesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/ImportDiscordProfilesCommand.php
@@ -113,7 +113,7 @@ class ImportDiscordProfilesCommand extends Command
             $profileSection->clear();
             $this->renderBox($profileSection, $profileTitle, $profileCurrent, $totalProfiles);
 
-            foreach (array_chunk($profiles, 100) as $batch) {
+            foreach (array_chunk($profiles, 250) as $batch) {
                 DB::transaction(function () use (
                     $batch, $action, $tenantId, $chunkName,
                     &$stats, &$errorSamples, &$profileCurrent, $totalProfiles,

--- a/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/MergeDuplicateDiscordProfilesCommand.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\ETL\Console;
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\IntegrationDiscord\ETL\Actions\MergeDuplicateDiscordUserAction;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+class MergeDuplicateDiscordProfilesCommand extends Command
+{
+    protected $signature = 'discord:merge-duplicate-profiles
+                            {--tenant=he4rt : Slug do tenant alvo (ignorado se --pairs-file for usado)}
+                            {--from-date=2026-05-01 : Cutoff: users criados a partir desta data sao candidatos (ignorado se --pairs-file for usado)}
+                            {--pairs-file= : Caminho de JSONL pre-gerado por discord:export-merge-pairs (fonte de verdade)}
+                            {--dry-run : Nao executa, so reporta plano}
+                            {--limit= : Para apos N pares processados}
+                            {--batch=1000 : Tamanho do batch para progress reporting}';
+
+    protected $description = 'Reverte users duplicados criados pelo bug do discord:import-profiles (re-aponta FKs e identities, deleta dups)';
+
+    public function handle(MergeDuplicateDiscordUserAction $merge): int
+    {
+        $pairsFile = $this->option('pairs-file');
+
+        if ($pairsFile !== null) {
+            return $this->runFromPairsFile($merge, (string) $pairsFile);
+        }
+
+        return $this->runFromHeuristic($merge);
+    }
+
+    private function runFromPairsFile(MergeDuplicateDiscordUserAction $merge, string $path): int
+    {
+        $absolute = str_starts_with($path, '/') ? $path : base_path($path);
+
+        if (!is_file($absolute)) {
+            error('Arquivo de pares nao encontrado: '.$absolute);
+
+            return self::FAILURE;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+        $batch = max(1, (int) $this->option('batch'));
+
+        $stats = ['merged' => 0, 'skipped' => 0, 'errors' => 0];
+
+        info(sprintf('Lendo pares de %s%s...', $absolute, $dryRun ? ' [DRY-RUN]' : ''));
+
+        $handle = fopen($absolute, 'r');
+        if ($handle === false) {
+            error('Nao foi possivel abrir o arquivo: '.$absolute);
+
+            return self::FAILURE;
+        }
+
+        $line = 0;
+        while (($raw = fgets($handle)) !== false) {
+            $line++;
+
+            if ($limit !== null && $stats['merged'] >= $limit) {
+                break;
+            }
+
+            $raw = mb_trim($raw);
+            if ($raw === '') {
+                continue;
+            }
+
+            $pair = json_decode($raw, true);
+            if (!is_array($pair)) {
+                $stats['errors']++;
+                Log::error('merge-duplicate-profiles invalid JSONL line', ['line' => $line, 'raw' => $raw]);
+
+                continue;
+            }
+
+            $oldUserId = $pair['old_user_id'] ?? null;
+            $newUserId = $pair['new_user_id'] ?? null;
+            $newUsername = $pair['new_username'] ?? null;
+
+            if (!is_string($oldUserId) || !is_string($newUserId) || !is_string($newUsername)) {
+                $stats['errors']++;
+                Log::error('merge-duplicate-profiles missing fields in JSONL', ['line' => $line, 'pair' => $pair]);
+
+                continue;
+            }
+
+            $oldUser = User::query()->find($oldUserId);
+            $newUser = User::query()->find($newUserId);
+
+            if (!$oldUser instanceof User || !$newUser instanceof User) {
+                $stats['skipped']++;
+                Log::warning('merge-duplicate-profiles user(s) not found', [
+                    'line' => $line,
+                    'old_user_id' => $oldUserId,
+                    'new_user_id' => $newUserId,
+                    'old_found' => $oldUser instanceof User,
+                    'new_found' => $newUser instanceof User,
+                ]);
+
+                continue;
+            }
+
+            if ($dryRun) {
+                $this->line(sprintf(
+                    '  WOULD MERGE  %s (orphan, %s) <- %s (dup, %s)',
+                    $oldUser->username,
+                    $oldUser->created_at->toDateTimeString(),
+                    $newUser->username,
+                    $newUser->created_at->toDateTimeString(),
+                ));
+                $stats['merged']++;
+
+                continue;
+            }
+
+            try {
+                $merge->handle($oldUser, $newUser, $newUsername);
+                $stats['merged']++;
+
+                if ($stats['merged'] % $batch === 0) {
+                    info(sprintf('  ... %d merged', $stats['merged']));
+                }
+            } catch (Throwable $e) {
+                $stats['errors']++;
+                Log::error('merge-duplicate-profiles failed', [
+                    'line' => $line,
+                    'old_user_id' => $oldUserId,
+                    'new_user_id' => $newUserId,
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        fclose($handle);
+
+        $this->newLine();
+        table(
+            headers: ['Metrica', 'Valor'],
+            rows: [
+                ['Merged', number_format($stats['merged'])],
+                ['Skipped (user nao encontrado)', number_format($stats['skipped'])],
+                ['Erros', number_format($stats['errors'])],
+                ['Linhas processadas', number_format($line)],
+            ],
+        );
+
+        info($dryRun ? 'Dry-run finalizado.' : 'Merge finalizado.');
+
+        return self::SUCCESS;
+    }
+
+    private function runFromHeuristic(MergeDuplicateDiscordUserAction $merge): int
+    {
+        $tenant = Tenant::query()->where('slug', $this->option('tenant'))->first();
+        if (!$tenant instanceof Tenant) {
+            error('Tenant nao encontrado: '.$this->option('tenant'));
+
+            return self::FAILURE;
+        }
+
+        $fromDate = (string) $this->option('from-date');
+        $dryRun = (bool) $this->option('dry-run');
+        $limit = $this->option('limit') !== null ? (int) $this->option('limit') : null;
+        $batch = max(1, (int) $this->option('batch'));
+
+        $stats = ['merged' => 0, 'no_match' => 0, 'conflict' => 0, 'errors' => 0];
+
+        info(sprintf(
+            'Procurando dups apos %s no tenant "%s"%s (heuristic mode)...',
+            $fromDate,
+            $tenant->slug,
+            $dryRun ? ' [DRY-RUN]' : '',
+        ));
+
+        $userMorph = (new User)->getMorphClass();
+
+        $usersWithDiscordIdentity = array_flip(ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('model_type', $userMorph)
+            ->pluck('model_id')
+            ->all());
+
+        $candidates = ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('model_type', $userMorph)
+            ->where('tenant_id', $tenant->getKey())
+            ->whereExists(fn ($q) => $q
+                ->select(DB::raw(1))
+                ->from('users')
+                ->whereRaw('users.id::text = external_identities.model_id')
+                ->whereDate('users.created_at', '>=', $fromDate)
+            )
+            ->with('user')
+            ->orderBy('created_at')
+            ->cursor();
+
+        foreach ($candidates as $identity) {
+            if ($limit !== null && $stats['merged'] >= $limit) {
+                break;
+            }
+
+            $newUser = $identity->user;
+            if (!$newUser instanceof User) {
+                continue;
+            }
+
+            $candidateUsernames = $this->extractOrphanUsernameCandidates($identity, $newUser);
+
+            $matches = User::query()
+                ->where('id', '!=', $newUser->id)
+                ->whereIn('username', $candidateUsernames)
+                ->whereDate('created_at', '<', $fromDate)
+                ->get()
+                ->reject(fn (User $u): bool => isset($usersWithDiscordIdentity[(string) $u->id]));
+
+            if ($matches->isEmpty()) {
+                $stats['no_match']++;
+
+                continue;
+            }
+
+            if ($matches->count() > 1) {
+                $stats['conflict']++;
+                Log::warning('merge-duplicate-profiles conflict: multiple orphan candidates', [
+                    'new_user_id' => $newUser->id,
+                    'username' => $newUser->username,
+                    'candidate_ids' => $matches->pluck('id')->all(),
+                    'candidate_usernames' => $matches->pluck('username')->all(),
+                ]);
+
+                continue;
+            }
+
+            $oldUser = $matches->first();
+
+            if ($dryRun) {
+                $this->line(sprintf(
+                    '  WOULD MERGE  %s (orphan, %s) <- %s (dup, %s)',
+                    $oldUser->username,
+                    $oldUser->created_at->toDateTimeString(),
+                    $newUser->username,
+                    $newUser->created_at->toDateTimeString(),
+                ));
+                $stats['merged']++;
+
+                continue;
+            }
+
+            try {
+                $merge->handle($oldUser, $newUser, $newUser->username);
+                $stats['merged']++;
+
+                if ($stats['merged'] % $batch === 0) {
+                    info(sprintf('  ... %d merged', $stats['merged']));
+                }
+            } catch (Throwable $e) {
+                $stats['errors']++;
+                Log::error('merge-duplicate-profiles failed', [
+                    'new_user_id' => $newUser->id,
+                    'old_user_id' => $oldUser->id,
+                    'error' => $e->getMessage(),
+                    'trace' => $e->getTraceAsString(),
+                ]);
+            }
+        }
+
+        $this->newLine();
+        table(
+            headers: ['Metrica', 'Valor'],
+            rows: [
+                ['Merged', number_format($stats['merged'])],
+                ['Sem match (legitimos novos ou pomelo sem legacy)', number_format($stats['no_match'])],
+                ['Conflitos (multiplos candidatos)', number_format($stats['conflict'])],
+                ['Erros', number_format($stats['errors'])],
+            ],
+        );
+
+        if ($stats['conflict'] > 0) {
+            warning('Conflitos requerem revisao manual. Detalhes em storage/logs.');
+        }
+
+        info($dryRun ? 'Dry-run finalizado.' : 'Merge finalizado.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Build prioritized list of candidate orphan usernames using identity metadata
+     * (more reliable than guessing from current Discord username).
+     *
+     * @return list<string>
+     */
+    private function extractOrphanUsernameCandidates(ExternalIdentity $identity, User $newUser): array
+    {
+        $candidates = [];
+        $metadata = $identity->metadata ?? [];
+
+        if (isset($metadata['legacy_username']) && is_string($metadata['legacy_username'])) {
+            $candidates[] = $metadata['legacy_username'];
+        }
+
+        foreach ($metadata['badges'] ?? [] as $badge) {
+            if (!is_array($badge) || ($badge['id'] ?? null) !== 'legacy_username') {
+                continue;
+            }
+
+            $description = $badge['description'] ?? '';
+            if (is_string($description) && preg_match('/Originally known as (.+?)$/', $description, $matches) === 1) {
+                $candidates[] = mb_trim($matches[1]);
+            }
+        }
+
+        $candidates[] = $newUser->username.'#0';
+        $candidates[] = $newUser->username;
+
+        return array_values(array_unique($candidates));
+    }
+}

--- a/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
+++ b/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
@@ -6,6 +6,7 @@ namespace He4rt\IntegrationDiscord;
 
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordMessagesCommand;
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordProfilesCommand;
+use He4rt\IntegrationDiscord\ETL\Console\MergeDuplicateDiscordProfilesCommand;
 use Illuminate\Support\ServiceProvider;
 
 class IntegrationDiscordServiceProvider extends ServiceProvider
@@ -18,6 +19,7 @@ class IntegrationDiscordServiceProvider extends ServiceProvider
             $this->commands([
                 ImportDiscordProfilesCommand::class,
                 ImportDiscordMessagesCommand::class,
+                MergeDuplicateDiscordProfilesCommand::class,
             ]);
         }
     }

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordMessageTest.php
@@ -1158,3 +1158,26 @@ test('membership_events are idempotent on re-import', function (): void {
 
     expect(MembershipEvent::query()->count())->toBe(1);
 });
+
+test('resolveOrCreateUser reuses existing legacy #0 user when no discord identity exists', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+
+    $existing = User::factory()->create(['username' => 'oldbie#0', 'name' => 'Oldbie']);
+
+    $raw = discordMessage([
+        'id' => 'msg-legacy',
+        'author' => ['id' => '999000', 'username' => 'oldbie', 'global_name' => 'Oldbie'],
+    ]);
+
+    $action = resolve(ImportDiscordMessageAction::class);
+    $message = $action->handle(DiscordMessageDTO::fromDump($raw), $tenant->getKey());
+
+    $identity = ExternalIdentity::query()
+        ->where('provider', IdentityProvider::Discord)
+        ->where('external_account_id', '999000')
+        ->first();
+
+    expect((string) $identity->model_id)->toBe((string) $existing->id)
+        ->and((string) $message->external_identity_id)->toBe((string) $identity->id)
+        ->and(User::query()->where('username', 'like', 'oldbie%')->count())->toBe(1);
+});

--- a/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/ImportDiscordProfileTest.php
@@ -323,3 +323,135 @@ test('connected account dto creates from dump format', function (): void {
         ->and($dto->verified)->toBeTrue()
         ->and($dto->metadata)->toBe($account);
 });
+
+// Regression: identity-first lookup prevents user duplication on Discord username changes.
+
+test('it reuses existing user when discord identity already exists with legacy #0 username', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $oldUser = User::factory()->create(['username' => 'sun.dev_#0', 'name' => 'Sun']);
+    ExternalIdentity::factory()
+        ->morphFor()
+        ->create([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '49615312957476864',
+            'tenant_id' => $tenant->getKey(),
+            'model_id' => $oldUser->id,
+        ]);
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['username' => 'sun.dev_', 'global_name' => 'Sun'],
+            'connected_accounts' => [],
+        ])),
+        $tenant->getKey(),
+    );
+
+    expect(User::query()->whereIn('username', ['sun.dev_', 'sun.dev_#0'])->count())->toBe(1)
+        ->and(User::query()->find($oldUser->id)->username)->toBe('sun.dev_');
+
+    $identity = ExternalIdentity::query()
+        ->where('provider', IdentityProvider::Discord)
+        ->where('external_account_id', '49615312957476864')
+        ->first();
+
+    expect((string) $identity->model_id)->toBe((string) $oldUser->id);
+});
+
+test('it updates username when discord pomelo handle changes', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $user = User::factory()->create(['username' => 'oldhandle', 'name' => 'oldhandle']);
+    ExternalIdentity::factory()
+        ->morphFor()
+        ->create([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '49615312957476864',
+            'tenant_id' => $tenant->getKey(),
+            'model_id' => $user->id,
+        ]);
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['username' => 'newhandle', 'global_name' => 'New Display'],
+            'connected_accounts' => [],
+        ])),
+        $tenant->getKey(),
+    );
+
+    $user->refresh();
+    expect($user->username)->toBe('newhandle')
+        ->and($user->name)->toBe('New Display')
+        ->and(User::query()->where('username', 'oldhandle')->exists())->toBeFalse();
+});
+
+test('it does not steal connected account identity already linked to another user', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $alice = User::factory()->create(['username' => 'alice']);
+    $aliceTwitch = ExternalIdentity::factory()
+        ->morphFor()
+        ->create([
+            'provider' => IdentityProvider::Twitch,
+            'external_account_id' => '81085454',
+            'tenant_id' => $tenant->getKey(),
+            'model_id' => $alice->id,
+        ]);
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['id' => '999', 'username' => 'bob'],
+            'connected_accounts' => [
+                ['type' => 'twitch', 'id' => '81085454', 'name' => 'fake', 'verified' => true],
+            ],
+        ])),
+        $tenant->getKey(),
+    );
+
+    $aliceTwitch->refresh();
+    expect((string) $aliceTwitch->model_id)->toBe((string) $alice->id)
+        ->and(ExternalIdentity::query()->where('provider', IdentityProvider::Twitch)->count())->toBe(1);
+});
+
+test('it creates user when no identity and no username match exists', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $usersBefore = User::query()->count();
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['id' => '777', 'username' => 'fresh', 'global_name' => 'Fresh'],
+            'connected_accounts' => [],
+        ])),
+        $tenant->getKey(),
+    );
+
+    expect(User::query()->count())->toBe($usersBefore + 1)
+        ->and(User::query()->where('username', 'fresh')->exists())->toBeTrue();
+});
+
+test('it links discord identity to portal user matching username when no identity exists yet', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $action = resolve(ImportDiscordProfileAction::class);
+
+    $portalUser = User::factory()->create(['username' => 'portal_user', 'name' => 'Portal']);
+
+    $action->handle(
+        DiscordProfileDTO::fromDump(discordProfile([
+            'user' => ['id' => '888', 'username' => 'portal_user'],
+            'connected_accounts' => [],
+        ])),
+        $tenant->getKey(),
+    );
+
+    $identity = ExternalIdentity::query()
+        ->where('provider', IdentityProvider::Discord)
+        ->where('external_account_id', '888')
+        ->first();
+
+    expect((string) $identity->model_id)->toBe((string) $portalUser->id);
+});

--- a/app-modules/integration-discord/tests/Feature/ETL/MergeDuplicateDiscordProfilesTest.php
+++ b/app-modules/integration-discord/tests/Feature/ETL/MergeDuplicateDiscordProfilesTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Ramsey\Uuid\Uuid;
+
+function makeImportedDup(Tenant $tenant, string $discordId, string $username, array $metadataExtras = []): array
+{
+    $newUser = User::factory()->create([
+        'username' => $username,
+        'name' => $username,
+        'created_at' => '2026-05-01 21:30:00',
+    ]);
+
+    $identity = ExternalIdentity::factory()
+        ->morphFor()
+        ->create([
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => $discordId,
+            'tenant_id' => $tenant->getKey(),
+            'model_id' => $newUser->id,
+            'metadata' => $metadataExtras,
+        ]);
+
+    return [$newUser, $identity];
+}
+
+function makeOrphan(string $username, ?string $createdAt = '2025-08-10 00:00:00'): User
+{
+    return User::factory()->create([
+        'username' => $username,
+        'name' => $username,
+        'created_at' => $createdAt,
+    ]);
+}
+
+test('dry-run does not modify the database', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('Tats#0927');
+    [$newUser] = makeImportedDup($tenant, '49615312957476864', '_tats', ['legacy_username' => 'Tats#0927']);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--dry-run' => true, '--from-date' => '2026-05-01']);
+
+    expect(User::query()->find($newUser->id))->not->toBeNull()
+        ->and(User::query()->find($orphan->id))->not->toBeNull()
+        ->and(User::query()->find($orphan->id)->username)->toBe('Tats#0927');
+});
+
+test('merges via metadata.legacy_username (preferred match)', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('Tats#0927');
+    [$newUser, $identity] = makeImportedDup($tenant, '49615312957476864', '_tats', ['legacy_username' => 'Tats#0927']);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    $orphan->refresh();
+    $identity->refresh();
+
+    expect(User::query()->find($newUser->id))->toBeNull()
+        ->and($orphan->username)->toBe('_tats')
+        ->and((string) $identity->model_id)->toBe((string) $orphan->id);
+});
+
+test('merges via badge legacy_username description fallback', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('OldName#1234');
+    [$newUser, $identity] = makeImportedDup($tenant, '111', 'newname', [
+        'badges' => [
+            ['id' => 'legacy_username', 'description' => 'Originally known as OldName#1234'],
+        ],
+    ]);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    $orphan->refresh();
+    $identity->refresh();
+
+    expect(User::query()->find($newUser->id))->toBeNull()
+        ->and($orphan->username)->toBe('newname')
+        ->and((string) $identity->model_id)->toBe((string) $orphan->id);
+});
+
+test('merges via #0 heuristic when metadata has no legacy_username', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('xpto#0');
+    [$newUser, $identity] = makeImportedDup($tenant, '222', 'xpto');
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    $orphan->refresh();
+    $identity->refresh();
+
+    expect(User::query()->find($newUser->id))->toBeNull()
+        ->and($orphan->username)->toBe('xpto')
+        ->and((string) $identity->model_id)->toBe((string) $orphan->id);
+});
+
+test('skips when no orphan candidate exists (genuinely new user)', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    [$newUser] = makeImportedDup($tenant, '333', 'brand_new');
+
+    $exitCode = Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    expect($exitCode)->toBe(0)
+        ->and(User::query()->find($newUser->id))->not->toBeNull();
+});
+
+test('skips when multiple orphan candidates match (conflict)', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphanA = makeOrphan('ambig#0');
+    $orphanB = makeOrphan('ambig#9999');
+    [$newUser] = makeImportedDup($tenant, '444', 'ambig', [
+        'badges' => [
+            ['id' => 'legacy_username', 'description' => 'Originally known as ambig#9999'],
+        ],
+    ]);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    expect(User::query()->find($newUser->id))->not->toBeNull()
+        ->and(User::query()->find($orphanA->id))->not->toBeNull()
+        ->and(User::query()->find($orphanB->id))->not->toBeNull();
+});
+
+test('reassigns user_id on tables with simple FK', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('xpto#0');
+    [$newUser] = makeImportedDup($tenant, '555', 'xpto');
+
+    $charId = (string) Uuid::uuid4();
+    DB::table('characters')->insert([
+        'id' => $charId,
+        'user_id' => $newUser->id,
+        'tenant_id' => $tenant->getKey(),
+        'experience' => 100,
+        'reputation' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    $row = DB::table('characters')->where('id', $charId)->first();
+    expect($row)->not->toBeNull()
+        ->and((string) $row->user_id)->toBe((string) $orphan->id);
+});
+
+test('dedupes pivot rows when both users have same key', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('xpto#0');
+    [$newUser] = makeImportedDup($tenant, '666', 'xpto');
+
+    DB::table('tenant_users')->insert([
+        ['tenant_id' => $tenant->getKey(), 'user_id' => $orphan->id, 'created_at' => now(), 'updated_at' => now()],
+        ['tenant_id' => $tenant->getKey(), 'user_id' => $newUser->id, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01']);
+
+    $count = DB::table('tenant_users')
+        ->where('tenant_id', $tenant->getKey())
+        ->where('user_id', $orphan->id)
+        ->count();
+    expect($count)->toBe(1);
+});
+
+test('merges via --pairs-file JSONL when provided (file-based strategy)', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('renamed-once');
+    [$newUser, $identity] = makeImportedDup($tenant, '7777', 'renamed-twice');
+
+    $jsonl = json_encode([
+        'tenant_id' => $tenant->getKey(),
+        'external_account_id' => '7777',
+        'old_user_id' => $orphan->id,
+        'old_username' => $orphan->username,
+        'new_user_id' => $newUser->id,
+        'new_username' => $newUser->username,
+    ]);
+
+    $path = tempnam(sys_get_temp_dir(), 'pairs-').'.jsonl';
+    file_put_contents($path, $jsonl."\n");
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--pairs-file' => $path]);
+
+    @unlink($path);
+
+    $orphan->refresh();
+    $identity->refresh();
+
+    expect(User::query()->find($newUser->id))->toBeNull()
+        ->and($orphan->username)->toBe('renamed-twice')
+        ->and((string) $identity->model_id)->toBe((string) $orphan->id);
+});
+
+test('--pairs-file skips lines whose users no longer exist', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    $orphan = makeOrphan('valid-orphan');
+    [$newUser] = makeImportedDup($tenant, '8888', 'valid-dup');
+
+    $lines = [
+        json_encode([
+            'tenant_id' => $tenant->getKey(),
+            'external_account_id' => '8888',
+            'old_user_id' => $orphan->id,
+            'new_user_id' => $newUser->id,
+            'new_username' => 'valid-dup',
+        ]),
+        json_encode([
+            'tenant_id' => $tenant->getKey(),
+            'external_account_id' => '0000',
+            'old_user_id' => '00000000-0000-0000-0000-000000000000',
+            'new_user_id' => '11111111-1111-1111-1111-111111111111',
+            'new_username' => 'ghost',
+        ]),
+    ];
+
+    $path = tempnam(sys_get_temp_dir(), 'pairs-').'.jsonl';
+    file_put_contents($path, implode("\n", $lines)."\n");
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--pairs-file' => $path]);
+
+    @unlink($path);
+
+    expect(User::query()->find($newUser->id))->toBeNull()
+        ->and(User::query()->find($orphan->id))->not->toBeNull();
+});
+
+test('respects --limit option', function (): void {
+    $tenant = Tenant::factory()->create(['slug' => 'he4rt']);
+    makeOrphan('a#0');
+    makeOrphan('b#0');
+    [$dup1] = makeImportedDup($tenant, '101', 'a');
+    [$dup2] = makeImportedDup($tenant, '102', 'b');
+
+    Artisan::call('discord:merge-duplicate-profiles', ['--from-date' => '2026-05-01', '--limit' => 1]);
+
+    $remaining = User::query()
+        ->whereIn('id', [$dup1->id, $dup2->id])
+        ->count();
+
+    expect($remaining)->toBe(1);
+});


### PR DESCRIPTION
## Summary

- **Root cause**: `ImportDiscordProfileAction` looked up users by Discord username, which is mutable (Pomelo migration + handle changes). When the dump's username didn't match any stored user, the action created a new user and `ExternalIdentity::updateOrCreate` re-pointed the existing identity to it — orphaning the original user along with its `character`, `address`, `information`, and other FKs. Production had ~24k duplicate users created on 2026-05-01 and ~12k orphans.
- **Profile import fix** (`0cec93f`): identity-first lookup (`provider`, `external_account_id`, `tenant_id`) before falling back to username. Connected accounts no longer steal an identity already linked to another user. Same fallback variant (`username#0`) added to `ImportDiscordMessageAction::resolveOrCreateUser` for the prewarm-miss path.
- **Recovery tooling** (`668fdd8`): `MergeDuplicateDiscordUserAction` moves identities + FKs from duplicate to orphan inside a transaction and deletes the duplicate. The `discord:merge-duplicate-profiles` CLI consumes either a JSONL `--pairs-file` (authoritative, generated out-of-band from a pre-bug DB snapshot) or runs in heuristic mode for `#0` legacy / `metadata.legacy_username` matching.

## Production result

Recovery already executed against prod with a pairs file derived from a pre-bug pg_dump:

| Metric | Pre-bug | Post-bug | Post-merge |
| --- | --- | --- | --- |
| Users total | ~44k | 62.574 | **44.270** |
| Orphans (excl. legacy seeds) | 0 | 11.973 | **0** |
| Duplicate users from 2026-05-01 | 0 | 24.189 | **5.892** (genuinely new) |

18.304 merges executed, 0 errors, 0 conflicts. The remaining 20 orphans are unrelated to this bug — they were left over by a prior cascade delete of tenant `3pontos`.

## Test plan

- [x] `php artisan test --compact app-modules/integration-discord/tests` (146 passing)
- [x] `vendor/bin/pint --dirty --format agent`
- [x] `vendor/bin/phpstan analyse --memory-limit=2G app-modules/integration-discord/src` (0 errors)
- [x] `vendor/bin/rector --dry-run app-modules/integration-discord/src` (clean)
- [x] Production dry-run + full run executed with `--pairs-file` (18.304 merged, 0 errors)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New command to merge duplicate Discord user profiles with support for batch processing and dry-run mode.
  * Enhanced Discord profile import with improved conflict detection and duplicate user handling.

* **Performance**
  * Optimized batch processing for faster Discord profile imports.

* **Tests**
  * Added comprehensive test coverage for profile merging and import conflict scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->