### PR TITLE
feat: voice event persistence and Discord gateway data lake

### DIFF
--- a/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
+++ b/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
@@ -21,6 +21,7 @@ final class PersistVoiceStateAction
         }
 
         $tenantProvider = ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
             ->where('model_type', (new Tenant)->getMorphClass())
             ->where('external_account_id', (string) $state->guild_id) // @phpstan-ignore property.notFound
             ->first();

--- a/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
+++ b/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\BotDiscord\Actions\VoiceChannel;
+
+use Discord\Parts\WebSockets\VoiceStateUpdate;
+use He4rt\Activity\Voice\Models\Voice;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+
+final class PersistVoiceStateAction
+{
+    public function execute(VoiceStateUpdate $state, ?VoiceStateUpdate $oldState): void
+    {
+        $events = $this->resolveEvents($state, $oldState);
+
+        if ($events === []) {
+            return;
+        }
+
+        $tenantProvider = ExternalIdentity::query()
+            ->where('model_type', (new Tenant)->getMorphClass())
+            ->where('external_account_id', (string) $state->guild_id)
+            ->first();
+
+        if (!$tenantProvider) {
+            return;
+        }
+
+        $identity = ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Discord)
+            ->where('external_account_id', (string) $state->user_id)
+            ->where('tenant_id', $tenantProvider->tenant_id)
+            ->first();
+
+        if (!$identity) {
+            return;
+        }
+
+        foreach ($events as $event) {
+            Voice::query()->create([
+                'tenant_id' => $tenantProvider->tenant_id,
+                'external_identity_id' => $identity->id,
+                'channel_name' => $event['channel_id'],
+                'state' => $event['state'],
+                'occurred_at' => now(),
+                'obtained_experience' => 0,
+            ]);
+        }
+    }
+
+    /**
+     * @return list<array{channel_id: string, state: string}>
+     */
+    private function resolveEvents(VoiceStateUpdate $state, ?VoiceStateUpdate $oldState): array
+    {
+        $newChannelId = $state->channel_id;
+        $oldChannelId = $oldState?->channel_id;
+
+        if ($newChannelId === null && $oldChannelId !== null) {
+            return [['channel_id' => $oldChannelId, 'state' => 'left']];
+        }
+
+        if ($newChannelId !== null && $oldChannelId === null) {
+            return [['channel_id' => $newChannelId, 'state' => 'joined']];
+        }
+
+        if ($newChannelId !== null && $oldChannelId !== null && $newChannelId !== $oldChannelId) {
+            return [
+                ['channel_id' => $oldChannelId, 'state' => 'left'],
+                ['channel_id' => $newChannelId, 'state' => 'joined'],
+            ];
+        }
+
+        return [];
+    }
+}

--- a/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
+++ b/app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php
@@ -22,7 +22,7 @@ final class PersistVoiceStateAction
 
         $tenantProvider = ExternalIdentity::query()
             ->where('model_type', (new Tenant)->getMorphClass())
-            ->where('external_account_id', (string) $state->guild_id)
+            ->where('external_account_id', (string) $state->guild_id) // @phpstan-ignore property.notFound
             ->first();
 
         if (!$tenantProvider) {
@@ -56,8 +56,8 @@ final class PersistVoiceStateAction
      */
     private function resolveEvents(VoiceStateUpdate $state, ?VoiceStateUpdate $oldState): array
     {
-        $newChannelId = $state->channel_id;
-        $oldChannelId = $oldState?->channel_id;
+        $newChannelId = $state->channel_id; // @phpstan-ignore property.notFound
+        $oldChannelId = $oldState?->channel_id; // @phpstan-ignore property.notFound
 
         if ($newChannelId === null && $oldChannelId !== null) {
             return [['channel_id' => $oldChannelId, 'state' => 'left']];

--- a/app-modules/bot-discord/src/BotDiscordServiceProvider.php
+++ b/app-modules/bot-discord/src/BotDiscordServiceProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\BotDiscord;
 
+use He4rt\BotDiscord\Events\RawGatewayEvent;
 use He4rt\BotDiscord\Listeners\AutoExecuteAction;
 use He4rt\BotDiscord\Listeners\NotifyModerationChannel;
 use He4rt\BotDiscord\Moderation\DiscordModerationAdapter;
@@ -12,6 +13,7 @@ use He4rt\Moderation\Cases\Events\CaseReadyForEnforcement;
 use He4rt\Moderation\Enums\Platform;
 use He4rt\Moderation\Platform\PlatformRegistry;
 use Illuminate\Support\Facades\Event;
+use Laracord\Bot\Hook;
 use Laracord\Laracord;
 use Laracord\LaracordServiceProvider;
 
@@ -53,6 +55,11 @@ class BotDiscordServiceProvider extends LaracordServiceProvider
             ->discoverEvents(__DIR__.'/Events', 'He4rt\BotDiscord\Events')
             ->discoverCommands(__DIR__.'/Commands', 'He4rt\BotDiscord\Commands')
             ->discoverSlashCommands(__DIR__.'/SlashCommands', 'He4rt\BotDiscord\SlashCommands')
-            ->discoverTasks(__DIR__.'/Tasks', 'He4rt\BotDiscord\Tasks');
+            ->discoverTasks(__DIR__.'/Tasks', 'He4rt\BotDiscord\Tasks')
+            ->registerHook(Hook::AFTER_BOOT, function () use ($bot): void {
+                $bot->discord()->on('raw', function (object $payload): void {
+                    resolve(RawGatewayEvent::class)->handle($payload);
+                });
+            });
     }
 }

--- a/app-modules/bot-discord/src/Events/DynamicVoiceEvent.php
+++ b/app-modules/bot-discord/src/Events/DynamicVoiceEvent.php
@@ -8,7 +8,9 @@ use Discord\Discord;
 use Discord\Parts\WebSockets\VoiceStateUpdate;
 use Discord\WebSockets\Event as Events;
 use He4rt\BotDiscord\Actions\VoiceChannel\HandleStateChannelAction;
+use He4rt\BotDiscord\Actions\VoiceChannel\PersistVoiceStateAction;
 use Laracord\Events\Event;
+use Throwable;
 
 class DynamicVoiceEvent extends Event
 {
@@ -31,5 +33,13 @@ class DynamicVoiceEvent extends Event
             userId: $userId,
             channelId: $channelId,
         );
+
+        try {
+            resolve(PersistVoiceStateAction::class)->execute($state, $oldState);
+        } catch (Throwable $throwable) {
+            $this->logger()->error(
+                sprintf('%s | File: %s | Line: %s', $throwable->getMessage(), $throwable->getFile(), $throwable->getLine()),
+            );
+        }
     }
 }

--- a/app-modules/bot-discord/src/Events/RawGatewayEvent.php
+++ b/app-modules/bot-discord/src/Events/RawGatewayEvent.php
@@ -17,9 +17,9 @@ final class RawGatewayEvent
         DiscordEventLog::query()->create([
             'event_type' => $payload->t,
             'guild_id' => $payload->d->guild_id ?? null,
-            'user_id' => $payload->d->user_id ?? (isset($payload->d->author) ? $payload->d->author->id : null),
-            'channel_id' => $payload->d->channel_id ?? null,
-            'payload' => json_decode(json_encode($payload->d), true),
+            'user_id' => $payload->d->user_id ?? $payload->d->author->id ?? $payload->d->user->id ?? null,
+            'channel_id' => $payload->d->channel_id ?? $payload->d->id ?? null,
+            'payload' => (array) $payload,
         ]);
     }
 }

--- a/app-modules/bot-discord/src/Events/RawGatewayEvent.php
+++ b/app-modules/bot-discord/src/Events/RawGatewayEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\BotDiscord\Events;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+
+final class RawGatewayEvent
+{
+    public function handle(object $payload): void
+    {
+        if (!isset($payload->t, $payload->d)) {
+            return;
+        }
+
+        DiscordEventLog::query()->create([
+            'event_type' => $payload->t,
+            'guild_id' => $payload->d->guild_id ?? null,
+            'user_id' => $payload->d->user_id ?? $payload->d->author?->id ?? null,
+            'channel_id' => $payload->d->channel_id ?? null,
+            'payload' => json_decode(json_encode($payload->d), true),
+            'occurred_at' => now(),
+        ]);
+    }
+}

--- a/app-modules/bot-discord/src/Events/RawGatewayEvent.php
+++ b/app-modules/bot-discord/src/Events/RawGatewayEvent.php
@@ -17,7 +17,7 @@ final class RawGatewayEvent
         DiscordEventLog::query()->create([
             'event_type' => $payload->t,
             'guild_id' => $payload->d->guild_id ?? null,
-            'user_id' => $payload->d->user_id ?? $payload->d->author?->id ?? null,
+            'user_id' => $payload->d->user_id ?? (isset($payload->d->author) ? $payload->d->author->id : null),
             'channel_id' => $payload->d->channel_id ?? null,
             'payload' => json_decode(json_encode($payload->d), true),
             'occurred_at' => now(),

--- a/app-modules/bot-discord/src/Events/RawGatewayEvent.php
+++ b/app-modules/bot-discord/src/Events/RawGatewayEvent.php
@@ -20,7 +20,6 @@ final class RawGatewayEvent
             'user_id' => $payload->d->user_id ?? (isset($payload->d->author) ? $payload->d->author->id : null),
             'channel_id' => $payload->d->channel_id ?? null,
             'payload' => json_decode(json_encode($payload->d), true),
-            'occurred_at' => now(),
         ]);
     }
 }

--- a/app-modules/bot-discord/tests/Feature/Actions/VoiceChannel/PersistVoiceStateActionTest.php
+++ b/app-modules/bot-discord/tests/Feature/Actions/VoiceChannel/PersistVoiceStateActionTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Discord\Parts\WebSockets\VoiceStateUpdate;
+use He4rt\Activity\Voice\Models\Voice;
+use He4rt\BotDiscord\Actions\VoiceChannel\PersistVoiceStateAction;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+function makeVoiceState(?string $guildId, ?string $channelId, string $userId): VoiceStateUpdate
+{
+    $state = Mockery::mock(VoiceStateUpdate::class)->makePartial()->shouldAllowMockingProtectedMethods();
+    $state->shouldReceive('getAttribute')->with('guild_id')->andReturn($guildId);
+    $state->shouldReceive('getAttribute')->with('channel_id')->andReturn($channelId);
+    $state->shouldReceive('getAttribute')->with('user_id')->andReturn($userId);
+
+    return $state;
+}
+
+beforeEach(function (): void {
+    $this->tenant = Tenant::factory()->create();
+    $this->user = User::factory()->create();
+    $this->discordUserId = '123456789';
+    $this->guildId = '987654321';
+    $this->channelId = '111222333';
+
+    ExternalIdentity::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'model_type' => (new Tenant)->getMorphClass(),
+        'model_id' => $this->tenant->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => $this->guildId,
+    ]);
+
+    ExternalIdentity::factory()->create([
+        'tenant_id' => $this->tenant->id,
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $this->user->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => $this->discordUserId,
+    ]);
+});
+
+test('persists a joined event when user connects to a channel', function (): void {
+    $state = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+    $oldState = makeVoiceState($this->guildId, null, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, $oldState);
+
+    $voice = Voice::query()->latest()->first();
+
+    expect($voice)->not->toBeNull()
+        ->and($voice->state)->toBe('joined')
+        ->and($voice->channel_name)->toBe($this->channelId)
+        ->and($voice->tenant_id)->toBe($this->tenant->id)
+        ->and($voice->obtained_experience)->toBe(0);
+});
+
+test('persists a joined event when oldState is null', function (): void {
+    $state = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, null);
+
+    expect(Voice::query()->count())->toBe(1)
+        ->and(Voice::query()->first()->state)->toBe('joined');
+});
+
+test('persists a left event when user disconnects', function (): void {
+    $state = makeVoiceState($this->guildId, null, $this->discordUserId);
+    $oldState = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, $oldState);
+
+    $voice = Voice::query()->latest()->first();
+
+    expect($voice)->not->toBeNull()
+        ->and($voice->state)->toBe('left')
+        ->and($voice->channel_name)->toBe($this->channelId);
+});
+
+test('persists two events when user switches channels', function (): void {
+    $newChannelId = '444555666';
+    $state = makeVoiceState($this->guildId, $newChannelId, $this->discordUserId);
+    $oldState = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, $oldState);
+
+    $voices = Voice::query()->orderBy('id')->get();
+
+    expect($voices)->toHaveCount(2)
+        ->and($voices[0]->state)->toBe('left')
+        ->and($voices[0]->channel_name)->toBe($this->channelId)
+        ->and($voices[1]->state)->toBe('joined')
+        ->and($voices[1]->channel_name)->toBe($newChannelId);
+});
+
+test('skips persistence for mute toggle in same channel', function (): void {
+    $state = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+    $oldState = makeVoiceState($this->guildId, $this->channelId, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, $oldState);
+
+    expect(Voice::query()->count())->toBe(0);
+});
+
+test('skips persistence when tenant is not found', function (): void {
+    $state = makeVoiceState('unknown-guild', $this->channelId, $this->discordUserId);
+
+    (new PersistVoiceStateAction)->execute($state, null);
+
+    expect(Voice::query()->count())->toBe(0);
+});
+
+test('skips persistence when user identity is not found', function (): void {
+    $state = makeVoiceState($this->guildId, $this->channelId, 'unknown-user');
+
+    (new PersistVoiceStateAction)->execute($state, null);
+
+    expect(Voice::query()->count())->toBe(0);
+});

--- a/app-modules/bot-discord/tests/Feature/Events/RawGatewayEventTest.php
+++ b/app-modules/bot-discord/tests/Feature/Events/RawGatewayEventTest.php
@@ -30,7 +30,7 @@ test('persists a dispatch event to discord_event_logs', function (): void {
         ->and($log->guild_id)->toBe('123456789')
         ->and($log->user_id)->toBe('987654321')
         ->and($log->payload)->toBeArray()
-        ->and($log->payload['roles'])->toBe([]);
+        ->and($log->payload['d']['roles'])->toBe([]);
 });
 
 test('extracts user_id from author when user_id is absent', function (): void {
@@ -52,6 +52,45 @@ test('extracts user_id from author when user_id is absent', function (): void {
 
     expect($log->user_id)->toBe('555666777')
         ->and($log->channel_id)->toBe('111222333');
+});
+
+test('extracts user_id from user object when user_id and author are absent', function (): void {
+    $payload = (object) [
+        'op' => 0,
+        't' => 'GUILD_MEMBER_UPDATE',
+        's' => 25,
+        'd' => (object) [
+            'guild_id' => '123456789',
+            'user' => (object) ['id' => '444555666'],
+            'roles' => [],
+        ],
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    $log = DiscordEventLog::query()->first();
+
+    expect($log->user_id)->toBe('444555666');
+});
+
+test('falls back to id for channel_id when channel_id is absent', function (): void {
+    $payload = (object) [
+        'op' => 0,
+        't' => 'VOICE_CHANNEL_STATUS_UPDATE',
+        's' => 5,
+        'd' => (object) [
+            'id' => '1501350540737646784',
+            'status' => null,
+            'guild_id' => '123456789',
+        ],
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    $log = DiscordEventLog::query()->first();
+
+    expect($log->channel_id)->toBe('1501350540737646784')
+        ->and($log->guild_id)->toBe('123456789');
 });
 
 test('skips non-dispatch events without type', function (): void {

--- a/app-modules/bot-discord/tests/Feature/Events/RawGatewayEventTest.php
+++ b/app-modules/bot-discord/tests/Feature/Events/RawGatewayEventTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\BotDiscord\Events\RawGatewayEvent;
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('persists a dispatch event to discord_event_logs', function (): void {
+    $payload = (object) [
+        'op' => 0,
+        't' => 'GUILD_MEMBER_ADD',
+        's' => 42,
+        'd' => (object) [
+            'guild_id' => '123456789',
+            'user_id' => '987654321',
+            'channel_id' => null,
+            'roles' => [],
+        ],
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    $log = DiscordEventLog::query()->first();
+
+    expect($log)->not->toBeNull()
+        ->and($log->event_type)->toBe('GUILD_MEMBER_ADD')
+        ->and($log->guild_id)->toBe('123456789')
+        ->and($log->user_id)->toBe('987654321')
+        ->and($log->payload)->toBeArray()
+        ->and($log->payload['roles'])->toBe([]);
+});
+
+test('extracts user_id from author when user_id is absent', function (): void {
+    $payload = (object) [
+        'op' => 0,
+        't' => 'MESSAGE_CREATE',
+        's' => 43,
+        'd' => (object) [
+            'guild_id' => '123456789',
+            'channel_id' => '111222333',
+            'content' => 'hello',
+            'author' => (object) ['id' => '555666777'],
+        ],
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    $log = DiscordEventLog::query()->first();
+
+    expect($log->user_id)->toBe('555666777')
+        ->and($log->channel_id)->toBe('111222333');
+});
+
+test('skips non-dispatch events without type', function (): void {
+    $payload = (object) [
+        'op' => 11,
+        'd' => null,
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    expect(DiscordEventLog::query()->count())->toBe(0);
+});
+
+test('skips heartbeat ack events', function (): void {
+    $payload = (object) [
+        'op' => 1,
+        't' => null,
+        'd' => null,
+    ];
+
+    (new RawGatewayEvent)->handle($payload);
+
+    expect(DiscordEventLog::query()->count())->toBe(0);
+});

--- a/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
@@ -20,7 +20,6 @@ return new class extends Migration
             $table->string('user_id')->nullable();
             $table->string('channel_id')->nullable();
             $table->jsonb('payload');
-            $table->timestamp('occurred_at')->index();
             $table->timestamps();
         });
     }

--- a/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_event_logs', function (Blueprint $table): void {
+            $table->id();
+            $table->string('event_type')->index();
+            $table->string('guild_id')->nullable()->index();
+            $table->string('user_id')->nullable();
+            $table->string('channel_id')->nullable();
+            $table->jsonb('payload');
+            $table->timestamp('occurred_at')->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_event_logs');
+    }
+};

--- a/app-modules/integration-discord/src/Models/DiscordEventLog.php
+++ b/app-modules/integration-discord/src/Models/DiscordEventLog.php
@@ -14,7 +14,6 @@ final class DiscordEventLog extends Model
         'user_id',
         'channel_id',
         'payload',
-        'occurred_at',
     ];
 
     /**
@@ -24,7 +23,6 @@ final class DiscordEventLog extends Model
     {
         return [
             'payload' => 'array',
-            'occurred_at' => 'datetime',
         ];
     }
 }

--- a/app-modules/integration-discord/src/Models/DiscordEventLog.php
+++ b/app-modules/integration-discord/src/Models/DiscordEventLog.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+final class DiscordEventLog extends Model
+{
+    protected $fillable = [
+        'event_type',
+        'guild_id',
+        'user_id',
+        'channel_id',
+        'payload',
+        'occurred_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'payload' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/integration-discord/tests/Feature/Models/DiscordEventLogTest.php
+++ b/app-modules/integration-discord/tests/Feature/Models/DiscordEventLogTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('persists a raw gateway event', function (): void {
+    $log = DiscordEventLog::query()->create([
+        'event_type' => 'MESSAGE_CREATE',
+        'guild_id' => '123456789',
+        'user_id' => '987654321',
+        'channel_id' => '111222333',
+        'payload' => ['content' => 'hello world', 'author' => ['id' => '987654321']],
+        'occurred_at' => now(),
+    ]);
+
+    expect($log)->not->toBeNull()
+        ->and($log->event_type)->toBe('MESSAGE_CREATE')
+        ->and($log->guild_id)->toBe('123456789')
+        ->and($log->payload)->toBeArray()
+        ->and($log->payload['content'])->toBe('hello world');
+});
+
+test('allows nullable guild_id, user_id, and channel_id', function (): void {
+    $log = DiscordEventLog::query()->create([
+        'event_type' => 'READY',
+        'guild_id' => null,
+        'user_id' => null,
+        'channel_id' => null,
+        'payload' => ['v' => 10, 'session_id' => 'abc'],
+        'occurred_at' => now(),
+    ]);
+
+    expect($log->guild_id)->toBeNull()
+        ->and($log->user_id)->toBeNull()
+        ->and($log->channel_id)->toBeNull();
+});

--- a/app-modules/integration-discord/tests/Feature/Models/DiscordEventLogTest.php
+++ b/app-modules/integration-discord/tests/Feature/Models/DiscordEventLogTest.php
@@ -14,7 +14,6 @@ test('persists a raw gateway event', function (): void {
         'user_id' => '987654321',
         'channel_id' => '111222333',
         'payload' => ['content' => 'hello world', 'author' => ['id' => '987654321']],
-        'occurred_at' => now(),
     ]);
 
     expect($log)->not->toBeNull()
@@ -31,7 +30,6 @@ test('allows nullable guild_id, user_id, and channel_id', function (): void {
         'user_id' => null,
         'channel_id' => null,
         'payload' => ['v' => 10, 'session_id' => 'abc'],
-        'occurred_at' => now(),
     ]);
 
     expect($log->guild_id)->toBeNull()


### PR DESCRIPTION
## Summary

- **Voice join/leave persistence**: The Discord bot was receiving `VOICE_STATE_UPDATE` events but only updating Redis cache — voice activity stopped being recorded in the database since March 2026. Added `PersistVoiceStateAction` that resolves tenant/identity and writes `joined`/`left` records to `voice_messages`, following the same pattern as the ETL importer.
- **Discord event data lake**: New `discord_event_logs` table (jsonb payload) that captures every raw Discord gateway event via the `raw` listener, registered through Laracord's `AFTER_BOOT` hook. Acts as a generic data lake for future analytics.

## Files changed

| File | Change |
|---|---|
| `bot-discord/Actions/VoiceChannel/PersistVoiceStateAction.php` | New — persists voice join/leave |
| `bot-discord/Events/DynamicVoiceEvent.php` | Modified — calls PersistVoiceStateAction |
| `bot-discord/Events/RawGatewayEvent.php` | New — raw gateway listener |
| `bot-discord/BotDiscordServiceProvider.php` | Modified — registers AFTER_BOOT hook |
| `integration-discord/Models/DiscordEventLog.php` | New — Eloquent model |
| `integration-discord/migrations/create_discord_event_logs_table.php` | New — migration |

## Test plan

- [x] 7 tests for `PersistVoiceStateAction` (join, leave, channel switch, mute skip, missing tenant/identity)
- [x] 4 tests for `RawGatewayEvent` (dispatch persist, author fallback, non-dispatch skip, heartbeat skip)
- [x] 2 tests for `DiscordEventLog` model (persist, nullable fields)
- [x] PHPStan passes with 0 errors
- [x] Pint formatting clean
- [x] Verified live: voice events and raw gateway events appearing in database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
Adds persistence for Discord voice join/leave events via PersistVoiceStateAction (fixes regression that stopped DB writes) and introduces a Discord gateway data lake by logging raw gateway events to a new discord_event_logs table via a RawGatewayEvent listener registered in Laracord's AFTER_BOOT hook.

## References
- PR `#259`: https://github.com/he4rt/heartdevs.com/pull/259
- Regression noted: voice activity DB writes stopped on 2026-03-23
- Related historical PRs/commits referenced in context: `#145`, `#149`, `#171`

## Dependencies & Requirements
- No new external composer/runtime dependencies.
- Requires running the migration: app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php (uses jsonb; PostgreSQL JSONB required).
- No environment variable changes.

## Contributor Summary
| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| danielhe4rt | 432 | 1 | 9 |

## Changes Summary
| File Path | Change Description |
|---|---|
| app-modules/bot-discord/src/Actions/VoiceChannel/PersistVoiceStateAction.php | New action to resolve tenant/identity and persist voice `joined`/`left` events to Voice model |
| app-modules/bot-discord/src/Events/DynamicVoiceEvent.php | Now invokes PersistVoiceStateAction and logs exceptions from persistence |
| app-modules/bot-discord/src/Events/RawGatewayEvent.php | New handler that records every raw Discord gateway event into discord_event_logs with fallback extraction for user_id/channel_id |
| app-modules/bot-discord/src/BotDiscordServiceProvider.php | Registers RawGatewayEvent listener via Laracord AFTER_BOOT hook (wire-up) |
| app-modules/bot-discord/tests/Feature/Actions/VoiceChannel/PersistVoiceStateActionTest.php | Tests for join/leave/switch and identity/tenant edge cases (7 tests) |
| app-modules/bot-discord/tests/Feature/Events/RawGatewayEventTest.php | Tests for raw event persistence and fallback extraction paths (4 tests) |
| app-modules/integration-discord/src/Models/DiscordEventLog.php | New Eloquent model for discord_event_logs (payload cast to array) |
| app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php | Migration creating discord_event_logs (event_type, guild_id, user_id, channel_id, payload jsonb, timestamps using created_at/updated_at) |
| app-modules/integration-discord/tests/Feature/Models/DiscordEventLogTest.php | Model tests covering persistence and nullable ID fields |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/he4rt/heartdevs.com/pull/259?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->