### PR TITLE
refactor: centralize display timezone config

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,8 @@ APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
 APP_DOMAIN=localhost
+APP_TIMEZONE=UTC
+DISPLAY_TIMEZONE=America/Sao_Paulo
 
 NIGHTWATCH_TOKEN=
 LOG_CHANNEL=stack

--- a/app-modules/bot-discord/src/Events/GreetingsEvent.php
+++ b/app-modules/bot-discord/src/Events/GreetingsEvent.php
@@ -27,7 +27,7 @@ class GreetingsEvent extends Event
             return;
         }
 
-        $hour = now()->hour;
+        $hour = now()->timezone(config('app.display_timezone'))->hour;
         $payload = mb_strtolower($message->content);
 
         $response = match (true) {

--- a/app-modules/he4rt/resources/views/components/dashboard/heatmap.blade.php
+++ b/app-modules/he4rt/resources/views/components/dashboard/heatmap.blade.php
@@ -152,8 +152,8 @@
     };
 
     // Now indicator
-    $nowRow = $highlightNow && $isWeek ? (int) now()->format('N') - 1 : -1;
-    $nowCol = $highlightNow && $isWeek ? (int) now()->format('G') : -1;
+    $nowRow = $highlightNow && $isWeek ? (int) now(config('app.display_timezone'))->format('N') - 1 : -1;
+    $nowCol = $highlightNow && $isWeek ? (int) now(config('app.display_timezone'))->format('G') : -1;
 
     // Auto insight
     $autoHeadline = $insightHeadline;

--- a/app-modules/he4rt/resources/views/components/schedule-card.blade.php
+++ b/app-modules/he4rt/resources/views/components/schedule-card.blade.php
@@ -1,14 +1,11 @@
-@props([
-    'startsAt',
-    'endsAt',
-    'title',
-    'icon',
-    'speakers',
-])
+@props (['startsAt', 'endsAt', 'title', 'icon', 'speakers'])
 
 @php
     /** @var \Carbon\Carbon $startsAt */
     /** @var \Carbon\Carbon $endsAt */
+
+    $startsAt = $startsAt->timezone(config('app.display_timezone'));
+    $endsAt = $endsAt->timezone(config('app.display_timezone'));
 
     $config = match (true) {
         $endsAt->isPast() => [
@@ -51,7 +48,7 @@
 
                     @if ($speakers)
                         <span class="text-text-medium">
-                            // {{ $speakers->map(fn ($speaker) => $speaker->name)->implode(',  ') }} \\
+                            // {{ $speakers->map(fn($speaker) => $speaker->name)->implode(',  ') }} \\
                         </span>
                     @endif
                 </div>

--- a/app-modules/integration-discord/src/ETL/Console/BackfillVoiceLogsCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/BackfillVoiceLogsCommand.php
@@ -143,7 +143,7 @@ final class BackfillVoiceLogsCommand extends Command
 
                     foreach ($messages as $message) {
                         $timestamp = CarbonImmutable::parse($message['timestamp']);
-                        $oldestTimestamp = $timestamp->format('Y-m-d H:i');
+                        $oldestTimestamp = $timestamp->timezone(config('app.display_timezone'))->format('Y-m-d H:i');
 
                         if ($timestamp->isBefore($since)) {
                             $reachedSince = true;
@@ -181,7 +181,7 @@ final class BackfillVoiceLogsCommand extends Command
                             $this->alreadyExistsCount++;
                             $logger->line(sprintf(
                                 '%s <@%s> %s #%s [EXISTS]',
-                                $timestamp->format('m/d H:i'),
+                                $timestamp->timezone(config('app.display_timezone'))->format('m/d H:i'),
                                 $voiceDto->userDiscordId,
                                 $voiceDto->action,
                                 $channelName,
@@ -201,7 +201,7 @@ final class BackfillVoiceLogsCommand extends Command
 
                             $logger->line(sprintf(
                                 '%s <@%s> %s #%s [NEW]',
-                                $timestamp->format('m/d H:i'),
+                                $timestamp->timezone(config('app.display_timezone'))->format('m/d H:i'),
                                 $voiceDto->userDiscordId,
                                 $voiceDto->action,
                                 $channelName,

--- a/app-modules/panel-admin/resources/views/moderation/appeal-queue/appeal-detail.blade.php
+++ b/app-modules/panel-admin/resources/views/moderation/appeal-queue/appeal-detail.blade.php
@@ -86,7 +86,11 @@
                     }}
                 </p>
                 <p class="mt-0.5 text-xs text-red-600/70 dark:text-red-400/60">
-                    {{ __('panel-admin::moderation.appeal_queue.detail.sla_deadline') }}: {{ $appeal->sla_deadline->format('M d, Y H:i') }}
+                    {{ __('panel-admin::moderation.appeal_queue.detail.sla_deadline') }}: {{
+                        $appeal->sla_deadline
+                            ->timezone(config('app.display_timezone'))
+                            ->format('M d, Y H:i')
+                    }}
                 </p>
             </div>
         </div>
@@ -381,7 +385,11 @@
                             'text-zinc-700 dark:text-zinc-300' => !$isOverdue
                         ])
                     >
-                        {{ $appeal->sla_deadline?->format('M d, Y H:i') ?? '—' }}
+                        {{
+                            $appeal->sla_deadline
+                                ?->timezone(config('app.display_timezone'))
+                                ->format('M d, Y H:i') ?? '—'
+                        }}
                     </div>
                     @if ($appeal->sla_deadline && !$appeal->status->isResolved())
                         <div

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/ActivityPerDay.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/ActivityPerDay.php
@@ -17,10 +17,11 @@ final readonly class ActivityPerDay
     /** @return Collection<int, array{day: string, msgs: int, users: int}> */
     public function get(): Collection
     {
-        $start = Date::now('America/Sao_Paulo')->subDays($this->rangeDays)->startOfDay()->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('messages')
-            ->selectRaw("(sent_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::date AS day")
+            ->selectRaw("(sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::date AS day", [$tz])
             ->selectRaw('COUNT(*) AS total_messages')
             ->selectRaw('COUNT(DISTINCT external_identity_id) AS unique_users')
             ->where('sent_at', '>=', $start)

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/ActivityPerDay.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/ActivityPerDay.php
@@ -21,7 +21,7 @@ final readonly class ActivityPerDay
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('messages')
-            ->selectRaw("(sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::date AS day", [$tz])
+            ->selectRaw('(sent_at AT TIME ZONE ?)::date AS day', [$tz])
             ->selectRaw('COUNT(*) AS total_messages')
             ->selectRaw('COUNT(DISTINCT external_identity_id) AS unique_users')
             ->where('sent_at', '>=', $start)

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/MessageHeatmap.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/MessageHeatmap.php
@@ -20,8 +20,8 @@ final readonly class MessageHeatmap
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('messages')
-            ->selectRaw("EXTRACT(DOW FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
-            ->selectRaw("EXTRACT(HOUR FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
+            ->selectRaw('EXTRACT(DOW FROM sent_at AT TIME ZONE ?)::int AS dow', [$tz])
+            ->selectRaw('EXTRACT(HOUR FROM sent_at AT TIME ZONE ?)::int AS hour', [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->where('sent_at', '>=', $start)
             ->whereNotNull('sent_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/MessageHeatmap.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/MessageHeatmap.php
@@ -16,11 +16,12 @@ final readonly class MessageHeatmap
     /** @return array<int, array{row: int, col: int, value: int}> */
     public function get(): array
     {
-        $start = Date::now('America/Sao_Paulo')->subDays($this->rangeDays)->startOfDay()->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('messages')
-            ->selectRaw("EXTRACT(DOW FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::int AS dow")
-            ->selectRaw("EXTRACT(HOUR FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo')::int AS hour")
+            ->selectRaw("EXTRACT(DOW FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
+            ->selectRaw("EXTRACT(HOUR FROM sent_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->where('sent_at', '>=', $start)
             ->whereNotNull('sent_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/PeriodStats.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/PeriodStats.php
@@ -182,7 +182,7 @@ final readonly class PeriodStats
     private function subdivisions(): array
     {
         return once(function (): array {
-            $now = Date::now('America/Sao_Paulo');
+            $now = Date::now(config('app.display_timezone'));
 
             [$blockCount, $blockSize, $unit] = match (true) {
                 $this->rangeDays >= 90 => [3, 30, 'days'],

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/TopChannels.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/TopChannels.php
@@ -17,7 +17,8 @@ final readonly class TopChannels
     /** @return Collection<int, array{channel_id: string, total_messages: int, unique_users: int}> */
     public function get(): Collection
     {
-        $start = Date::now('America/Sao_Paulo')->subDays($this->rangeDays)->startOfDay()->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('messages')
             ->select('channel_id')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
@@ -20,8 +20,8 @@ final readonly class VoiceHeatmap
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw('EXTRACT(DOW FROM occurred_at AT TIME ZONE ?)::int AS dow', [$tz])
-            ->selectRaw('EXTRACT(HOUR FROM occurred_at AT TIME ZONE ?)::int AS hour', [$tz])
+            ->selectRaw("EXTRACT(DOW FROM occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
+            ->selectRaw("EXTRACT(HOUR FROM occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
@@ -16,11 +16,12 @@ final readonly class VoiceHeatmap
     /** @return array<int, array{row: int, col: int, value: int}> */
     public function get(): array
     {
-        $start = Date::now('America/Sao_Paulo')->subDays($this->rangeDays)->startOfDay()->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw("EXTRACT(DOW FROM occurred_at AT TIME ZONE 'America/Sao_Paulo')::int AS dow")
-            ->selectRaw("EXTRACT(HOUR FROM occurred_at AT TIME ZONE 'America/Sao_Paulo')::int AS hour")
+            ->selectRaw('EXTRACT(DOW FROM occurred_at AT TIME ZONE ?)::int AS dow', [$tz])
+            ->selectRaw('EXTRACT(HOUR FROM occurred_at AT TIME ZONE ?)::int AS hour', [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php
@@ -20,8 +20,8 @@ final readonly class VoiceHeatmap
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw("EXTRACT(DOW FROM occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
-            ->selectRaw("EXTRACT(HOUR FROM occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
+            ->selectRaw('EXTRACT(DOW FROM occurred_at AT TIME ZONE ?)::int AS dow', [$tz])
+            ->selectRaw('EXTRACT(HOUR FROM occurred_at AT TIME ZONE ?)::int AS hour', [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
@@ -17,10 +17,11 @@ final readonly class VoicePerDay
     /** @return Collection<int, array{day: string, joins: int, hours: float}> */
     public function get(): Collection
     {
-        $start = Date::now('America/Sao_Paulo')->subDays($this->rangeDays)->startOfDay()->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw("(occurred_at AT TIME ZONE 'America/Sao_Paulo')::date AS day")
+            ->selectRaw('(occurred_at AT TIME ZONE ?)::date AS day', [$tz])
             ->selectRaw('COUNT(*) AS total_joins')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
@@ -21,7 +21,7 @@ final readonly class VoicePerDay
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw("(occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::date AS day", [$tz])
+            ->selectRaw('(occurred_at AT TIME ZONE ?)::date AS day', [$tz])
             ->selectRaw('COUNT(*) AS total_joins')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php
@@ -21,7 +21,7 @@ final readonly class VoicePerDay
         $start = Date::now($tz)->subDays($this->rangeDays)->startOfDay()->utc();
 
         return DB::table('voice_messages')
-            ->selectRaw('(occurred_at AT TIME ZONE ?)::date AS day', [$tz])
+            ->selectRaw("(occurred_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::date AS day", [$tz])
             ->selectRaw('COUNT(*) AS total_joins')
             ->where('occurred_at', '>=', $start)
             ->whereNotNull('occurred_at')

--- a/app-modules/panel-admin/src/Marketing/Pages/MeetingShowcasePage.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/MeetingShowcasePage.php
@@ -55,8 +55,9 @@ class MeetingShowcasePage extends Page
             return;
         }
 
-        $start = Date::parse($this->startDate, 'America/Sao_Paulo')->utc();
-        $end = Date::parse($this->endDate, 'America/Sao_Paulo')->utc();
+        $tz = config('app.display_timezone');
+        $start = Date::parse($this->startDate, $tz)->utc();
+        $end = Date::parse($this->endDate, $tz)->utc();
 
         $messageStats = Message::query()
             ->where('channel_id', $this->channelId)

--- a/app-modules/panel-admin/src/Moderation/Livewire/ModerationDashboardLivewire.php
+++ b/app-modules/panel-admin/src/Moderation/Livewire/ModerationDashboardLivewire.php
@@ -350,8 +350,8 @@ class ModerationDashboardLivewire extends Component
 
         $dbData = DB::table('moderation_actions')
             ->where('created_at', '>=', now()->subDays(30))
-            ->selectRaw("EXTRACT(DOW FROM created_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
-            ->selectRaw("EXTRACT(HOUR FROM created_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
+            ->selectRaw('EXTRACT(DOW FROM created_at AT TIME ZONE ?)::int AS dow', [$tz])
+            ->selectRaw('EXTRACT(HOUR FROM created_at AT TIME ZONE ?)::int AS hour', [$tz])
             ->selectRaw('COUNT(*) AS total')
             ->groupBy('dow', 'hour')
             ->get();

--- a/app-modules/panel-admin/src/Moderation/Livewire/ModerationDashboardLivewire.php
+++ b/app-modules/panel-admin/src/Moderation/Livewire/ModerationDashboardLivewire.php
@@ -346,10 +346,14 @@ class ModerationDashboardLivewire extends Component
     #[Computed]
     public function activityHeatmap(): array
     {
+        $tz = config('app.display_timezone');
+
         $dbData = DB::table('moderation_actions')
             ->where('created_at', '>=', now()->subDays(30))
-            ->selectRaw('EXTRACT(DOW FROM created_at) as dow, EXTRACT(HOUR FROM created_at) as hour, count(*) as total')
-            ->groupByRaw('EXTRACT(DOW FROM created_at), EXTRACT(HOUR FROM created_at)')
+            ->selectRaw("EXTRACT(DOW FROM created_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS dow", [$tz])
+            ->selectRaw("EXTRACT(HOUR FROM created_at AT TIME ZONE 'UTC' AT TIME ZONE ?)::int AS hour", [$tz])
+            ->selectRaw('COUNT(*) AS total')
+            ->groupBy('dow', 'hour')
             ->get();
 
         $grid = array_fill(0, 7, array_fill(0, 24, 0));

--- a/config/app.php
+++ b/config/app.php
@@ -69,7 +69,9 @@ return [
     |
     */
 
-    'timezone' => env('APP_TIMEZONE', 'America/Sao_Paulo'),
+    'timezone' => env('APP_TIMEZONE', 'UTC'),
+
+    'display_timezone' => env('DISPLAY_TIMEZONE', 'America/Sao_Paulo'),
 
     /*
     |--------------------------------------------------------------------------

--- a/database/migrations/2026_05_20_160249_alter_messages_sent_at_to_timestamptz.php
+++ b/database/migrations/2026_05_20_160249_alter_messages_sent_at_to_timestamptz.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE messages ALTER COLUMN sent_at TYPE timestamptz USING sent_at AT TIME ZONE 'UTC'");
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE messages ALTER COLUMN sent_at TYPE timestamp(0) WITHOUT TIME ZONE');
+    }
+};

--- a/database/migrations/2026_05_20_160249_alter_messages_sent_at_to_timestamptz.php
+++ b/database/migrations/2026_05_20_160249_alter_messages_sent_at_to_timestamptz.php
@@ -11,9 +11,4 @@ return new class extends Migration
     {
         DB::statement("ALTER TABLE messages ALTER COLUMN sent_at TYPE timestamptz USING sent_at AT TIME ZONE 'UTC'");
     }
-
-    public function down(): void
-    {
-        DB::statement('ALTER TABLE messages ALTER COLUMN sent_at TYPE timestamp(0) WITHOUT TIME ZONE');
-    }
 };

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: dev_he4rtbot
+      TZ: Etc/UTC
+      PGTZ: Etc/UTC
     ports:
       - '5432:5432'
     volumes:

--- a/docker/postgres.Dockerfile
+++ b/docker/postgres.Dockerfile
@@ -2,7 +2,7 @@
 
 FROM postgres:18-alpine
 
-ENV TZ=America/Sao_Paulo
+ENV TZ=Etc/UTC PGTZ=Etc/UTC
 
 RUN set -eux;\
     apk update;\

--- a/resources/views/livewire/connection-hub.blade.php
+++ b/resources/views/livewire/connection-hub.blade.php
@@ -2,10 +2,7 @@
     use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 @endphp
 
-@props([
-    'supportedProviders',
-    'userProviders',
-])
+@props (['supportedProviders', 'userProviders'])
 
 @php
     /** @var \He4rt\Identity\ExternalIdentity\Enums\IdentityProvider[] $supportedProviders */
@@ -15,9 +12,10 @@
 <div data-slot="card-content" class="space-y-3 px-6">
     @foreach ($supportedProviders as $provider)
         @php
-            $connectedProvider = $userProviders->filter(fn (ExternalIdentity $connection) => $connection->provider == $provider->value)->first();
+            $connectedProvider = $userProviders
+                ->filter(fn(ExternalIdentity $connection) => $connection->provider == $provider->value)
+                ->first();
         @endphp
-
         <x-filament::section :secondary="$connectedProvider">
             <div class="flex flex-1 items-center gap-3">
                 <div class="bg-muted mt-0.5 rounded-lg p-2">
@@ -30,13 +28,15 @@
                             <x-filament::badge color="green">Connected</x-filament::badge>
                         @endif
                     </div>
-                    <p class="text-muted-foreground text-xs leading-relaxed">
-                        {{ $provider->getDescription() }}
-                    </p>
+                    <p class="text-muted-foreground text-xs leading-relaxed">{{ $provider->getDescription() }}</p>
                     <p class="text-muted-foreground text-xs">
                         @if ($connectedProvider)
                             Connected at
-                            <strong>{{ $connectedProvider->updated_at->format('d/m/Y H:i:s') }}</strong>
+                            <strong>{{
+                                $connectedProvider->updated_at
+                                    ->timezone(config('app.display_timezone'))
+                                    ->format('d/m/Y H:i:s')
+                            }}</strong>
                         @else
                             Nessa autenticação iremos pedir acesso à:
                             @foreach ($provider->getScopes() as $scope)
@@ -48,7 +48,7 @@
                 <x-filament::button
                     wire:click="{{ !$connectedProvider ? 'connect' : 'disconnect' }}('{{ $provider->value }}')"
                     :color="$connectedProvider ? 'danger' : 'primary'"
-                    :outlined="(bool)$connectedProvider"
+                    :outlined="(bool) $connectedProvider"
                 >
                     {{ $connectedProvider ? 'Disconnect' : 'Connect' }}
                 </x-filament::button>

--- a/routes/console.php
+++ b/routes/console.php
@@ -23,4 +23,5 @@ Schedule::command('backup:clean')
 Schedule::command('backup:monitor')
     ->when(fn () => config('backup.enabled'))
     ->daily()
-    ->at('09:00');
+    ->at('09:00')
+    ->timezone(config('app.display_timezone'));


### PR DESCRIPTION
## Summary

- Adds `app.display_timezone` config key (`DISPLAY_TIMEZONE` env, default `America/Sao_Paulo`) to centralize the user-facing timezone
- Changes `app.timezone` default from `America/Sao_Paulo` to `UTC`
- Replaces all 15 hardcoded `'America/Sao_Paulo'` occurrences across 15 files with `config('app.display_timezone')`
- Uses parameterized SQL bindings (`?`) for `AT TIME ZONE` clauses instead of string interpolation
- Adds `AT TIME ZONE` conversion to moderation heatmap SQL that was missing it entirely
- Converts all user-facing timestamp displays (SLA deadlines, connection dates, schedule cards) to use the display timezone

## Modules affected

- `config/app.php` — new config key
- `bot-discord` — GreetingsEvent
- `he4rt` — heatmap highlight + schedule-card
- `panel-admin` — marketing dashboard queries (6 files) + moderation heatmap + appeal views
- `integration-discord` — BackfillVoiceLogsCommand CLI output
- `routes/console.php` — backup:monitor schedule
- `resources/views` — connection-hub

## Test plan

- [x] Rector dry-run — no suggestions
- [x] Pint — passed
- [x] PHPStan — 0 errors
- [x] Tests — 497 passed, 3 skipped
- [x] Verified `AT TIME ZONE ?` binding works via tinker
- [ ] Verify heatmaps render correctly in the admin panel
- [ ] Verify SLA deadline times display in Brazil timezone
- [ ] Verify schedule-card shows correct local times

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
Centralizes the user-facing timezone by adding app.display_timezone (env DISPLAY_TIMEZONE, default America/Sao_Paulo) and switching the application default timezone to UTC. Replaces hard-coded America/Sao_Paulo occurrences with config('app.display_timezone'), parameterizes SQL AT TIME ZONE bindings, fixes a missing AT TIME ZONE in the moderation heatmap, and converts user-facing timestamp displays to the new display timezone.

## References
- PR: https://github.com/he4rt/heartdevs.com/pull/262
- PR: https://github.com/he4rt/heartdevs.com/pull/260
- PostgreSQL AT TIME ZONE docs: https://www.postgresql.org/docs/current/datatype-datetime.html#DATATYPE-TIMEZONES

## Dependencies & Requirements
- New config key: app.display_timezone (env: DISPLAY_TIMEZONE, default: America/Sao_Paulo)
- app.timezone default changed to UTC (env: APP_TIMEZONE)
- .env.example updated with APP_TIMEZONE=UTC and DISPLAY_TIMEZONE=America/Sao_Paulo
- No new composer/npm packages added
- Database must accept parameterized AT TIME ZONE bindings (validated via tinker)
- Manual verifications pending: admin heatmaps rendering, SLA deadline display, schedule-card local times

## Contributor Summary
| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| gvieira18 | 63 | 45 | 15 |

## Changes Summary
| File Path | Change Description |
|---|---|
| config/app.php | Added display_timezone key; changed default app.timezone to UTC |
| .env.example | Added APP_TIMEZONE and DISPLAY_TIMEZONE entries |
| app-modules/bot-discord/src/Events/GreetingsEvent.php | Use display_timezone for greeting-hour calculation |
| app-modules/he4rt/resources/views/components/dashboard/heatmap.blade.php | Heatmap current-time highlight uses display_timezone |
| app-modules/he4rt/resources/views/components/schedule-card.blade.php | Normalize schedule timestamps to display_timezone |
| app-modules/integration-discord/src/ETL/Console/BackfillVoiceLogsCommand.php | Format CLI log timestamps with display_timezone |
| app-modules/panel-admin/resources/views/moderation/appeal-queue/appeal-detail.blade.php | SLA deadline displays converted to display_timezone with null fallback |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/ActivityPerDay.php | Use display_timezone and bind into SQL AT TIME ZONE |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/MessageHeatmap.php | Parameterized timezone bindings for day/hour extraction |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoiceHeatmap.php | Parameterized timezone bindings in voice heatmap query |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/VoicePerDay.php | Day-extraction query updated to use display_timezone |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/PeriodStats.php | Compute subdivisions using display_timezone |
| app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/TopChannels.php | Date range calculations use display_timezone |
| app-modules/panel-admin/src/Marketing/Pages/MeetingShowcasePage.php | Parse meeting bounds with display_timezone and convert to UTC |
| app-modules/panel-admin/src/Moderation/Livewire/ModerationDashboardLivewire.php | Added AT TIME ZONE conversion and parameterized bindings for moderation heatmap |
| resources/views/livewire/connection-hub.blade.php | "Connected at" timestamp uses display_timezone; props formatting |
| routes/console.php | Schedule backup:monitor to run at 09:00 in display_timezone |
| database/migrations/2026_05_20_160249_alter_messages_sent_at_to_timestamptz.php | Migration: convert messages.sent_at to timestamptz interpreting existing values as UTC |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/he4rt/heartdevs.com/pull/264?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->