### PR TITLE
fix(cache): allow all serializable classes from cache

### DIFF
--- a/config/cache.php
+++ b/config/cache.php
@@ -2,7 +2,6 @@
 
 declare(strict_types=1);
 
-use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use Illuminate\Support\Str;
 
 return [
@@ -122,14 +121,12 @@ return [
     | Serializable Classes
     |--------------------------------------------------------------------------
     |
-    | Classes that may be unserialized from cache. Laravel 13 defaults to
-    | blocking all class unserialization for security. List classes that
-    | your application intentionally stores as objects in cache.
+    | This option controls which classes may be unserialized from the cache.
+    | Setting this to false prevents all object unserialization, hardening
+    | your application against PHP deserialization attacks.
     |
     */
 
-    'serializable_classes' => [
-        ExternalIdentity::class,
-    ],
+    'serializable_classes' => true,
 
 ];


### PR DESCRIPTION
## Summary

Laravel 13 default-blocks object unserialization from cache (`serializable_classes` defaults to a strict allowlist). The previous config only whitelisted `ExternalIdentity`, which broke any feature storing DTOs or `Carbon` instances in cache.

Concrete impact: `VoiceChannelDTO` from `bot-discord` (cached via `cache()->tags(['voice_channels'])`) was being recovered as `__PHP_Incomplete_Class`. Calls like `$dto->isEmpty()` raised a fatal `Error: The script tried to call a method on an incomplete object`. The same applies to `Carbon` timestamps inside the DTO (`lastJoinedAt`).

## Why `true` instead of expanding the allowlist

- The app intentionally stores **multiple** object graphs in cache (DTOs, Carbon, Eloquent collections via tags, etc.). Any future DTO would silently regress without a config update.
- Cache backends are internal trust boundaries (Redis/DB owned by the app). The deserialization-attack vector that motivates the strict default applies to user-controlled payloads, not first-party app cache.
- `true` matches Laravel's pre-13 behavior — no surprises for code written against earlier conventions, no maintenance burden of keeping a class list in sync with feature work.

If a stricter posture is needed later, we can re-introduce an allowlist scoped to the actual classes used (DTOs + `Illuminate\Support\Carbon` + `Carbon\Carbon` + Eloquent models touched by tagged caches).

## Validation result

Reproduced the bug locally by reverting `config/cache.php` to `main`, ran `bin/voice-channel-validation.php` via tinker, then re-ran with the fix.

| Assertion | Expected | Before fix | After fix |
|-----------|---------|------------|-----------|
| `$r instanceof VoiceChannelDTO` | `true` | `false` (incomplete class) | ✓ `true` |
| `$r->lastJoinedAt instanceof CarbonInterface` | `true` | `false` + warning | ✓ `true` |
| `$r->isEmpty()` | `false` | **fatal Error** | ✓ `false` |
| `$r->isLongTermEmpty()` | `false` | **fatal Error** | ✓ `false` |

## Test plan

- [ ] CI passes (pint, phpstan, pest)
- [ ] Manual: run validation snippet below in tinker and confirm all 4 assertions match expected
- [ ] Manual: trigger a voice-channel cache write/read flow in the bot and confirm DTOs round-trip cleanly

<details>
<summary>Validation snippet (drop in <code>bin/voice-channel-validation.php</code> and run via <code>php artisan tinker --execute 'require base_path("bin/voice-channel-validation.php");'</code>)</summary>

```php
<?php

use He4rt\BotDiscord\DTO\VoiceChannelDTO;

$dto = VoiceChannelDTO::make([
    'guildId'      => '123456789012345678',
    'channelId'    => '987654321098765432',
    'ownerId'      => '111222333444555666',
    'usersCount'   => 2,
    'users'        => [
        '111222333444555666' => ['username' => 'gvieira', 'joinedAt' => now()->toISOString()],
        '777888999000111222' => ['username' => 'he4rtuser', 'joinedAt' => now()->subMinutes(5)->toISOString()],
    ],
    'lastJoinedAt' => now(),
]);

echo '=== PRÉ-REDIS (objeto PHP) ===' . PHP_EOL;
dump($dto);

$key = 'active_voice_channels_keys';
cache()->tags(['voice_channels'])->put($key, [$dto], 60);

echo '=== PÓS-REDIS (recuperado do cache) ===' . PHP_EOL;
$recovered = cache()->tags(['voice_channels'])->get($key);
dump($recovered);

echo '=== Verificações ===' . PHP_EOL;
$r = $recovered[0];
var_dump($r instanceof VoiceChannelDTO);                       // expected: true
var_dump($r->lastJoinedAt instanceof \Carbon\CarbonInterface); // expected: true
var_dump($r->isEmpty());                                       // expected: false
var_dump($r->isLongTermEmpty());                               // expected: false
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Updated the cache configuration to allow all serializable classes by setting `serializable_classes` to `true` instead of an allowlist containing only `ExternalIdentity`. This addresses a Laravel 13 default that prevents unserialization of non-whitelisted classes, which was causing DTOs and Carbon instances cached via tags to be recovered as incomplete objects.

## References

- Related to bot-discord VoiceChannelDTO caching issues where objects were being restored as `__PHP_Incomplete_Class` instead of proper object instances
- Impacts cache tag functionality used throughout the application

## Dependencies & Requirements

Configuration-only change. No new dependencies added or updated. Environment variables and cache backend configurations remain unchanged.

## Contributor Summary

| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---|---|---|
| gvieira18 | 4 | 7 | 1 |

## Changes Summary

| File Path | Change Description |
|---|---|
| config/cache.php | Changed `serializable_classes` from an array allowlist `[ExternalIdentity::class]` to boolean `true` to allow unserialization of all cached object types including DTOs, Carbon instances, and Eloquent collections |

<!-- end of auto-generated comment: release notes by coderabbit.ai -->