### PR TITLE
feat(integration-discord): normalize Discord entities for community health metrics

### DIFF
--- a/app-modules/integration-discord/database/factories/DiscordChannelFactory.php
+++ b/app-modules/integration-discord/database/factories/DiscordChannelFactory.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Database\Factories;
+
+use He4rt\IntegrationDiscord\Enums\DiscordChannelType;
+use He4rt\IntegrationDiscord\Models\DiscordChannel;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DiscordChannel>
+ */
+final class DiscordChannelFactory extends Factory
+{
+    protected $model = DiscordChannel::class;
+
+    public function definition(): array
+    {
+        return [
+            'discord_guild_id' => DiscordGuild::factory(),
+            'discord_channel_id' => (string) fake()->unique()->numberBetween(100000000000000000, 999999999999999999),
+            'name' => fake()->slug(2),
+            'type' => DiscordChannelType::GuildText,
+            'position' => fake()->numberBetween(0, 50),
+            'nsfw' => false,
+        ];
+    }
+
+    public function voice(): static
+    {
+        return $this->state([
+            'type' => DiscordChannelType::GuildVoice,
+            'bitrate' => 64000,
+            'user_limit' => 0,
+        ]);
+    }
+
+    public function category(): static
+    {
+        return $this->state([
+            'type' => DiscordChannelType::GuildCategory,
+        ]);
+    }
+}

--- a/app-modules/integration-discord/database/factories/DiscordGuildFactory.php
+++ b/app-modules/integration-discord/database/factories/DiscordGuildFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Database\Factories;
+
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DiscordGuild>
+ */
+final class DiscordGuildFactory extends Factory
+{
+    protected $model = DiscordGuild::class;
+
+    public function definition(): array
+    {
+        return [
+            'discord_guild_id' => (string) fake()->unique()->numberBetween(100000000000000000, 999999999999999999),
+            'name' => fake()->company(),
+            'icon' => fake()->optional()->md5(),
+            'description' => fake()->optional()->sentence(),
+            'member_count' => fake()->numberBetween(10, 50000),
+            'premium_tier' => fake()->numberBetween(0, 3),
+            'features' => [],
+        ];
+    }
+}

--- a/app-modules/integration-discord/database/factories/DiscordMemberFactory.php
+++ b/app-modules/integration-discord/database/factories/DiscordMemberFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Database\Factories;
+
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DiscordMember>
+ */
+final class DiscordMemberFactory extends Factory
+{
+    protected $model = DiscordMember::class;
+
+    public function definition(): array
+    {
+        return [
+            'discord_guild_id' => DiscordGuild::factory(),
+            'discord_user_id' => (string) fake()->unique()->numberBetween(100000000000000000, 999999999999999999),
+            'username' => fake()->userName(),
+            'global_name' => fake()->optional()->name(),
+            'avatar' => fake()->optional()->md5(),
+            'is_bot' => false,
+            'is_pending' => false,
+            'joined_at' => fake()->dateTimeBetween('-2 years'),
+        ];
+    }
+
+    public function bot(): static
+    {
+        return $this->state([
+            'is_bot' => true,
+        ]);
+    }
+
+    public function pending(): static
+    {
+        return $this->state([
+            'is_pending' => true,
+        ]);
+    }
+
+    public function left(): static
+    {
+        return $this->state([
+            'left_at' => now(),
+        ]);
+    }
+}

--- a/app-modules/integration-discord/database/factories/DiscordRoleFactory.php
+++ b/app-modules/integration-discord/database/factories/DiscordRoleFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Database\Factories;
+
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<DiscordRole>
+ */
+final class DiscordRoleFactory extends Factory
+{
+    protected $model = DiscordRole::class;
+
+    public function definition(): array
+    {
+        return [
+            'discord_guild_id' => DiscordGuild::factory(),
+            'discord_role_id' => (string) fake()->unique()->numberBetween(100000000000000000, 999999999999999999),
+            'name' => fake()->word(),
+            'color' => fake()->numberBetween(0, 16777215),
+            'position' => fake()->numberBetween(0, 50),
+            'permissions' => 0,
+            'is_hoisted' => false,
+            'is_mentionable' => false,
+            'is_managed' => false,
+        ];
+    }
+}

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200000_create_discord_guilds_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200000_create_discord_guilds_table.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_guilds', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('tenant_id')->nullable()->constrained('tenants')->nullOnDelete();
+            $table->string('discord_guild_id')->unique();
+            $table->string('name');
+            $table->string('icon')->nullable();
+            $table->text('description')->nullable();
+            $table->integer('member_count')->nullable();
+            $table->smallInteger('premium_tier')->default(0);
+            $table->jsonb('features')->default('[]');
+            $table->timestamp('synced_at')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_guilds');
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200001_create_discord_channels_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200001_create_discord_channels_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_channels', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('discord_guild_id')->constrained('discord_guilds')->cascadeOnDelete();
+            $table->string('discord_channel_id')->unique();
+            $table->foreignId('parent_id')->nullable()->constrained('discord_channels')->nullOnDelete();
+            $table->string('name');
+            $table->smallInteger('type');
+            $table->text('topic')->nullable();
+            $table->smallInteger('position')->default(0);
+            $table->boolean('nsfw')->default(false);
+            $table->integer('bitrate')->nullable();
+            $table->integer('user_limit')->nullable();
+            $table->timestamps();
+
+            $table->index('discord_guild_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_channels');
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200002_create_discord_roles_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200002_create_discord_roles_table.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_roles', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('discord_guild_id')->constrained('discord_guilds')->cascadeOnDelete();
+            $table->string('discord_role_id')->unique();
+            $table->string('name');
+            $table->integer('color')->default(0);
+            $table->smallInteger('position')->default(0);
+            $table->bigInteger('permissions')->default(0);
+            $table->boolean('is_hoisted')->default(false);
+            $table->boolean('is_mentionable')->default(false);
+            $table->boolean('is_managed')->default(false);
+            $table->string('icon')->nullable();
+            $table->timestamps();
+
+            $table->index('discord_guild_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_roles');
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200003_create_discord_members_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200003_create_discord_members_table.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_members', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('discord_guild_id')->constrained('discord_guilds')->cascadeOnDelete();
+            $table->string('discord_user_id');
+            $table->foreignUuid('external_identity_id')->nullable()->constrained('external_identities')->nullOnDelete();
+            $table->string('username');
+            $table->string('global_name')->nullable();
+            $table->string('avatar')->nullable();
+            $table->string('nickname')->nullable();
+            $table->boolean('is_bot')->default(false);
+            $table->boolean('is_pending')->default(false);
+            $table->timestamp('joined_at')->nullable();
+            $table->timestamp('premium_since')->nullable();
+            $table->timestamp('communication_disabled_until')->nullable();
+            $table->timestamp('left_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['discord_guild_id', 'discord_user_id']);
+            $table->index('discord_user_id');
+            $table->index('external_identity_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_members');
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200004_create_discord_member_roles_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200004_create_discord_member_roles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('discord_member_roles', function (Blueprint $table): void {
+            $table->foreignId('discord_member_id')->constrained('discord_members')->cascadeOnDelete();
+            $table->foreignId('discord_role_id')->constrained('discord_roles')->cascadeOnDelete();
+            $table->timestamp('assigned_at')->nullable();
+            $table->timestamps();
+
+            $table->primary(['discord_member_id', 'discord_role_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_member_roles');
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('discord_member_role_history', function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('discord_member_id')->constrained('discord_members')->cascadeOnDelete();
+            $table->foreignId('discord_role_id')->constrained('discord_roles')->cascadeOnDelete();
+            $table->string('action');
+            $table->timestamp('occurred_at');
+            $table->foreignId('source_event_log_id')->nullable()->constrained('discord_event_logs')->nullOnDelete();
+            $table->timestamps();
+
+            $table->index('discord_member_id');
+            $table->index('discord_role_id');
+            $table->index('occurred_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('discord_member_role_history');
+    }
+};

--- a/app-modules/integration-discord/src/Enums/DiscordChannelType.php
+++ b/app-modules/integration-discord/src/Enums/DiscordChannelType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Enums;
+
+enum DiscordChannelType: int
+{
+    case GuildText = 0;
+    case Dm = 1;
+    case GuildVoice = 2;
+    case GroupDm = 3;
+    case GuildCategory = 4;
+    case GuildAnnouncement = 5;
+    case AnnouncementThread = 10;
+    case PublicThread = 11;
+    case PrivateThread = 12;
+    case GuildStageVoice = 13;
+    case GuildForum = 15;
+    case GuildMedia = 16;
+}

--- a/app-modules/integration-discord/src/Enums/RoleHistoryAction.php
+++ b/app-modules/integration-discord/src/Enums/RoleHistoryAction.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Enums;
+
+enum RoleHistoryAction: string
+{
+    case Assigned = 'assigned';
+    case Removed = 'removed';
+}

--- a/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
+++ b/app-modules/integration-discord/src/IntegrationDiscordServiceProvider.php
@@ -7,6 +7,9 @@ namespace He4rt\IntegrationDiscord;
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordMessagesCommand;
 use He4rt\IntegrationDiscord\ETL\Console\ImportDiscordProfilesCommand;
 use He4rt\IntegrationDiscord\ETL\Console\MergeDuplicateDiscordProfilesCommand;
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Sync\Console\SyncDiscordGuildCommand;
+use He4rt\IntegrationDiscord\Sync\Observers\DiscordEventLogObserver;
 use He4rt\IntegrationDiscord\Transport\DiscordConnector;
 use He4rt\IntegrationDiscord\Transport\DiscordOAuthConnector;
 use Illuminate\Support\ServiceProvider;
@@ -28,11 +31,14 @@ class IntegrationDiscordServiceProvider extends ServiceProvider
 
     public function boot(): void
     {
+        DiscordEventLog::observe(DiscordEventLogObserver::class);
+
         if ($this->app->runningInConsole()) {
             $this->commands([
                 ImportDiscordProfilesCommand::class,
                 ImportDiscordMessagesCommand::class,
                 MergeDuplicateDiscordProfilesCommand::class,
+                SyncDiscordGuildCommand::class,
             ]);
         }
     }

--- a/app-modules/integration-discord/src/Models/DiscordChannel.php
+++ b/app-modules/integration-discord/src/Models/DiscordChannel.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Carbon\Carbon;
+use He4rt\IntegrationDiscord\Database\Factories\DiscordChannelFactory;
+use He4rt\IntegrationDiscord\Enums\DiscordChannelType;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $discord_guild_id
+ * @property string $discord_channel_id
+ * @property int|null $parent_id
+ * @property string $name
+ * @property DiscordChannelType $type
+ * @property string|null $topic
+ * @property int $position
+ * @property bool $nsfw
+ * @property int|null $bitrate
+ * @property int|null $user_limit
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read DiscordGuild $guild
+ * @property-read DiscordChannel|null $parent
+ * @property-read Collection<int, DiscordChannel> $children
+ */
+final class DiscordChannel extends Model
+{
+    /** @use HasFactory<DiscordChannelFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'discord_guild_id',
+        'discord_channel_id',
+        'parent_id',
+        'name',
+        'type',
+        'topic',
+        'position',
+        'nsfw',
+        'bitrate',
+        'user_limit',
+    ];
+
+    /**
+     * @return BelongsTo<DiscordGuild, $this>
+     */
+    public function guild(): BelongsTo
+    {
+        return $this->belongsTo(DiscordGuild::class, 'discord_guild_id');
+    }
+
+    /**
+     * @return BelongsTo<self, $this>
+     */
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    /**
+     * @return HasMany<self, $this>
+     */
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    protected static function newFactory(): DiscordChannelFactory
+    {
+        return DiscordChannelFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'type' => DiscordChannelType::class,
+            'nsfw' => 'boolean',
+            'position' => 'integer',
+            'bitrate' => 'integer',
+            'user_limit' => 'integer',
+        ];
+    }
+}

--- a/app-modules/integration-discord/src/Models/DiscordEventLog.php
+++ b/app-modules/integration-discord/src/Models/DiscordEventLog.php
@@ -4,8 +4,19 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationDiscord\Models;
 
+use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Model;
 
+/**
+ * @property int $id
+ * @property string $event_type
+ * @property string|null $guild_id
+ * @property string|null $user_id
+ * @property string|null $channel_id
+ * @property array<string, mixed> $payload
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 final class DiscordEventLog extends Model
 {
     protected $fillable = [

--- a/app-modules/integration-discord/src/Models/DiscordGuild.php
+++ b/app-modules/integration-discord/src/Models/DiscordGuild.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Carbon\Carbon;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\IntegrationDiscord\Database\Factories\DiscordGuildFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int|null $tenant_id
+ * @property string $discord_guild_id
+ * @property string $name
+ * @property string|null $icon
+ * @property string|null $description
+ * @property int|null $member_count
+ * @property int $premium_tier
+ * @property array<int, string> $features
+ * @property Carbon|null $synced_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Tenant|null $tenant
+ * @property-read Collection<int, DiscordChannel> $channels
+ * @property-read Collection<int, DiscordRole> $roles
+ * @property-read Collection<int, DiscordMember> $members
+ */
+final class DiscordGuild extends Model
+{
+    /** @use HasFactory<DiscordGuildFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'tenant_id',
+        'discord_guild_id',
+        'name',
+        'icon',
+        'description',
+        'member_count',
+        'premium_tier',
+        'features',
+        'synced_at',
+    ];
+
+    /**
+     * @return BelongsTo<Tenant, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * @return HasMany<DiscordChannel, $this>
+     */
+    public function channels(): HasMany
+    {
+        return $this->hasMany(DiscordChannel::class, 'discord_guild_id');
+    }
+
+    /**
+     * @return HasMany<DiscordRole, $this>
+     */
+    public function roles(): HasMany
+    {
+        return $this->hasMany(DiscordRole::class, 'discord_guild_id');
+    }
+
+    /**
+     * @return HasMany<DiscordMember, $this>
+     */
+    public function members(): HasMany
+    {
+        return $this->hasMany(DiscordMember::class, 'discord_guild_id');
+    }
+
+    protected static function newFactory(): DiscordGuildFactory
+    {
+        return DiscordGuildFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'features' => 'array',
+            'synced_at' => 'datetime',
+            'premium_tier' => 'integer',
+            'member_count' => 'integer',
+        ];
+    }
+}

--- a/app-modules/integration-discord/src/Models/DiscordMember.php
+++ b/app-modules/integration-discord/src/Models/DiscordMember.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Carbon\Carbon;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\IntegrationDiscord\Database\Factories\DiscordMemberFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $discord_guild_id
+ * @property string $discord_user_id
+ * @property string|null $external_identity_id
+ * @property string $username
+ * @property string|null $global_name
+ * @property string|null $avatar
+ * @property string|null $nickname
+ * @property bool $is_bot
+ * @property bool $is_pending
+ * @property Carbon|null $joined_at
+ * @property Carbon|null $premium_since
+ * @property Carbon|null $communication_disabled_until
+ * @property Carbon|null $left_at
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read DiscordGuild $guild
+ * @property-read ExternalIdentity|null $externalIdentity
+ * @property-read Collection<int, DiscordRole> $roles
+ * @property-read Collection<int, DiscordMemberRoleHistory> $roleHistory
+ */
+final class DiscordMember extends Model
+{
+    /** @use HasFactory<DiscordMemberFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'discord_guild_id',
+        'discord_user_id',
+        'external_identity_id',
+        'username',
+        'global_name',
+        'avatar',
+        'nickname',
+        'is_bot',
+        'is_pending',
+        'joined_at',
+        'premium_since',
+        'communication_disabled_until',
+        'left_at',
+    ];
+
+    /**
+     * @return BelongsTo<DiscordGuild, $this>
+     */
+    public function guild(): BelongsTo
+    {
+        return $this->belongsTo(DiscordGuild::class, 'discord_guild_id');
+    }
+
+    /**
+     * @return BelongsTo<ExternalIdentity, $this>
+     */
+    public function externalIdentity(): BelongsTo
+    {
+        return $this->belongsTo(ExternalIdentity::class);
+    }
+
+    /**
+     * @return BelongsToMany<DiscordRole, $this>
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(DiscordRole::class, 'discord_member_roles')
+            ->withPivot('assigned_at')
+            ->withTimestamps();
+    }
+
+    /**
+     * @return HasMany<DiscordMemberRoleHistory, $this>
+     */
+    public function roleHistory(): HasMany
+    {
+        return $this->hasMany(DiscordMemberRoleHistory::class);
+    }
+
+    protected static function newFactory(): DiscordMemberFactory
+    {
+        return DiscordMemberFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'is_bot' => 'boolean',
+            'is_pending' => 'boolean',
+            'joined_at' => 'datetime',
+            'premium_since' => 'datetime',
+            'communication_disabled_until' => 'datetime',
+            'left_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/integration-discord/src/Models/DiscordMemberRoleHistory.php
+++ b/app-modules/integration-discord/src/Models/DiscordMemberRoleHistory.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Carbon\Carbon;
+use He4rt\IntegrationDiscord\Enums\RoleHistoryAction;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $discord_member_id
+ * @property int $discord_role_id
+ * @property RoleHistoryAction $action
+ * @property Carbon $occurred_at
+ * @property int|null $source_event_log_id
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read DiscordMember $member
+ * @property-read DiscordRole $role
+ * @property-read DiscordEventLog|null $sourceEventLog
+ */
+final class DiscordMemberRoleHistory extends Model
+{
+    protected $table = 'discord_member_role_history';
+
+    protected $fillable = [
+        'discord_member_id',
+        'discord_role_id',
+        'action',
+        'occurred_at',
+        'source_event_log_id',
+    ];
+
+    /**
+     * @return BelongsTo<DiscordMember, $this>
+     */
+    public function member(): BelongsTo
+    {
+        return $this->belongsTo(DiscordMember::class, 'discord_member_id');
+    }
+
+    /**
+     * @return BelongsTo<DiscordRole, $this>
+     */
+    public function role(): BelongsTo
+    {
+        return $this->belongsTo(DiscordRole::class, 'discord_role_id');
+    }
+
+    /**
+     * @return BelongsTo<DiscordEventLog, $this>
+     */
+    public function sourceEventLog(): BelongsTo
+    {
+        return $this->belongsTo(DiscordEventLog::class, 'source_event_log_id');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'action' => RoleHistoryAction::class,
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/integration-discord/src/Models/DiscordRole.php
+++ b/app-modules/integration-discord/src/Models/DiscordRole.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Models;
+
+use Carbon\Carbon;
+use He4rt\IntegrationDiscord\Database\Factories\DiscordRoleFactory;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+/**
+ * @property int $id
+ * @property int $discord_guild_id
+ * @property string $discord_role_id
+ * @property string $name
+ * @property int $color
+ * @property int $position
+ * @property int $permissions
+ * @property bool $is_hoisted
+ * @property bool $is_mentionable
+ * @property bool $is_managed
+ * @property string|null $icon
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read DiscordGuild $guild
+ * @property-read Collection<int, DiscordMember> $members
+ */
+final class DiscordRole extends Model
+{
+    /** @use HasFactory<DiscordRoleFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'discord_guild_id',
+        'discord_role_id',
+        'name',
+        'color',
+        'position',
+        'permissions',
+        'is_hoisted',
+        'is_mentionable',
+        'is_managed',
+        'icon',
+    ];
+
+    /**
+     * @return BelongsTo<DiscordGuild, $this>
+     */
+    public function guild(): BelongsTo
+    {
+        return $this->belongsTo(DiscordGuild::class, 'discord_guild_id');
+    }
+
+    /**
+     * @return BelongsToMany<DiscordMember, $this>
+     */
+    public function members(): BelongsToMany
+    {
+        return $this->belongsToMany(DiscordMember::class, 'discord_member_roles')
+            ->withPivot('assigned_at')
+            ->withTimestamps();
+    }
+
+    protected static function newFactory(): DiscordRoleFactory
+    {
+        return DiscordRoleFactory::new();
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'color' => 'integer',
+            'position' => 'integer',
+            'permissions' => 'integer',
+            'is_hoisted' => 'boolean',
+            'is_mentionable' => 'boolean',
+            'is_managed' => 'boolean',
+        ];
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Actions/SyncDiscordGuildAction.php
+++ b/app-modules/integration-discord/src/Sync/Actions/SyncDiscordGuildAction.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Actions;
+
+use He4rt\IntegrationDiscord\Enums\DiscordChannelType;
+use He4rt\IntegrationDiscord\Models\DiscordChannel;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+use He4rt\IntegrationDiscord\Transport\DiscordConnector;
+use He4rt\IntegrationDiscord\Transport\Requests\Channels\ListGuildChannels;
+use He4rt\IntegrationDiscord\Transport\Requests\Guilds\GetGuild;
+use He4rt\IntegrationDiscord\Transport\Requests\Members\ListGuildMembers;
+use He4rt\IntegrationDiscord\Transport\Requests\Roles\ListGuildRoles;
+
+final readonly class SyncDiscordGuildAction
+{
+    public function __construct(
+        private DiscordConnector $connector,
+    ) {}
+
+    public function execute(string $discordGuildId, bool $fresh = false): DiscordGuild
+    {
+        $guild = $this->syncGuild($discordGuildId, $fresh);
+        $this->syncChannels($guild, $discordGuildId);
+        $roleMap = $this->syncRoles($guild, $discordGuildId);
+        $this->syncMembers($guild, $discordGuildId, $roleMap);
+
+        $guild->update(['synced_at' => now()]);
+
+        return $guild->refresh();
+    }
+
+    private function syncGuild(string $discordGuildId, bool $fresh): DiscordGuild
+    {
+        if ($fresh) {
+            DiscordGuild::query()->where('discord_guild_id', $discordGuildId)->delete();
+        }
+
+        $response = $this->connector->send(new GetGuild($discordGuildId));
+
+        /** @var array<string, mixed> $data */
+        $data = $response->json();
+
+        return DiscordGuild::query()->updateOrCreate(
+            ['discord_guild_id' => $discordGuildId],
+            [
+                'name' => $data['name'],
+                'icon' => $data['icon'] ?? null,
+                'description' => $data['description'] ?? null,
+                'member_count' => $data['approximate_member_count'] ?? null,
+                'premium_tier' => $data['premium_tier'] ?? 0,
+                'features' => $data['features'] ?? [],
+            ],
+        );
+    }
+
+    private function syncChannels(DiscordGuild $guild, string $discordGuildId): void
+    {
+        $response = $this->connector->send(new ListGuildChannels($discordGuildId));
+
+        /** @var array<int, array<string, mixed>> $channels */
+        $channels = $response->json();
+
+        $channelIdMap = [];
+
+        foreach ($channels as $channelData) {
+            $channel = DiscordChannel::query()->updateOrCreate(
+                ['discord_channel_id' => $channelData['id']],
+                [
+                    'discord_guild_id' => $guild->id,
+                    'name' => $channelData['name'] ?? '',
+                    'type' => DiscordChannelType::tryFrom($channelData['type'] ?? 0) ?? DiscordChannelType::GuildText,
+                    'topic' => $channelData['topic'] ?? null,
+                    'position' => $channelData['position'] ?? 0,
+                    'nsfw' => $channelData['nsfw'] ?? false,
+                    'bitrate' => $channelData['bitrate'] ?? null,
+                    'user_limit' => $channelData['user_limit'] ?? null,
+                ],
+            );
+
+            $channelIdMap[$channelData['id']] = [
+                'internal_id' => $channel->id,
+                'parent_discord_id' => $channelData['parent_id'] ?? null,
+            ];
+        }
+
+        foreach ($channelIdMap as $mapping) {
+            if ($mapping['parent_discord_id'] !== null && isset($channelIdMap[$mapping['parent_discord_id']])) {
+                DiscordChannel::query()
+                    ->where('id', $mapping['internal_id'])
+                    ->update(['parent_id' => $channelIdMap[$mapping['parent_discord_id']]['internal_id']]);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, int>
+     */
+    private function syncRoles(DiscordGuild $guild, string $discordGuildId): array
+    {
+        $response = $this->connector->send(new ListGuildRoles($discordGuildId));
+
+        /** @var array<int, array<string, mixed>> $roles */
+        $roles = $response->json();
+
+        $roleMap = [];
+
+        foreach ($roles as $roleData) {
+            $role = DiscordRole::query()->updateOrCreate(
+                ['discord_role_id' => $roleData['id']],
+                [
+                    'discord_guild_id' => $guild->id,
+                    'name' => $roleData['name'],
+                    'color' => $roleData['color'] ?? 0,
+                    'position' => $roleData['position'] ?? 0,
+                    'permissions' => (int) ($roleData['permissions'] ?? 0),
+                    'is_hoisted' => $roleData['hoist'] ?? false,
+                    'is_mentionable' => $roleData['mentionable'] ?? false,
+                    'is_managed' => $roleData['managed'] ?? false,
+                    'icon' => $roleData['icon'] ?? null,
+                ],
+            );
+
+            $roleMap[$roleData['id']] = $role->id;
+        }
+
+        return $roleMap;
+    }
+
+    /**
+     * @param  array<string, int>  $roleMap
+     */
+    private function syncMembers(DiscordGuild $guild, string $discordGuildId, array $roleMap): void
+    {
+        $after = null;
+
+        do {
+            $response = $this->connector->send(new ListGuildMembers($discordGuildId, 1000, $after));
+
+            /** @var array<int, array<string, mixed>> $members */
+            $members = $response->json();
+
+            foreach ($members as $memberData) {
+                $user = $memberData['user'] ?? [];
+                $userId = $user['id'] ?? null;
+
+                if ($userId === null) {
+                    continue;
+                }
+
+                $member = DiscordMember::query()->updateOrCreate(
+                    [
+                        'discord_guild_id' => $guild->id,
+                        'discord_user_id' => $userId,
+                    ],
+                    [
+                        'username' => $user['username'] ?? 'unknown',
+                        'global_name' => $user['global_name'] ?? null,
+                        'avatar' => $user['avatar'] ?? null,
+                        'nickname' => $memberData['nick'] ?? null,
+                        'is_bot' => $user['bot'] ?? false,
+                        'is_pending' => $memberData['pending'] ?? false,
+                        'joined_at' => $memberData['joined_at'] ?? null,
+                        'premium_since' => $memberData['premium_since'] ?? null,
+                        'communication_disabled_until' => $memberData['communication_disabled_until'] ?? null,
+                    ],
+                );
+
+                /** @var array<int, string> $roleIds */
+                $roleIds = $memberData['roles'] ?? [];
+
+                $memberRoleIds = collect($roleIds)
+                    ->filter(fn (string $roleId): bool => isset($roleMap[$roleId]))
+                    ->mapWithKeys(fn (string $roleId): array => [
+                        $roleMap[$roleId] => ['assigned_at' => now()],
+                    ])
+                    ->all();
+
+                $member->roles()->sync($memberRoleIds);
+
+                $after = $userId;
+            }
+        } while (count($members) === 1000);
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Console/SyncDiscordGuildCommand.php
+++ b/app-modules/integration-discord/src/Sync/Console/SyncDiscordGuildCommand.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Console;
+
+use He4rt\IntegrationDiscord\Sync\Actions\SyncDiscordGuildAction;
+use Illuminate\Console\Command;
+
+final class SyncDiscordGuildCommand extends Command
+{
+    protected $signature = 'discord:sync {guild_id?} {--fresh : Truncate guild data before re-importing}';
+
+    protected $description = 'Sync Discord guild data (channels, roles, members) from the Discord API';
+
+    public function handle(SyncDiscordGuildAction $action): int
+    {
+        $guildId = $this->argument('guild_id') ?? config('he4rt.discord.guild_id');
+
+        if ($guildId === null) {
+            $this->error('No guild ID provided and no default configured.');
+
+            return self::FAILURE;
+        }
+
+        $fresh = (bool) $this->option('fresh');
+
+        $this->info(sprintf('Syncing Discord guild %s%s...', $guildId, $fresh ? ' (fresh)' : ''));
+
+        $guild = $action->execute((string) $guildId, $fresh);
+
+        $this->info(sprintf(
+            'Sync complete: %s — %d channels, %d roles, %d members',
+            $guild->name,
+            $guild->channels()->count(),
+            $guild->roles()->count(),
+            $guild->members()->count(),
+        ));
+
+        return self::SUCCESS;
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Handlers/HandleAuditLogEntry.php
+++ b/app-modules/integration-discord/src/Sync/Handlers/HandleAuditLogEntry.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Handlers;
+
+use He4rt\IntegrationDiscord\Enums\RoleHistoryAction;
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use He4rt\IntegrationDiscord\Models\DiscordMemberRoleHistory;
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+
+final class HandleAuditLogEntry
+{
+    private const int ACTION_TYPE_MEMBER_ROLE_UPDATE = 25;
+
+    public function handle(DiscordEventLog $eventLog): void
+    {
+        $payload = $eventLog->payload;
+
+        if (($payload['action_type'] ?? null) !== self::ACTION_TYPE_MEMBER_ROLE_UPDATE) {
+            return;
+        }
+
+        $guildDiscordId = $payload['guild_id'] ?? $eventLog->guild_id;
+        $targetUserId = $payload['target_id'] ?? null;
+
+        if ($guildDiscordId === null || $targetUserId === null) {
+            return;
+        }
+
+        $guild = DiscordGuild::query()->where('discord_guild_id', $guildDiscordId)->first();
+
+        if ($guild === null) {
+            return;
+        }
+
+        $member = DiscordMember::query()
+            ->where('discord_guild_id', $guild->id)
+            ->where('discord_user_id', $targetUserId)
+            ->first();
+
+        if ($member === null) {
+            return;
+        }
+
+        foreach ($payload['changes'] ?? [] as $change) {
+            $this->processChange($member, $guild, $change, $eventLog);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $change
+     */
+    private function processChange(DiscordMember $member, DiscordGuild $guild, array $change, DiscordEventLog $eventLog): void
+    {
+        $key = $change['key'] ?? null;
+
+        if ($key === '$add') {
+            $this->recordRoleChanges($member, $guild, $change['new_value'] ?? [], RoleHistoryAction::Assigned, $eventLog);
+        } elseif ($key === '$remove') {
+            $this->recordRoleChanges($member, $guild, $change['new_value'] ?? [], RoleHistoryAction::Removed, $eventLog);
+        }
+    }
+
+    /**
+     * @param  array<int, array{id: string, name: string}>  $roles
+     */
+    private function recordRoleChanges(
+        DiscordMember $member,
+        DiscordGuild $guild,
+        array $roles,
+        RoleHistoryAction $action,
+        DiscordEventLog $eventLog,
+    ): void {
+        foreach ($roles as $roleData) {
+            $role = DiscordRole::query()
+                ->where('discord_guild_id', $guild->id)
+                ->where('discord_role_id', $roleData['id'])
+                ->first();
+
+            if ($role === null) {
+                continue;
+            }
+
+            DiscordMemberRoleHistory::query()->create([
+                'discord_member_id' => $member->id,
+                'discord_role_id' => $role->id,
+                'action' => $action,
+                'occurred_at' => now(),
+                'source_event_log_id' => $eventLog->id,
+            ]);
+        }
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Handlers/HandleMemberAdd.php
+++ b/app-modules/integration-discord/src/Sync/Handlers/HandleMemberAdd.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Handlers;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+
+final class HandleMemberAdd
+{
+    public function handle(DiscordEventLog $eventLog): void
+    {
+        $payload = $eventLog->payload;
+        $guildDiscordId = $payload['guild_id'] ?? $eventLog->guild_id;
+
+        if ($guildDiscordId === null) {
+            return;
+        }
+
+        $guild = DiscordGuild::query()->where('discord_guild_id', $guildDiscordId)->first();
+
+        if ($guild === null) {
+            return;
+        }
+
+        $user = $payload['user'] ?? [];
+
+        DiscordMember::query()->updateOrCreate(
+            [
+                'discord_guild_id' => $guild->id,
+                'discord_user_id' => $user['id'] ?? $eventLog->user_id,
+            ],
+            [
+                'username' => $user['username'] ?? 'unknown',
+                'global_name' => $user['global_name'] ?? null,
+                'avatar' => $user['avatar'] ?? null,
+                'is_bot' => $user['bot'] ?? false,
+                'is_pending' => $payload['pending'] ?? false,
+                'joined_at' => $payload['joined_at'] ?? null,
+                'left_at' => null,
+            ],
+        );
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Handlers/HandleMemberRemove.php
+++ b/app-modules/integration-discord/src/Sync/Handlers/HandleMemberRemove.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Handlers;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+
+final class HandleMemberRemove
+{
+    public function handle(DiscordEventLog $eventLog): void
+    {
+        $payload = $eventLog->payload;
+        $guildDiscordId = $payload['guild_id'] ?? $eventLog->guild_id;
+        $userId = $payload['user']['id'] ?? $eventLog->user_id;
+
+        if ($guildDiscordId === null || $userId === null) {
+            return;
+        }
+
+        $guild = DiscordGuild::query()->where('discord_guild_id', $guildDiscordId)->first();
+
+        if ($guild === null) {
+            return;
+        }
+
+        $member = DiscordMember::query()
+            ->where('discord_guild_id', $guild->id)
+            ->where('discord_user_id', $userId)
+            ->first();
+
+        if ($member === null) {
+            return;
+        }
+
+        $member->update(['left_at' => now()]);
+        $member->roles()->detach();
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Handlers/HandleMemberUpdate.php
+++ b/app-modules/integration-discord/src/Sync/Handlers/HandleMemberUpdate.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Handlers;
+
+use He4rt\IntegrationDiscord\Enums\RoleHistoryAction;
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+use He4rt\IntegrationDiscord\Models\DiscordMemberRoleHistory;
+use He4rt\IntegrationDiscord\Models\DiscordRole;
+
+final class HandleMemberUpdate
+{
+    public function handle(DiscordEventLog $eventLog): void
+    {
+        $payload = $eventLog->payload;
+        $guildDiscordId = $payload['guild_id'] ?? $eventLog->guild_id;
+
+        if ($guildDiscordId === null) {
+            return;
+        }
+
+        $guild = DiscordGuild::query()->where('discord_guild_id', $guildDiscordId)->first();
+
+        if ($guild === null) {
+            return;
+        }
+
+        $user = $payload['user'] ?? [];
+        $userId = $user['id'] ?? $eventLog->user_id;
+
+        if ($userId === null) {
+            return;
+        }
+
+        $member = DiscordMember::query()->updateOrCreate(
+            [
+                'discord_guild_id' => $guild->id,
+                'discord_user_id' => $userId,
+            ],
+            [
+                'username' => $user['username'] ?? 'unknown',
+                'global_name' => $user['global_name'] ?? null,
+                'avatar' => $user['avatar'] ?? null,
+                'nickname' => $payload['nick'] ?? null,
+                'is_bot' => $user['bot'] ?? false,
+                'is_pending' => $payload['pending'] ?? false,
+                'joined_at' => $payload['joined_at'] ?? null,
+                'premium_since' => $payload['premium_since'] ?? null,
+                'communication_disabled_until' => $payload['communication_disabled_until'] ?? null,
+            ],
+        );
+
+        $this->syncRoles($member, $guild, $payload['roles'] ?? [], $eventLog);
+    }
+
+    /**
+     * @param  array<int, string>  $newRoleIds
+     */
+    private function syncRoles(DiscordMember $member, DiscordGuild $guild, array $newRoleIds, DiscordEventLog $eventLog): void
+    {
+        $roleMap = DiscordRole::query()
+            ->where('discord_guild_id', $guild->id)
+            ->whereIn('discord_role_id', $newRoleIds)
+            ->pluck('id', 'discord_role_id');
+
+        $currentRoleIds = $member->roles()->pluck('discord_roles.id')->all();
+        $newInternalIds = $roleMap->values()->all();
+
+        $added = array_diff($newInternalIds, $currentRoleIds);
+        $removed = array_diff($currentRoleIds, $newInternalIds);
+
+        foreach ($added as $roleId) {
+            $member->roles()->attach($roleId, ['assigned_at' => now()]);
+
+            DiscordMemberRoleHistory::query()->create([
+                'discord_member_id' => $member->id,
+                'discord_role_id' => $roleId,
+                'action' => RoleHistoryAction::Assigned,
+                'occurred_at' => now(),
+                'source_event_log_id' => $eventLog->id,
+            ]);
+        }
+
+        foreach ($removed as $roleId) {
+            $member->roles()->detach($roleId);
+
+            DiscordMemberRoleHistory::query()->create([
+                'discord_member_id' => $member->id,
+                'discord_role_id' => $roleId,
+                'action' => RoleHistoryAction::Removed,
+                'occurred_at' => now(),
+                'source_event_log_id' => $eventLog->id,
+            ]);
+        }
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Handlers/HandleVoiceStateUpdate.php
+++ b/app-modules/integration-discord/src/Sync/Handlers/HandleVoiceStateUpdate.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Handlers;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Models\DiscordGuild;
+use He4rt\IntegrationDiscord\Models\DiscordMember;
+
+final class HandleVoiceStateUpdate
+{
+    public function handle(DiscordEventLog $eventLog): void
+    {
+        $payload = $eventLog->payload;
+        $guildDiscordId = $payload['guild_id'] ?? $eventLog->guild_id;
+
+        if ($guildDiscordId === null) {
+            return;
+        }
+
+        $guild = DiscordGuild::query()->where('discord_guild_id', $guildDiscordId)->first();
+
+        if ($guild === null) {
+            return;
+        }
+
+        $member = $payload['member'] ?? [];
+        $user = $member['user'] ?? [];
+        $userId = $payload['user_id'] ?? $user['id'] ?? $eventLog->user_id;
+
+        if ($userId === null) {
+            return;
+        }
+
+        DiscordMember::query()->updateOrCreate(
+            [
+                'discord_guild_id' => $guild->id,
+                'discord_user_id' => $userId,
+            ],
+            [
+                'username' => $user['username'] ?? 'unknown',
+                'global_name' => $user['global_name'] ?? null,
+                'avatar' => $user['avatar'] ?? null,
+                'is_bot' => $user['bot'] ?? false,
+                'is_pending' => $member['pending'] ?? false,
+                'joined_at' => $member['joined_at'] ?? null,
+            ],
+        );
+    }
+}

--- a/app-modules/integration-discord/src/Sync/Observers/DiscordEventLogObserver.php
+++ b/app-modules/integration-discord/src/Sync/Observers/DiscordEventLogObserver.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Observers;
+
+use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use He4rt\IntegrationDiscord\Sync\Handlers\HandleAuditLogEntry;
+use He4rt\IntegrationDiscord\Sync\Handlers\HandleMemberAdd;
+use He4rt\IntegrationDiscord\Sync\Handlers\HandleMemberRemove;
+use He4rt\IntegrationDiscord\Sync\Handlers\HandleMemberUpdate;
+use He4rt\IntegrationDiscord\Sync\Handlers\HandleVoiceStateUpdate;
+
+final class DiscordEventLogObserver
+{
+    /** @var array<string, class-string> */
+    private const array HANDLER_MAP = [
+        'GUILD_MEMBER_ADD' => HandleMemberAdd::class,
+        'GUILD_MEMBER_REMOVE' => HandleMemberRemove::class,
+        'GUILD_MEMBER_UPDATE' => HandleMemberUpdate::class,
+        'GUILD_AUDIT_LOG_ENTRY_CREATE' => HandleAuditLogEntry::class,
+        'VOICE_STATE_UPDATE' => HandleVoiceStateUpdate::class,
+    ];
+
+    public function created(DiscordEventLog $eventLog): void
+    {
+        $handlerClass = self::HANDLER_MAP[$eventLog->event_type] ?? null;
+
+        if ($handlerClass === null) {
+            return;
+        }
+
+        resolve($handlerClass)->handle($eventLog);
+    }
+}

--- a/app-modules/integration-discord/src/Transport/Requests/Channels/ListGuildChannels.php
+++ b/app-modules/integration-discord/src/Transport/Requests/Channels/ListGuildChannels.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Transport\Requests\Channels;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+final class ListGuildChannels extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        private readonly string $guildId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/guilds/%s/channels', $this->guildId);
+    }
+}

--- a/app-modules/integration-discord/src/Transport/Requests/Guilds/GetGuild.php
+++ b/app-modules/integration-discord/src/Transport/Requests/Guilds/GetGuild.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Transport\Requests\Guilds;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+final class GetGuild extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        private readonly string $guildId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/guilds/%s', $this->guildId);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function defaultQuery(): array
+    {
+        return ['with_counts' => 'true'];
+    }
+}

--- a/app-modules/integration-discord/src/Transport/Requests/Members/ListGuildMembers.php
+++ b/app-modules/integration-discord/src/Transport/Requests/Members/ListGuildMembers.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Transport\Requests\Members;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+final class ListGuildMembers extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        private readonly string $guildId,
+        private readonly int $limit = 1000,
+        private readonly ?string $after = null,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/guilds/%s/members', $this->guildId);
+    }
+
+    /**
+     * @return array<string, string|int>
+     */
+    protected function defaultQuery(): array
+    {
+        $query = ['limit' => $this->limit];
+
+        if ($this->after !== null) {
+            $query['after'] = $this->after;
+        }
+
+        return $query;
+    }
+}

--- a/app-modules/integration-discord/src/Transport/Requests/Roles/ListGuildRoles.php
+++ b/app-modules/integration-discord/src/Transport/Requests/Roles/ListGuildRoles.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Transport\Requests\Roles;
+
+use Saloon\Enums\Method;
+use Saloon\Http\Request;
+
+final class ListGuildRoles extends Request
+{
+    protected Method $method = Method::GET;
+
+    public function __construct(
+        private readonly string $guildId,
+    ) {}
+
+    public function resolveEndpoint(): string
+    {
+        return sprintf('/guilds/%s/roles', $this->guildId);
+    }
+}

--- a/docs/superpowers/specs/2026-05-19-discord-entity-normalization-design.md
+++ b/docs/superpowers/specs/2026-05-19-discord-entity-normalization-design.md
@@ -1,0 +1,332 @@
+# Discord Entity Normalization
+
+**Date:** 2026-05-19
+**Module:** `integration-discord`
+**Status:** Draft
+
+## Problem
+
+The `discord_event_logs` table stores raw gateway events as JSONB blobs. Discord entities like guilds, channels, roles, and members exist only as embedded strings (`guild_id`, `channel_id`) or nested JSON fields across the codebase. This makes it impossible to efficiently query community health metrics like "messages per channel", "role growth trends", or "member retention funnels" without parsing JSON at query time.
+
+## Goal
+
+Normalize Discord entities into first-class relational tables within the `integration-discord` module. Populate them via Discord REST API sync and real-time gateway event processing. Enable efficient SQL queries for the 10 community health features identified in the analysis phase.
+
+## Decision Summary
+
+| Decision        | Choice                                 | Rationale                                                                |
+| --------------- | -------------------------------------- | ------------------------------------------------------------------------ |
+| Data source     | Events + API sync                      | Complete picture from day one, events keep it fresh                      |
+| Guild model     | Separate `discord_guilds` table        | Clean separation between platform (tenant) and Discord-specific metadata |
+| Role tracking   | Current state + history                | Enables both fast lookups and trend analysis                             |
+| Member identity | Optional link to `external_identities` | Not all Discord members have platform accounts                           |
+| Approach        | Full Discord Mirror (6 tables)         | Relational model pays for itself across multiple dashboard features      |
+
+## Schema
+
+### discord_guilds
+
+Stores Discord guild metadata. Linked to the existing `tenants` table via optional FK.
+
+| Column           | Type                  | Nullable       | Notes                     |
+| ---------------- | --------------------- | -------------- | ------------------------- |
+| id               | bigint (PK)           | no             | Auto-increment            |
+| tenant_id        | bigint (FK → tenants) | yes            | Link to platform tenant   |
+| discord_guild_id | varchar               | no             | Discord snowflake, unique |
+| name             | varchar               | no             |                           |
+| icon             | varchar               | yes            | Icon hash                 |
+| description      | text                  | yes            |                           |
+| member_count     | integer               | yes            | From API, updated on sync |
+| premium_tier     | smallint              | no, default 0  | Boost level (0-3)         |
+| features         | jsonb                 | no, default [] | Discord feature flags     |
+| synced_at        | timestamp             | yes            | Last full API sync        |
+| timestamps       |                       |                | created_at, updated_at    |
+
+**Indexes:** unique on `discord_guild_id`.
+
+### discord_channels
+
+All channels in a guild (text, voice, category, stage, forum, announcement).
+
+| Column             | Type                           | Nullable          | Notes                              |
+| ------------------ | ------------------------------ | ----------------- | ---------------------------------- |
+| id                 | bigint (PK)                    | no                | Auto-increment                     |
+| discord_guild_id   | bigint (FK → discord_guilds)   | no                |                                    |
+| discord_channel_id | varchar                        | no                | Discord snowflake, unique          |
+| parent_id          | bigint (FK → discord_channels) | yes               | Category parent                    |
+| name               | varchar                        | no                |                                    |
+| type               | smallint                       | no                | DiscordChannelType int-backed enum |
+| topic              | text                           | yes               |                                    |
+| position           | smallint                       | no, default 0     |                                    |
+| nsfw               | boolean                        | no, default false |                                    |
+| bitrate            | integer                        | yes               | Voice channels only                |
+| user_limit         | integer                        | yes               | Voice channels only                |
+| timestamps         |                                |                   | created_at, updated_at             |
+
+**Indexes:** unique on `discord_channel_id`, index on `discord_guild_id`.
+
+### discord_roles
+
+All roles in a guild.
+
+| Column           | Type                         | Nullable          | Notes                           |
+| ---------------- | ---------------------------- | ----------------- | ------------------------------- |
+| id               | bigint (PK)                  | no                | Auto-increment                  |
+| discord_guild_id | bigint (FK → discord_guilds) | no                |                                 |
+| discord_role_id  | varchar                      | no                | Discord snowflake, unique       |
+| name             | varchar                      | no                |                                 |
+| color            | integer                      | no, default 0     | Decimal color value             |
+| position         | smallint                     | no, default 0     |                                 |
+| permissions      | bigint                       | no, default 0     | Discord permission bitfield     |
+| is_hoisted       | boolean                      | no, default false | Shown separately in member list |
+| is_mentionable   | boolean                      | no, default false |                                 |
+| is_managed       | boolean                      | no, default false | Bot-managed role                |
+| icon             | varchar                      | yes               | Role icon hash                  |
+| timestamps       |                              |                   | created_at, updated_at          |
+
+**Indexes:** unique on `discord_role_id`, index on `discord_guild_id`.
+
+### discord_members
+
+Guild members. One row per user per guild (same Discord user in two guilds = two rows).
+
+| Column                       | Type                            | Nullable          | Notes                               |
+| ---------------------------- | ------------------------------- | ----------------- | ----------------------------------- |
+| id                           | bigint (PK)                     | no                | Auto-increment                      |
+| discord_guild_id             | bigint (FK → discord_guilds)    | no                |                                     |
+| discord_user_id              | varchar                         | no                | Discord snowflake                   |
+| external_identity_id         | uuid (FK → external_identities) | yes               | Linked platform account             |
+| username                     | varchar                         | no                |                                     |
+| global_name                  | varchar                         | yes               | Discord display name                |
+| avatar                       | varchar                         | yes               | Avatar hash                         |
+| nickname                     | varchar                         | yes               | Guild-specific nickname             |
+| is_bot                       | boolean                         | no, default false |                                     |
+| is_pending                   | boolean                         | no, default false | Has not passed membership screening |
+| joined_at                    | timestamp                       | yes               |                                     |
+| premium_since                | timestamp                       | yes               | Nitro boosting since                |
+| communication_disabled_until | timestamp                       | yes               | Timeout                             |
+| left_at                      | timestamp                       | yes               | When member left/was removed        |
+| timestamps                   |                                 |                   | created_at, updated_at              |
+
+**Indexes:** unique composite on (`discord_guild_id`, `discord_user_id`), index on `discord_user_id`, index on `external_identity_id`.
+
+### discord_member_roles
+
+Current role assignments (pivot table). Represents the current state snapshot.
+
+| Column            | Type                          | Nullable | Notes                                 |
+| ----------------- | ----------------------------- | -------- | ------------------------------------- |
+| discord_member_id | bigint (FK → discord_members) | no       | Composite PK                          |
+| discord_role_id   | bigint (FK → discord_roles)   | no       | Composite PK                          |
+| assigned_at       | timestamp                     | yes      | When the role was assigned (if known) |
+| created_at        | timestamp                     | yes      |                                       |
+| updated_at        | timestamp                     | yes      |                                       |
+
+**Indexes:** composite PK on (`discord_member_id`, `discord_role_id`).
+
+### discord_member_role_history
+
+Log of role assignment and removal events. Append-only for trend analysis.
+
+| Column              | Type                             | Nullable | Notes                                     |
+| ------------------- | -------------------------------- | -------- | ----------------------------------------- |
+| id                  | bigint (PK)                      | no       | Auto-increment                            |
+| discord_member_id   | bigint (FK → discord_members)    | no       |                                           |
+| discord_role_id     | bigint (FK → discord_roles)      | no       |                                           |
+| action              | varchar                          | no       | RoleHistoryAction enum: assigned, removed |
+| occurred_at         | timestamp                        | no       | When the change happened                  |
+| source_event_log_id | bigint (FK → discord_event_logs) | yes      | Trace back to raw event                   |
+| timestamps          |                                  |          | created_at, updated_at                    |
+
+**Indexes:** index on `discord_member_id`, index on `discord_role_id`, index on `occurred_at`.
+
+## Entity Relationship Diagram
+
+```
+discord_guilds (1) ──────┬──── (N) discord_channels
+                         │              │
+                         │              └── parent_id → discord_channels (self-FK)
+                         │
+                         ├──── (N) discord_roles
+                         │              │
+                         │              └──── (N) discord_member_roles (N) ────┐
+                         │                                                     │
+                         └──── (N) discord_members ◄───────────────────────────┘
+                                        │
+                                        ├──── (N) discord_member_role_history
+                                        │              │
+                                        │              └── discord_role_id → discord_roles
+                                        │
+                                        └──── external_identity_id → external_identities (optional)
+
+tenants (1) ──── (0..1) discord_guilds
+```
+
+## Enums
+
+### DiscordChannelType
+
+```php
+enum DiscordChannelType: int
+{
+    case GuildText = 0;
+    case Dm = 1;
+    case GuildVoice = 2;
+    case GroupDm = 3;
+    case GuildCategory = 4;
+    case GuildAnnouncement = 5;
+    case AnnouncementThread = 10;
+    case PublicThread = 11;
+    case PrivateThread = 12;
+    case GuildStageVoice = 13;
+    case GuildForum = 15;
+    case GuildMedia = 16;
+}
+```
+
+### RoleHistoryAction
+
+```php
+enum RoleHistoryAction: string
+{
+    case Assigned = 'assigned';
+    case Removed = 'removed';
+}
+```
+
+## Sync Strategy
+
+### Full API Sync (Command)
+
+```
+php artisan discord:sync {guild_id?} --fresh
+```
+
+- Fetches guild, channels, roles, and members from Discord REST API
+- Upserts all entities (idempotent, safe to re-run)
+- `--fresh` flag truncates guild data before re-importing
+- Paginates member list (1000 per request, uses `after` cursor)
+- Schedulable daily via Laravel scheduler
+
+**New Transport Requests:**
+
+| Class               | Endpoint                                                    | Purpose           |
+| ------------------- | ----------------------------------------------------------- | ----------------- |
+| `GetGuild`          | `GET /guilds/{guild_id}`                                    | Guild metadata    |
+| `ListGuildChannels` | `GET /guilds/{guild_id}/channels`                           | All channels      |
+| `ListGuildRoles`    | `GET /guilds/{guild_id}/roles`                              | All roles         |
+| `ListGuildMembers`  | `GET /guilds/{guild_id}/members?limit=1000&after={last_id}` | Paginated members |
+
+### Event-Driven Updates (Observer)
+
+A `DiscordEventLogObserver` triggers on `DiscordEventLog::created` and routes to event-specific handlers:
+
+| Event Type                                      | Handler                  | Tables Updated                                                                                                |
+| ----------------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| `GUILD_MEMBER_ADD`                              | `HandleMemberAdd`        | `discord_members` (upsert)                                                                                    |
+| `GUILD_MEMBER_REMOVE`                           | `HandleMemberRemove`     | `discord_members` (set `left_at`), `discord_member_roles` (clear)                                             |
+| `GUILD_MEMBER_UPDATE`                           | `HandleMemberUpdate`     | `discord_members` (update), `discord_member_roles` (diff + sync), `discord_member_role_history` (log changes) |
+| `GUILD_AUDIT_LOG_ENTRY_CREATE` (action_type 25) | `HandleAuditLogEntry`    | `discord_member_role_history` (with actor attribution)                                                        |
+| `VOICE_STATE_UPDATE`                            | `HandleVoiceStateUpdate` | `discord_members` (ensure exists)                                                                             |
+
+Each handler extracts structured data from the JSONB payload and upserts into the normalized tables.
+
+## File Structure
+
+```
+app-modules/integration-discord/
+├── database/
+│   ├── migrations/
+│   │   ├── create_discord_guilds_table.php
+│   │   ├── create_discord_channels_table.php
+│   │   ├── create_discord_roles_table.php
+│   │   ├── create_discord_members_table.php
+│   │   ├── create_discord_member_roles_table.php
+│   │   └── create_discord_member_role_history_table.php
+│   └── factories/
+│       ├── DiscordGuildFactory.php
+│       ├── DiscordChannelFactory.php
+│       ├── DiscordRoleFactory.php
+│       └── DiscordMemberFactory.php
+├── src/
+│   ├── Models/
+│   │   ├── DiscordGuild.php
+│   │   ├── DiscordChannel.php
+│   │   ├── DiscordRole.php
+│   │   ├── DiscordMember.php
+│   │   └── DiscordMemberRoleHistory.php
+│   ├── Enums/
+│   │   ├── DiscordChannelType.php
+│   │   └── RoleHistoryAction.php
+│   ├── Sync/
+│   │   ├── Actions/
+│   │   │   └── SyncDiscordGuildAction.php
+│   │   ├── Console/
+│   │   │   └── SyncDiscordGuildCommand.php
+│   │   ├── Observers/
+│   │   │   └── DiscordEventLogObserver.php
+│   │   └── Handlers/
+│   │       ├── HandleMemberAdd.php
+│   │       ├── HandleMemberRemove.php
+│   │       ├── HandleMemberUpdate.php
+│   │       ├── HandleAuditLogEntry.php
+│   │       └── HandleVoiceStateUpdate.php
+│   └── Transport/
+│       └── Requests/
+│           ├── Guilds/
+│           │   └── GetGuild.php
+│           ├── Channels/
+│           │   └── ListGuildChannels.php
+│           ├── Members/
+│           │   └── ListGuildMembers.php
+│           └── Roles/
+│               └── ListGuildRoles.php
+└── tests/
+    ├── Feature/
+    │   ├── Sync/
+    │   │   ├── SyncDiscordGuildTest.php
+    │   │   ├── HandleMemberAddTest.php
+    │   │   ├── HandleMemberRemoveTest.php
+    │   │   ├── HandleMemberUpdateTest.php
+    │   │   └── HandleAuditLogEntryTest.php
+    │   └── Models/
+    │       ├── DiscordGuildTest.php
+    │       ├── DiscordChannelTest.php
+    │       ├── DiscordRoleTest.php
+    │       └── DiscordMemberTest.php
+    └── Unit/
+        └── Transport/
+            └── Requests/
+                ├── GetGuildTest.php
+                ├── ListGuildChannelsTest.php
+                ├── ListGuildMembersTest.php
+                └── ListGuildRolesTest.php
+```
+
+## Module Boundaries
+
+### integration-discord owns (new):
+
+- Discord entity models (Guild, Channel, Role, Member)
+- Sync action and command (API → database)
+- Event log observer and handlers (events → normalized tables)
+- Transport requests for new Discord API endpoints
+
+### integration-discord does NOT own:
+
+- The bot runtime or event handlers (bot-discord)
+- Community health dashboard queries or widgets (future panel-admin feature)
+- The `RawGatewayEvent` handler that creates `DiscordEventLog` entries (bot-discord)
+
+### bot-discord changes: None
+
+- `RawGatewayEvent` continues to create `DiscordEventLog` entries unchanged
+- The observer on `DiscordEventLog` handles normalization transparently
+
+## Testing Strategy
+
+- **Unit tests** for each Transport request (verify URL, method, headers)
+- **Feature tests** for each handler with real payloads from `discord_event_logs`
+- **Feature tests** for the sync action (mock API responses, verify upserts)
+- **Model tests** for relationships and scopes
+- All tests use factories; no direct DB manipulation


### PR DESCRIPTION
## Summary

- Adds 6 normalized tables (`discord_guilds`, `discord_channels`, `discord_roles`, `discord_members`, `discord_member_roles`, `discord_member_role_history`) to replace JSONB-only storage of Discord entities
- Implements full API sync via `php artisan discord:sync` that fetches guild state from Discord REST API (channels, roles, paginated members)
- Adds real-time event-driven updates via `DiscordEventLogObserver` that normalizes gateway events (`GUILD_MEMBER_ADD/REMOVE/UPDATE`, `GUILD_AUDIT_LOG_ENTRY_CREATE`, `VOICE_STATE_UPDATE`) into relational tables as they arrive
- Tracks both current role state (pivot table) and role change history (append-only log) for trend analysis
- Links `discord_guilds` to `tenants` and `discord_members` to `external_identities` via optional FKs

## Motivation

The `discord_event_logs` table stores raw JSONB payloads — great for a data lake, but impossible to query efficiently for community health dashboards (e.g., "messages per channel", "role growth trends", "member retention funnels"). These normalized tables enable SQL-native analytics without JSON parsing at query time.

## New files

| Layer | Files |
|-------|-------|
| Migrations | 6 tables with FKs, indexes, composite keys |
| Enums | `DiscordChannelType` (12 types), `RoleHistoryAction` (assigned/removed) |
| Models | `DiscordGuild`, `DiscordChannel`, `DiscordRole`, `DiscordMember`, `DiscordMemberRoleHistory` |
| Factories | 4 factories with states (`voice()`, `category()`, `bot()`, `pending()`, `left()`) |
| Transport | `GetGuild`, `ListGuildChannels`, `ListGuildRoles`, `ListGuildMembers` (paginated) |
| Sync | `SyncDiscordGuildAction`, `SyncDiscordGuildCommand`, `DiscordEventLogObserver`, 5 event handlers |

## Test plan

- [ ] Run `php artisan discord:sync` against the He4rt guild and verify tables are populated
- [ ] Verify gateway events (member join/leave/update, role changes) update normalized tables in real-time
- [ ] Verify `--fresh` flag truncates and re-imports cleanly
- [ ] Confirm existing tests still pass (183 tests, 452 assertions)
- [ ] PHPStan passes at configured level

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/he4rt/heartdevs.com/pull/261?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->