### PR TITLE
fix(docker): update postgres volume mount path for PG 18 compatibilit…

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - '5432:5432'
     volumes:
-      - he4rtbot-db:/var/lib/postgresql/data
+      - he4rtbot-db:/var/lib/postgresql
     networks:
       - dev-he4rtbot
     healthcheck:


### PR DESCRIPTION
## Problem                                                                                                                                                                                        
                                          
  The `he4rtbot-db` container was crashing on startup after upgrading to                                                                                                                            
  postgres:18. The volume was mounted at `/var/lib/postgresql/data`, which
  worked fine on older versions.                                                                                                                                                                    
                                          
  ## Root Cause                                                                                                                                                                                     
                                          
  Starting from PostgreSQL 18, the official Docker image changed its internal                                                                                                                       
  directory structure to use major-version-specific paths
  (`/var/lib/postgresql/18/main`), following `pg_ctlcluster` conventions.                                                                                                                           
  When the image detects existing data at `/var/lib/postgresql/data`, it                                                                                                                            
  aborts with:                                                                                                                                                                                      
                                                                                                                                                                                                    
  > Error: in 18+, these Docker images are configured to store database data                                                                                                                        
  > in a format which is compatible with "pg_ctlcluster" (specifically, using                                                                                                                       
  > major-version-specific directory names).                                                                                                                                                        
                                                            
  ## Fix                                                                                                                                                                                            
                                          
  Mount the volume at the parent path `/var/lib/postgresql` instead of                                                                                                                              
  `/var/lib/postgresql/data`, letting PostgreSQL manage the versioned
  subdirectory itself.                                                                                                                                                                              
                                          
  ## Migration                                                                                                                                                                                      
                                          
  If you already have a local `he4rtbot-db` volume, you need to recreate it:                                                                                                                        
   
  \```bash                                                                                                                                                                                          
  docker compose down                     
  docker volume rm he4rtbot-db                                                                                                                                                                      
  docker compose up he4rtbot-db -d        
  \``` 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database container volume configuration to optimize persistent storage handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->