### PR TITLE
feat(events): rsvp enrollment end-to-end

### DIFF
--- a/app-modules/events/database/factories/EnrollmentPolicyFactory.php
+++ b/app-modules/events/database/factories/EnrollmentPolicyFactory.php
@@ -33,4 +33,11 @@ final class EnrollmentPolicyFactory extends Factory
             'application_schema' => null,
         ];
     }
+
+    public function rsvp(): static
+    {
+        return $this->state(fn (): array => [
+            'enrollment_method' => EnrollmentMethod::Rsvp,
+        ]);
+    }
 }

--- a/app-modules/events/database/factories/EventFactory.php
+++ b/app-modules/events/database/factories/EventFactory.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Database\Factories;
 
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\Enrollment\Enums\AttendanceRequirement;
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Enums\EventType;
 use He4rt\Events\Event\Models\Event;
@@ -58,5 +62,67 @@ final class EventFactory extends Factory
             'starts_at' => $startsAt,
             'ends_at' => $startsAt->clone()->addHours(3),
         ]);
+    }
+
+    public function asWorkshop(): static
+    {
+        return $this->state(fn (): array => [
+            'event_type' => EventType::Workshop,
+            'status' => EventStatus::Published,
+        ])->afterCreating(function (Event $event): void {
+            EnrollmentPolicy::factory()->create([
+                'event_id' => $event->id,
+                'enrollment_method' => EnrollmentMethod::RsvpCheckin,
+                'check_in_method' => CheckInMethod::NumericCode,
+                'capacity' => 50,
+                'has_waitlist' => true,
+                'attendance_requirement' => AttendanceRequirement::AllDays,
+                'xp_on_confirmed' => 100,
+                'xp_on_checked_in' => 200,
+                'xp_on_attended' => 500,
+            ]);
+        });
+    }
+
+    public function asMeetup(): static
+    {
+        return $this->state(fn (): array => [
+            'event_type' => EventType::Meetup,
+            'status' => EventStatus::Published,
+        ])->afterCreating(function (Event $event): void {
+            EnrollmentPolicy::factory()->create([
+                'event_id' => $event->id,
+                'enrollment_method' => EnrollmentMethod::Rsvp,
+                'check_in_method' => CheckInMethod::Manual,
+                'capacity' => null,
+                'has_waitlist' => false,
+                'attendance_requirement' => AttendanceRequirement::AllDays,
+                'xp_on_confirmed' => 50,
+                'xp_on_checked_in' => 100,
+                'xp_on_attended' => 250,
+            ]);
+        });
+    }
+
+    public function asConference(): static
+    {
+        return $this->state(fn (): array => [
+            'event_type' => EventType::Conference,
+            'status' => EventStatus::Published,
+        ])->afterCreating(function (Event $event): void {
+            EnrollmentPolicy::factory()->create([
+                'event_id' => $event->id,
+                'enrollment_method' => EnrollmentMethod::Application,
+                'check_in_method' => CheckInMethod::QrCode,
+                'capacity' => 200,
+                'has_waitlist' => true,
+                'attendance_requirement' => AttendanceRequirement::MinimumDays,
+                'minimum_days' => 2,
+                'cancellation_deadline_hours' => 48,
+                'xp_on_confirmed' => 200,
+                'xp_on_checked_in' => 300,
+                'xp_on_attended' => 1000,
+            ]);
+        });
     }
 }

--- a/app-modules/events/database/factories/EventFactory.php
+++ b/app-modules/events/database/factories/EventFactory.php
@@ -32,4 +32,31 @@ final class EventFactory extends Factory
             'status' => EventStatus::Draft,
         ];
     }
+
+    public function published(): static
+    {
+        return $this->state(fn (): array => [
+            'status' => EventStatus::Published,
+        ]);
+    }
+
+    public function upcoming(): static
+    {
+        $startsAt = Date::now()->addDays(7);
+
+        return $this->state(fn (): array => [
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->addHours(3),
+        ]);
+    }
+
+    public function past(): static
+    {
+        $startsAt = Date::now()->subDays(7);
+
+        return $this->state(fn (): array => [
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->addHours(3),
+        ]);
+    }
 }

--- a/app-modules/events/lang/en/exceptions.php
+++ b/app-modules/events/lang/en/exceptions.php
@@ -6,5 +6,6 @@ return [
     'already_enrolled' => 'You are already enrolled in this event.',
     'event_past' => 'This event has already started and is no longer accepting enrollments.',
     'event_not_active' => 'This event is not available for enrollment.',
-    'invalid_enrollment_method' => 'This event does not accept RSVP enrollments.',
+    'invalid_enrollment_method' => 'This event requires application enrollment, not RSVP.',
+    'event_full' => 'This event has reached maximum capacity and does not have a waitlist.',
 ];

--- a/app-modules/events/lang/en/exceptions.php
+++ b/app-modules/events/lang/en/exceptions.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'already_enrolled' => 'You are already enrolled in this event.',
+    'event_past' => 'This event has already started and is no longer accepting enrollments.',
+    'event_not_active' => 'This event is not available for enrollment.',
+    'invalid_enrollment_method' => 'This event does not accept RSVP enrollments.',
+];

--- a/app-modules/events/lang/en/pages.php
+++ b/app-modules/events/lang/en/pages.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'back_to_events' => 'Back to Events',
+    'confirm_presence' => 'Confirm Presence',
+    'confirm_presence_hint' => 'Confirm your attendance to this event.',
+    'confirm_presence_success' => 'Your presence has been confirmed!',
+    'enrollment_status_label' => 'Your enrollment status',
+    'enrolled_at' => 'Enrolled on :date',
+    'no_enrollments' => 'You are not enrolled in any events yet.',
+    'no_upcoming_events' => 'No upcoming events available.',
+];

--- a/app-modules/events/lang/en/pages.php
+++ b/app-modules/events/lang/en/pages.php
@@ -7,6 +7,7 @@ return [
     'confirm_presence' => 'Confirm Presence',
     'confirm_presence_hint' => 'Confirm your attendance to this event.',
     'confirm_presence_success' => 'Your presence has been confirmed!',
+    'waitlist_success' => 'You have been added to the waitlist for this event.',
     'enrollment_status_label' => 'Your enrollment status',
     'enrolled_at' => 'Enrolled on :date',
     'no_enrollments' => 'You are not enrolled in any events yet.',

--- a/app-modules/events/lang/pt_BR/exceptions.php
+++ b/app-modules/events/lang/pt_BR/exceptions.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'already_enrolled' => 'Você já está inscrito neste evento.',
+    'event_past' => 'Este evento já começou e não aceita mais inscrições.',
+    'event_not_active' => 'Este evento não está disponível para inscrição.',
+    'invalid_enrollment_method' => 'Este evento não aceita inscrições via RSVP.',
+];

--- a/app-modules/events/lang/pt_BR/exceptions.php
+++ b/app-modules/events/lang/pt_BR/exceptions.php
@@ -6,5 +6,6 @@ return [
     'already_enrolled' => 'Você já está inscrito neste evento.',
     'event_past' => 'Este evento já começou e não aceita mais inscrições.',
     'event_not_active' => 'Este evento não está disponível para inscrição.',
-    'invalid_enrollment_method' => 'Este evento não aceita inscrições via RSVP.',
+    'invalid_enrollment_method' => 'Esse evento exige inscrição via formulário, não RSVP.',
+    'event_full' => 'Este evento atingiu a capacidade máxima e não possui lista de espera.',
 ];

--- a/app-modules/events/lang/pt_BR/pages.php
+++ b/app-modules/events/lang/pt_BR/pages.php
@@ -1,0 +1,14 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'back_to_events' => 'Voltar para Eventos',
+    'confirm_presence' => 'Confirmar Presença',
+    'confirm_presence_hint' => 'Confirme sua presença neste evento.',
+    'confirm_presence_success' => 'Sua presença foi confirmada!',
+    'enrollment_status_label' => 'Status da sua inscrição',
+    'enrolled_at' => 'Inscrito em :date',
+    'no_enrollments' => 'Você ainda não está inscrito em nenhum evento.',
+    'no_upcoming_events' => 'Nenhum evento disponível no momento.',
+];

--- a/app-modules/events/lang/pt_BR/pages.php
+++ b/app-modules/events/lang/pt_BR/pages.php
@@ -7,6 +7,7 @@ return [
     'confirm_presence' => 'Confirmar Presença',
     'confirm_presence_hint' => 'Confirme sua presença neste evento.',
     'confirm_presence_success' => 'Sua presença foi confirmada!',
+    'waitlist_success' => 'Você entrou na lista de espera deste evento.',
     'enrollment_status_label' => 'Status da sua inscrição',
     'enrolled_at' => 'Inscrito em :date',
     'no_enrollments' => 'Você ainda não está inscrito em nenhum evento.',

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -13,6 +13,7 @@ use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use He4rt\Events\Event\Enums\EventStatus;
+use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 
 final readonly class EnrollUserAction
@@ -30,33 +31,37 @@ final readonly class EnrollUserAction
                 EnrollmentException::alreadyEnrolled(),
             );
 
-            $now = now();
+            try {
+                $now = now();
 
-            $enrollment = new Enrollment([
-                'event_id' => $dto->eventId,
-                'user_id' => $dto->userId,
-                'enrolled_at' => $now,
-                'confirmed_at' => $now,
-            ]);
-            $enrollment->status = EnrollmentStatus::Confirmed;
-            $enrollment->save();
+                $enrollment = new Enrollment([
+                    'event_id' => $dto->eventId,
+                    'user_id' => $dto->userId,
+                    'enrolled_at' => $now,
+                    'confirmed_at' => $now,
+                ]);
+                $enrollment->status = EnrollmentStatus::Confirmed;
+                $enrollment->save();
 
-            EnrollmentTransition::query()->create([
-                'enrollment_id' => $enrollment->id,
-                'from_status' => null,
-                'to_status' => EnrollmentStatus::Confirmed,
-                'actor_id' => $dto->userId,
-                'triggered_by' => TriggeredBy::User,
-            ]);
+                EnrollmentTransition::query()->create([
+                    'enrollment_id' => $enrollment->id,
+                    'from_status' => null,
+                    'to_status' => EnrollmentStatus::Confirmed,
+                    'actor_id' => $dto->userId,
+                    'triggered_by' => TriggeredBy::User,
+                ]);
 
-            event(new EnrollmentConfirmed(
-                enrollmentId: $enrollment->id,
-                eventId: $dto->eventId,
-                userId: $dto->userId,
-                xpRewardRsvp: $dto->xpRewardOnConfirmed,
-            ));
+                event(new EnrollmentConfirmed(
+                    enrollmentId: $enrollment->id,
+                    eventId: $dto->eventId,
+                    userId: $dto->userId,
+                    xpRewardRsvp: $dto->xpRewardOnConfirmed,
+                ));
 
-            return $enrollment->fresh(['event.enrollmentPolicy']);
+                return $enrollment->fresh(['event.enrollmentPolicy']);
+            } catch (UniqueConstraintViolationException) {
+                throw EnrollmentException::alreadyEnrolled();
+            }
         });
     }
 

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Enrollment\Actions;
 
+use Carbon\CarbonInterface;
 use He4rt\Events\Enrollment\DTOs\EnrollUserDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
@@ -11,6 +12,7 @@ use He4rt\Events\Enrollment\Enums\TriggeredBy;
 use He4rt\Events\Enrollment\Events\EnrollmentConfirmed;
 use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use He4rt\Events\Event\Enums\EventStatus;
 use Illuminate\Database\UniqueConstraintViolationException;
@@ -31,6 +33,13 @@ final readonly class EnrollUserAction
                 EnrollmentException::alreadyEnrolled(),
             );
 
+            EnrollmentPolicy::query()
+                ->where('event_id', $dto->eventId)
+                ->lockForUpdate()
+                ->first();
+
+            $initial = $this->resolveInitialEnrollment($dto);
+
             try {
                 $now = now();
 
@@ -38,31 +47,76 @@ final readonly class EnrollUserAction
                     'event_id' => $dto->eventId,
                     'user_id' => $dto->userId,
                     'enrolled_at' => $now,
-                    'confirmed_at' => $now,
+                    'confirmed_at' => $initial['confirmedAt'],
+                    'waitlist_position' => $initial['waitlistPosition'],
                 ]);
-                $enrollment->status = EnrollmentStatus::Confirmed;
+                $enrollment->status = $initial['status'];
                 $enrollment->save();
 
                 EnrollmentTransition::query()->create([
                     'enrollment_id' => $enrollment->id,
                     'from_status' => null,
-                    'to_status' => EnrollmentStatus::Confirmed,
+                    'to_status' => $initial['status'],
                     'actor_id' => $dto->userId,
                     'triggered_by' => TriggeredBy::User,
                 ]);
 
-                event(new EnrollmentConfirmed(
-                    enrollmentId: $enrollment->id,
-                    eventId: $dto->eventId,
-                    userId: $dto->userId,
-                    xpRewardRsvp: $dto->xpRewardOnConfirmed,
-                ));
+                if ($initial['status'] === EnrollmentStatus::Confirmed) {
+                    event(new EnrollmentConfirmed(
+                        enrollmentId: $enrollment->id,
+                        eventId: $dto->eventId,
+                        userId: $dto->userId,
+                        xpRewardOnConfirmed: $dto->xpRewardOnConfirmed,
+                    ));
+                }
 
                 return $enrollment->fresh(['event.enrollmentPolicy']);
             } catch (UniqueConstraintViolationException) {
                 throw EnrollmentException::alreadyEnrolled();
             }
         });
+    }
+
+    /**
+     * @return array{status: EnrollmentStatus, waitlistPosition: ?int, confirmedAt: ?CarbonInterface}
+     */
+    private function resolveInitialEnrollment(EnrollUserDTO $dto): array
+    {
+        if ($dto->capacity === null) {
+            return [
+                'status' => EnrollmentStatus::Confirmed,
+                'waitlistPosition' => null,
+                'confirmedAt' => now(),
+            ];
+        }
+
+        $confirmedCount = Enrollment::query()
+            ->where('event_id', $dto->eventId)
+            ->confirmed()
+            ->count();
+
+        if ($confirmedCount < $dto->capacity) {
+            return [
+                'status' => EnrollmentStatus::Confirmed,
+                'waitlistPosition' => null,
+                'confirmedAt' => now(),
+            ];
+        }
+
+        if ($dto->hasWaitlist) {
+            $nextPosition = (int) Enrollment::query()
+                ->where('event_id', $dto->eventId)
+                ->waitlisted()
+                ->max('waitlist_position') + 1;
+
+            return [
+                'status' => EnrollmentStatus::Waitlisted,
+                'waitlistPosition' => $nextPosition,
+                'confirmedAt' => null,
+            ];
+        }
+
+        throw EnrollmentException::eventFull();
     }
 
     private function validate(EnrollUserDTO $dto): void

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Enrollment\Actions;
 
+use He4rt\Events\Enrollment\DTOs\EnrollUserDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Enums\TriggeredBy;
@@ -12,33 +13,28 @@ use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use He4rt\Events\Event\Enums\EventStatus;
-use He4rt\Events\Event\Models\Event;
-use He4rt\Identity\User\Models\User;
 use Illuminate\Support\Facades\DB;
 
 final readonly class EnrollUserAction
 {
-    public function handle(Event $event, User $user): Enrollment
+    public function handle(EnrollUserDTO $dto): Enrollment
     {
-        $this->validate($event, $user);
+        $this->validate($dto);
 
-        return DB::transaction(function () use ($event, $user): Enrollment {
+        return DB::transaction(function () use ($dto): Enrollment {
             throw_if(
                 Enrollment::query()
-                    ->where('event_id', $event->id)
-                    ->where('user_id', $user->id)
+                    ->where('event_id', $dto->eventId)
+                    ->where('user_id', $dto->userId)
                     ->exists(),
                 EnrollmentException::alreadyEnrolled(),
             );
 
-            $event->loadMissing('enrollmentPolicy');
-            $policy = $event->enrollmentPolicy;
-
             $now = now();
 
             $enrollment = new Enrollment([
-                'event_id' => $event->id,
-                'user_id' => $user->id,
+                'event_id' => $dto->eventId,
+                'user_id' => $dto->userId,
                 'enrolled_at' => $now,
                 'confirmed_at' => $now,
             ]);
@@ -49,38 +45,36 @@ final readonly class EnrollUserAction
                 'enrollment_id' => $enrollment->id,
                 'from_status' => null,
                 'to_status' => EnrollmentStatus::Confirmed,
-                'actor_id' => $user->id,
+                'actor_id' => $dto->userId,
                 'triggered_by' => TriggeredBy::User,
             ]);
 
             event(new EnrollmentConfirmed(
                 enrollmentId: $enrollment->id,
-                eventId: $event->id,
-                userId: $user->id,
-                xpRewardRsvp: $policy->xp_on_confirmed,
+                eventId: $dto->eventId,
+                userId: $dto->userId,
+                xpRewardRsvp: $dto->xpRewardOnConfirmed,
             ));
 
             return $enrollment->fresh(['event.enrollmentPolicy']);
         });
     }
 
-    private function validate(Event $event, User $user): void
+    private function validate(EnrollUserDTO $dto): void
     {
         throw_unless(
-            $event->status === EventStatus::Published,
+            $dto->eventStatus === EventStatus::Published,
             EnrollmentException::eventNotActive(),
         );
 
         throw_if(
-            $event->starts_at->lte(now()),
+            $dto->eventStartsAt->lte(now()),
             EnrollmentException::eventPast(),
         );
 
-        $event->loadMissing('enrollmentPolicy');
-
         throw_unless(
             in_array(
-                $event->enrollmentPolicy?->enrollment_method,
+                $dto->enrollmentMethod,
                 [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin],
                 strict: true,
             ),
@@ -89,8 +83,8 @@ final readonly class EnrollUserAction
 
         throw_if(
             Enrollment::query()
-                ->where('event_id', $event->id)
-                ->where('user_id', $user->id)
+                ->where('event_id', $dto->eventId)
+                ->where('user_id', $dto->userId)
                 ->exists(),
             EnrollmentException::alreadyEnrolled(),
         );

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -58,7 +58,7 @@ final readonly class EnrollUserAction
                     'triggered_by' => TriggeredBy::User,
                 ]);
 
-                if ($initial['status'] === EnrollmentStatus::Confirmed) {
+                if ($initial['status']->isConfirmed()) {
                     event(new EnrollmentConfirmed(
                         enrollmentId: $enrollment->id,
                         eventId: $dto->eventId,

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\Actions;
+
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Events\EnrollmentConfirmed;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\DB;
+
+final readonly class EnrollUserAction
+{
+    public function handle(Event $event, User $user): Enrollment
+    {
+        $this->validate($event, $user);
+
+        return DB::transaction(function () use ($event, $user): Enrollment {
+            throw_if(
+                Enrollment::query()
+                    ->where('event_id', $event->id)
+                    ->where('user_id', $user->id)
+                    ->exists(),
+                EnrollmentException::alreadyEnrolled(),
+            );
+
+            $event->loadMissing('enrollmentPolicy');
+            $policy = $event->enrollmentPolicy;
+
+            $now = now();
+
+            $enrollment = new Enrollment([
+                'event_id' => $event->id,
+                'user_id' => $user->id,
+                'enrolled_at' => $now,
+                'confirmed_at' => $now,
+            ]);
+            $enrollment->status = EnrollmentStatus::Confirmed;
+            $enrollment->save();
+
+            EnrollmentTransition::query()->create([
+                'enrollment_id' => $enrollment->id,
+                'from_status' => null,
+                'to_status' => EnrollmentStatus::Confirmed,
+                'actor_id' => $user->id,
+                'triggered_by' => TriggeredBy::User,
+            ]);
+
+            event(new EnrollmentConfirmed(
+                enrollmentId: $enrollment->id,
+                eventId: $event->id,
+                userId: $user->id,
+                xpRewardRsvp: $policy->xp_on_confirmed,
+            ));
+
+            return $enrollment->fresh(['event.enrollmentPolicy']);
+        });
+    }
+
+    private function validate(Event $event, User $user): void
+    {
+        throw_unless(
+            $event->status === EventStatus::Published,
+            EnrollmentException::eventNotActive(),
+        );
+
+        throw_if(
+            $event->starts_at->lte(now()),
+            EnrollmentException::eventPast(),
+        );
+
+        $event->loadMissing('enrollmentPolicy');
+
+        throw_unless(
+            in_array(
+                $event->enrollmentPolicy?->enrollment_method,
+                [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin],
+                strict: true,
+            ),
+            EnrollmentException::invalidEnrollmentMethod(),
+        );
+
+        throw_if(
+            Enrollment::query()
+                ->where('event_id', $event->id)
+                ->where('user_id', $user->id)
+                ->exists(),
+            EnrollmentException::alreadyEnrolled(),
+        );
+    }
+}

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -15,6 +15,7 @@ use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\DB;
 
@@ -22,9 +23,19 @@ final readonly class EnrollUserAction
 {
     public function handle(EnrollUserDTO $dto): Enrollment
     {
-        $this->validate($dto);
-
         return DB::transaction(function () use ($dto): Enrollment {
+            $event = Event::query()
+                ->whereKey($dto->eventId)
+                ->lockForUpdate()
+                ->firstOrFail();
+
+            $policy = EnrollmentPolicy::query()
+                ->where('event_id', $dto->eventId)
+                ->lockForUpdate()
+                ->first();
+
+            $this->validate($event, $policy);
+
             throw_if(
                 Enrollment::query()
                     ->where('event_id', $dto->eventId)
@@ -33,12 +44,7 @@ final readonly class EnrollUserAction
                 EnrollmentException::alreadyEnrolled(),
             );
 
-            EnrollmentPolicy::query()
-                ->where('event_id', $dto->eventId)
-                ->lockForUpdate()
-                ->first();
-
-            $initial = $this->resolveInitialEnrollment($dto);
+            $initial = $this->resolveInitialEnrollment($dto->eventId, $policy);
 
             try {
                 $enrollment = Enrollment::query()->create([
@@ -63,7 +69,7 @@ final readonly class EnrollUserAction
                         enrollmentId: $enrollment->id,
                         eventId: $dto->eventId,
                         userId: $dto->userId,
-                        xpRewardOnConfirmed: $dto->xpRewardOnConfirmed,
+                        xpRewardOnConfirmed: $policy?->xp_on_confirmed ?? 0,
                     ));
                 }
 
@@ -77,9 +83,11 @@ final readonly class EnrollUserAction
     /**
      * @return array{status: EnrollmentStatus, waitlistPosition: ?int, confirmedAt: ?CarbonInterface}
      */
-    private function resolveInitialEnrollment(EnrollUserDTO $dto): array
+    private function resolveInitialEnrollment(string $eventId, ?EnrollmentPolicy $policy): array
     {
-        if ($dto->capacity === null) {
+        $capacity = $policy?->capacity;
+
+        if ($capacity === null) {
             return [
                 'status' => EnrollmentStatus::Confirmed,
                 'waitlistPosition' => null,
@@ -88,11 +96,11 @@ final readonly class EnrollUserAction
         }
 
         $confirmedCount = Enrollment::query()
-            ->where('event_id', $dto->eventId)
+            ->where('event_id', $eventId)
             ->confirmed()
             ->count();
 
-        if ($confirmedCount < $dto->capacity) {
+        if ($confirmedCount < $capacity) {
             return [
                 'status' => EnrollmentStatus::Confirmed,
                 'waitlistPosition' => null,
@@ -100,9 +108,9 @@ final readonly class EnrollUserAction
             ];
         }
 
-        if ($dto->hasWaitlist) {
+        if ($policy->has_waitlist) {
             $nextPosition = (int) Enrollment::query()
-                ->where('event_id', $dto->eventId)
+                ->where('event_id', $eventId)
                 ->waitlisted()
                 ->max('waitlist_position') + 1;
 
@@ -116,33 +124,25 @@ final readonly class EnrollUserAction
         throw EnrollmentException::eventFull();
     }
 
-    private function validate(EnrollUserDTO $dto): void
+    private function validate(Event $event, ?EnrollmentPolicy $policy): void
     {
         throw_unless(
-            $dto->eventStatus === EventStatus::Published,
+            $event->status === EventStatus::Published,
             EnrollmentException::eventNotActive(),
         );
 
         throw_if(
-            $dto->eventStartsAt->lte(now()),
+            $event->starts_at->lte(now()),
             EnrollmentException::eventPast(),
         );
 
         throw_unless(
             in_array(
-                $dto->enrollmentMethod,
+                $policy?->enrollment_method,
                 [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin],
                 strict: true,
             ),
             EnrollmentException::invalidEnrollmentMethod(),
-        );
-
-        throw_if(
-            Enrollment::query()
-                ->where('event_id', $dto->eventId)
-                ->where('user_id', $dto->userId)
-                ->exists(),
-            EnrollmentException::alreadyEnrolled(),
         );
     }
 }

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -24,25 +24,9 @@ final readonly class EnrollUserAction
     public function handle(EnrollUserDTO $dto): Enrollment
     {
         return DB::transaction(function () use ($dto): Enrollment {
-            $event = Event::query()
-                ->whereKey($dto->eventId)
-                ->lockForUpdate()
-                ->firstOrFail();
+            [$event, $policy] = $this->loadLockedEnrollmentContext($dto->eventId);
 
-            $policy = EnrollmentPolicy::query()
-                ->where('event_id', $dto->eventId)
-                ->lockForUpdate()
-                ->first();
-
-            $this->validate($event, $policy);
-
-            throw_if(
-                Enrollment::query()
-                    ->where('event_id', $dto->eventId)
-                    ->where('user_id', $dto->userId)
-                    ->exists(),
-                EnrollmentException::alreadyEnrolled(),
-            );
+            $this->validate($event, $policy, $dto->userId);
 
             $initial = $this->resolveInitialEnrollment($dto->eventId, $policy);
 
@@ -78,6 +62,30 @@ final readonly class EnrollUserAction
                 throw EnrollmentException::alreadyEnrolled();
             }
         });
+    }
+
+    /**
+     * Load event and policy for validation and capacity checks.
+     *
+     * lockForUpdate() runs SELECT ... FOR UPDATE. Row locks are held until this
+     * DB::transaction commits or rolls back — there is no explicit unlock in code.
+     * Returned models are reused below so rules run on fresh DB state, not caller snapshots.
+     *
+     * @return array{0: Event, 1: ?EnrollmentPolicy}
+     */
+    private function loadLockedEnrollmentContext(string $eventId): array
+    {
+        $event = Event::query()
+            ->whereKey($eventId)
+            ->lockForUpdate()
+            ->firstOrFail();
+
+        $policy = EnrollmentPolicy::query()
+            ->where('event_id', $eventId)
+            ->lockForUpdate()
+            ->first();
+
+        return [$event, $policy];
     }
 
     /**
@@ -124,7 +132,7 @@ final readonly class EnrollUserAction
         throw EnrollmentException::eventFull();
     }
 
-    private function validate(Event $event, ?EnrollmentPolicy $policy): void
+    private function validate(Event $event, ?EnrollmentPolicy $policy, string $userId): void
     {
         throw_unless(
             $event->status === EventStatus::Published,
@@ -143,6 +151,14 @@ final readonly class EnrollUserAction
                 strict: true,
             ),
             EnrollmentException::invalidEnrollmentMethod(),
+        );
+
+        throw_if(
+            Enrollment::query()
+                ->where('event_id', $event->id)
+                ->where('user_id', $userId)
+                ->exists(),
+            EnrollmentException::alreadyEnrolled(),
         );
     }
 }

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -41,17 +41,14 @@ final readonly class EnrollUserAction
             $initial = $this->resolveInitialEnrollment($dto);
 
             try {
-                $now = now();
-
-                $enrollment = new Enrollment([
+                $enrollment = Enrollment::query()->create([
                     'event_id' => $dto->eventId,
                     'user_id' => $dto->userId,
-                    'enrolled_at' => $now,
+                    'status' => $initial['status'],
+                    'enrolled_at' => now(),
                     'confirmed_at' => $initial['confirmedAt'],
                     'waitlist_position' => $initial['waitlistPosition'],
                 ]);
-                $enrollment->status = $initial['status'];
-                $enrollment->save();
 
                 EnrollmentTransition::query()->create([
                     'enrollment_id' => $enrollment->id,

--- a/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
@@ -18,6 +18,8 @@ final readonly class EnrollUserDTO
         public EventStatus $eventStatus,
         public CarbonInterface $eventStartsAt,
         public ?EnrollmentMethod $enrollmentMethod,
+        public ?int $capacity,
+        public bool $hasWaitlist,
         public int $xpRewardOnConfirmed,
     ) {}
 
@@ -31,6 +33,8 @@ final readonly class EnrollUserDTO
             eventStatus: $event->status,
             eventStartsAt: $event->starts_at,
             enrollmentMethod: $event->enrollmentPolicy?->enrollment_method,
+            capacity: $event->enrollmentPolicy?->capacity,
+            hasWaitlist: $event->enrollmentPolicy?->has_waitlist ?? false,
             xpRewardOnConfirmed: $event->enrollmentPolicy?->xp_on_confirmed ?? 0,
         );
     }

--- a/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
@@ -14,13 +14,7 @@ final readonly class EnrollUserDTO
 {
     public function __construct(
         public string $eventId,
-        public string $userId,
-        public EventStatus $eventStatus,
-        public CarbonInterface $eventStartsAt,
-        public ?EnrollmentMethod $enrollmentMethod,
-        public ?int $capacity,
-        public bool $hasWaitlist,
-        public int $xpRewardOnConfirmed,
+        public string $userId
     ) {}
 
     public static function fromModels(Event $event, User $user): self

--- a/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\DTOs;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\User\Models\User;
+
+final readonly class EnrollUserDTO
+{
+    public function __construct(
+        public string $eventId,
+        public string $userId,
+        public EventStatus $eventStatus,
+        public CarbonInterface $eventStartsAt,
+        public ?EnrollmentMethod $enrollmentMethod,
+        public int $xpRewardOnConfirmed,
+    ) {}
+
+    public static function fromModels(Event $event, User $user): self
+    {
+        $event->loadMissing('enrollmentPolicy');
+
+        return new self(
+            eventId: $event->id,
+            userId: $user->id,
+            eventStatus: $event->status,
+            eventStartsAt: $event->starts_at,
+            enrollmentMethod: $event->enrollmentPolicy?->enrollment_method,
+            xpRewardOnConfirmed: $event->enrollmentPolicy?->xp_on_confirmed ?? 0,
+        );
+    }
+}

--- a/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
@@ -4,9 +4,6 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Enrollment\DTOs;
 
-use Carbon\CarbonInterface;
-use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
-use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Models\Event;
 use He4rt\Identity\User\Models\User;
 
@@ -14,22 +11,14 @@ final readonly class EnrollUserDTO
 {
     public function __construct(
         public string $eventId,
-        public string $userId
+        public string $userId,
     ) {}
 
     public static function fromModels(Event $event, User $user): self
     {
-        $event->loadMissing('enrollmentPolicy');
-
         return new self(
             eventId: $event->id,
             userId: $user->id,
-            eventStatus: $event->status,
-            eventStartsAt: $event->starts_at,
-            enrollmentMethod: $event->enrollmentPolicy?->enrollment_method,
-            capacity: $event->enrollmentPolicy?->capacity,
-            hasWaitlist: $event->enrollmentPolicy?->has_waitlist ?? false,
-            xpRewardOnConfirmed: $event->enrollmentPolicy?->xp_on_confirmed ?? 0,
         );
     }
 }

--- a/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
+++ b/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
@@ -69,4 +69,27 @@ enum EnrollmentStatus: string implements HasColor, HasIcon, HasLabel
     {
         return in_array($this, [self::Attended, self::Cancelled, self::Rejected, self::NoShow], strict: true);
     }
+
+    public function is(self ...$statuses): bool
+    {
+        return in_array($this, $statuses, strict: true);
+    }
+
+    public function isConfirmed(): bool
+    {
+        return $this->is(self::Confirmed);
+    }
+
+    public function isWaitlisted(): bool
+    {
+        return $this->is(self::Waitlisted);
+    }
+
+    public function getResponseMessage(): string
+    {
+        return match ($this) {
+            self::Confirmed => __('events::pages.confirm_presence_success'),
+            self::Waitlisted => __('events::pages.waitlist_success'),
+        };
+    }
 }

--- a/app-modules/events/src/Enrollment/Events/EnrollmentConfirmed.php
+++ b/app-modules/events/src/Enrollment/Events/EnrollmentConfirmed.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\Events;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class EnrollmentConfirmed implements ShouldDispatchAfterCommit
+{
+    use Dispatchable;
+
+    public function __construct(
+        public string $enrollmentId,
+        public string $eventId,
+        public string $userId,
+        public int $xpRewardRsvp,
+    ) {}
+}

--- a/app-modules/events/src/Enrollment/Events/EnrollmentConfirmed.php
+++ b/app-modules/events/src/Enrollment/Events/EnrollmentConfirmed.php
@@ -15,6 +15,6 @@ final readonly class EnrollmentConfirmed implements ShouldDispatchAfterCommit
         public string $enrollmentId,
         public string $eventId,
         public string $userId,
-        public int $xpRewardRsvp,
+        public int $xpRewardOnConfirmed,
     ) {}
 }

--- a/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
+++ b/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
@@ -40,4 +40,12 @@ final class EnrollmentException extends Exception
             Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
+
+    public static function eventFull(): self
+    {
+        return new self(
+            __('events::exceptions.event_full'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
 }

--- a/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
+++ b/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+
+final class EnrollmentException extends Exception
+{
+    public static function alreadyEnrolled(): self
+    {
+        return new self(
+            __('events::exceptions.already_enrolled'),
+            Response::HTTP_CONFLICT,
+        );
+    }
+
+    public static function eventPast(): self
+    {
+        return new self(
+            __('events::exceptions.event_past'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function eventNotActive(): self
+    {
+        return new self(
+            __('events::exceptions.event_not_active'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function invalidEnrollmentMethod(): self
+    {
+        return new self(
+            __('events::exceptions.invalid_enrollment_method'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+}

--- a/app-modules/events/src/Event/Enums/EventStatus.php
+++ b/app-modules/events/src/Event/Enums/EventStatus.php
@@ -17,6 +17,16 @@ enum EventStatus: string implements HasColor, HasIcon, HasLabel
     case Completed = 'completed';
     case Cancelled = 'cancelled';
 
+    /** @return list<self> */
+    public static function viewableByParticipant(): array
+    {
+        return [
+            self::Published,
+            self::Completed,
+            self::Cancelled,
+        ];
+    }
+
     public function getLabel(): string
     {
         return __('events::enums.event_status.'.$this->value);
@@ -54,5 +64,13 @@ enum EventStatus: string implements HasColor, HasIcon, HasLabel
     public function isTerminal(): bool
     {
         return in_array($this, [self::Completed, self::Cancelled], strict: true);
+    }
+
+    public function isViewableByParticipant(): bool
+    {
+        return match ($this) {
+            self::Published, self::Completed, self::Cancelled => true,
+            self::Draft => false,
+        };
     }
 }

--- a/app-modules/events/src/Event/Models/Event.php
+++ b/app-modules/events/src/Event/Models/Event.php
@@ -102,6 +102,11 @@ final class Event extends Model
         $query->where('status', EventStatus::Published);
     }
 
+    protected function scopeViewableByParticipant(Builder $query): void
+    {
+        $query->whereIn('status', EventStatus::viewableByParticipant());
+    }
+
     protected function scopeUpcoming(Builder $query): void
     {
         $query->where('starts_at', '>', now());

--- a/app-modules/events/src/Event/Models/Event.php
+++ b/app-modules/events/src/Event/Models/Event.php
@@ -110,7 +110,7 @@ final class Event extends Model
     protected function scopeActive(Builder $query): void
     {
         $query->where('status', EventStatus::Published)
-            ->where('starts_at', '>', now());
+            ->where('ends_at', '>', now());
     }
 
     /** @return array<string, mixed> */

--- a/app-modules/events/tests/Feature/EnrollUserActionTest.php
+++ b/app-modules/events/tests/Feature/EnrollUserActionTest.php
@@ -57,7 +57,7 @@ test('when a user enrolls in an rsvp event, then enrollment is confirmed with au
     EventFacade::assertDispatched(fn (EnrollmentConfirmed $event): bool => $event->enrollmentId === $enrollment->id
         && $event->eventId === $enrollment->event_id
         && $event->userId === $user->id
-        && $event->xpRewardRsvp === 50);
+        && $event->xpRewardOnConfirmed === 50);
 });
 
 test('when concurrent enrollment hits unique index, then already enrolled exception is thrown', function (): void {
@@ -143,6 +143,81 @@ test('when an event uses application enrollment method, then rsvp enrollment is 
 
     resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 })->throws(EnrollmentException::class);
+
+test('when event is at capacity with waitlist enabled, then enrollment is waitlisted', function (): void {
+    EventFacade::fake([EnrollmentConfirmed::class]);
+
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant, [], [
+        'capacity' => 1,
+        'has_waitlist' => true,
+    ]);
+
+    $existingUser = User::factory()->create();
+    Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'user_id' => $existingUser->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    $enrollment = resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
+
+    expect($enrollment->status)->toBe(EnrollmentStatus::Waitlisted)
+        ->and($enrollment->waitlist_position)->toBe(1)
+        ->and($enrollment->confirmed_at)->toBeNull();
+
+    EventFacade::assertNotDispatched(EnrollmentConfirmed::class);
+});
+
+test('when event is at capacity without waitlist, then enrollment is rejected', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant, [], [
+        'capacity' => 1,
+        'has_waitlist' => false,
+    ]);
+
+    $existingUser = User::factory()->create();
+    Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'user_id' => $existingUser->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
+})->throws(EnrollmentException::class);
+
+test('when event has available capacity, then enrollment is confirmed', function (): void {
+    EventFacade::fake([EnrollmentConfirmed::class]);
+
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant, [], [
+        'capacity' => 2,
+        'has_waitlist' => true,
+    ]);
+
+    $existingUser = User::factory()->create();
+    Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'user_id' => $existingUser->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    $enrollment = resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
+
+    expect($enrollment->status)->toBe(EnrollmentStatus::Confirmed)
+        ->and($enrollment->confirmed_at)->not->toBeNull();
+
+    EventFacade::assertDispatched(EnrollmentConfirmed::class);
+});
 
 test('when duplicate enrollment exists in database, then only one enrollment record is kept', function (): void {
     $user = User::factory()->create();

--- a/app-modules/events/tests/Feature/EnrollUserActionTest.php
+++ b/app-modules/events/tests/Feature/EnrollUserActionTest.php
@@ -60,6 +60,40 @@ test('when a user enrolls in an rsvp event, then enrollment is confirmed with au
         && $event->xpRewardRsvp === 50);
 });
 
+test('when concurrent enrollment hits unique index, then already enrolled exception is thrown', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant);
+    $dto = EnrollUserDTO::fromModels($event, $user);
+
+    $raced = false;
+
+    Enrollment::creating(function (Enrollment $enrollment) use (&$raced): void {
+        if ($raced) {
+            return;
+        }
+
+        $raced = true;
+
+        Enrollment::withoutEvents(function () use ($enrollment): void {
+            Enrollment::factory()->create([
+                'event_id' => $enrollment->event_id,
+                'user_id' => $enrollment->user_id,
+                'status' => EnrollmentStatus::Confirmed,
+                'enrolled_at' => now(),
+                'confirmed_at' => now(),
+            ]);
+        });
+    });
+
+    try {
+        expect(fn (): Enrollment => resolve(EnrollUserAction::class)->handle($dto))
+            ->toThrow(EnrollmentException::class);
+    } finally {
+        Enrollment::flushEventListeners();
+    }
+});
+
 test('when a user enrolls twice in the same event, then duplicate enrollment is rejected', function (): void {
     $user = User::factory()->create();
     $tenant = Tenant::factory()->create();

--- a/app-modules/events/tests/Feature/EnrollUserActionTest.php
+++ b/app-modules/events/tests/Feature/EnrollUserActionTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Events\Enrollment\Actions\EnrollUserAction;
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Events\EnrollmentConfirmed;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
+use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event as EventFacade;
+
+uses(RefreshDatabase::class);
+
+function createRsvpEvent(Tenant $tenant, array $eventAttributes = [], array $policyAttributes = []): Event
+{
+    return Event::factory()
+        ->published()
+        ->upcoming()
+        ->for($tenant)
+        ->has(EnrollmentPolicy::factory()->rsvp()->state($policyAttributes), 'enrollmentPolicy')
+        ->create($eventAttributes);
+}
+
+test('when a user enrolls in an rsvp event, then enrollment is confirmed with audit trail', function (): void {
+    EventFacade::fake([EnrollmentConfirmed::class]);
+
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant, [], ['xp_on_confirmed' => 50]);
+
+    $enrollment = resolve(EnrollUserAction::class)->handle($event, $user);
+
+    expect($enrollment->status)->toBe(EnrollmentStatus::Confirmed)
+        ->and($enrollment->enrolled_at)->not->toBeNull()
+        ->and($enrollment->confirmed_at)->not->toBeNull();
+
+    $transition = EnrollmentTransition::query()
+        ->where('enrollment_id', $enrollment->id)
+        ->first();
+
+    expect($transition)->not->toBeNull()
+        ->and($transition->from_status)->toBeNull()
+        ->and($transition->to_status)->toBe(EnrollmentStatus::Confirmed)
+        ->and($transition->actor_id)->toBe($user->id)
+        ->and($transition->triggered_by)->toBe(TriggeredBy::User);
+
+    EventFacade::assertDispatched(fn (EnrollmentConfirmed $event): bool => $event->enrollmentId === $enrollment->id
+        && $event->eventId === $enrollment->event_id
+        && $event->userId === $user->id
+        && $event->xpRewardRsvp === 50);
+});
+
+test('when a user enrolls twice in the same event, then duplicate enrollment is rejected', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant);
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+})->throws(EnrollmentException::class);
+
+test('when a user enrolls in a past event, then enrollment is rejected', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = Event::factory()
+        ->published()
+        ->past()
+        ->for($tenant)
+        ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
+        ->create();
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+})->throws(EnrollmentException::class);
+
+test('when a user enrolls in a draft event, then enrollment is rejected', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = Event::factory()
+        ->upcoming()
+        ->for($tenant)
+        ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
+        ->create(['status' => EventStatus::Draft]);
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+})->throws(EnrollmentException::class);
+
+test('when an event uses application enrollment method, then rsvp enrollment is rejected', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = Event::factory()
+        ->published()
+        ->upcoming()
+        ->for($tenant)
+        ->has(EnrollmentPolicy::factory()->state([
+            'enrollment_method' => EnrollmentMethod::Application,
+        ]), 'enrollmentPolicy')
+        ->create();
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+})->throws(EnrollmentException::class);
+
+test('when duplicate enrollment exists in database, then only one enrollment record is kept', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $event = createRsvpEvent($tenant);
+
+    resolve(EnrollUserAction::class)->handle($event, $user);
+
+    expect(Enrollment::query()->where('event_id', $event->id)->where('user_id', $user->id)->count())->toBe(1);
+});

--- a/app-modules/events/tests/Feature/EnrollUserActionTest.php
+++ b/app-modules/events/tests/Feature/EnrollUserActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use He4rt\Events\Enrollment\Actions\EnrollUserAction;
+use He4rt\Events\Enrollment\DTOs\EnrollUserDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Enums\TriggeredBy;
@@ -37,7 +38,7 @@ test('when a user enrolls in an rsvp event, then enrollment is confirmed with au
     $tenant = Tenant::factory()->create();
     $event = createRsvpEvent($tenant, [], ['xp_on_confirmed' => 50]);
 
-    $enrollment = resolve(EnrollUserAction::class)->handle($event, $user);
+    $enrollment = resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 
     expect($enrollment->status)->toBe(EnrollmentStatus::Confirmed)
         ->and($enrollment->enrolled_at)->not->toBeNull()
@@ -64,9 +65,9 @@ test('when a user enrolls twice in the same event, then duplicate enrollment is 
     $tenant = Tenant::factory()->create();
     $event = createRsvpEvent($tenant);
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 })->throws(EnrollmentException::class);
 
 test('when a user enrolls in a past event, then enrollment is rejected', function (): void {
@@ -79,7 +80,7 @@ test('when a user enrolls in a past event, then enrollment is rejected', functio
         ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
         ->create();
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 })->throws(EnrollmentException::class);
 
 test('when a user enrolls in a draft event, then enrollment is rejected', function (): void {
@@ -91,7 +92,7 @@ test('when a user enrolls in a draft event, then enrollment is rejected', functi
         ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
         ->create(['status' => EventStatus::Draft]);
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 })->throws(EnrollmentException::class);
 
 test('when an event uses application enrollment method, then rsvp enrollment is rejected', function (): void {
@@ -106,7 +107,7 @@ test('when an event uses application enrollment method, then rsvp enrollment is 
         ]), 'enrollmentPolicy')
         ->create();
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 })->throws(EnrollmentException::class);
 
 test('when duplicate enrollment exists in database, then only one enrollment record is kept', function (): void {
@@ -114,7 +115,7 @@ test('when duplicate enrollment exists in database, then only one enrollment rec
     $tenant = Tenant::factory()->create();
     $event = createRsvpEvent($tenant);
 
-    resolve(EnrollUserAction::class)->handle($event, $user);
+    resolve(EnrollUserAction::class)->handle(EnrollUserDTO::fromModels($event, $user));
 
     expect(Enrollment::query()->where('event_id', $event->id)->where('user_id', $user->id)->count())->toBe(1);
 });

--- a/app-modules/events/tests/Feature/EventFactoriesTest.php
+++ b/app-modules/events/tests/Feature/EventFactoriesTest.php
@@ -2,12 +2,17 @@
 
 declare(strict_types=1);
 
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\CheckIn\Models\CheckInCode;
 use He4rt\Events\CheckIn\Models\QrToken;
+use He4rt\Events\Enrollment\Enums\AttendanceRequirement;
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Enums\EventType;
 use He4rt\Events\Event\Models\Event;
 use Illuminate\Database\Eloquent\Collection;
 
@@ -95,4 +100,60 @@ test('when an event has check-in codes, then they are accessible via the relatio
 
     expect($event->checkInCodes)->toHaveCount(2)
         ->and($event->checkInCodes->first()->event_id)->toBe($event->id);
+});
+
+test('when creating a workshop via factory preset, then event and enrollment policy match community defaults', function (): void {
+    $event = Event::factory()->asWorkshop()->upcoming()->create();
+
+    $event->load('enrollmentPolicy');
+
+    expect($event->event_type)->toBe(EventType::Workshop)
+        ->and($event->status)->toBe(EventStatus::Published)
+        ->and($event->enrollmentPolicy)->not->toBeNull()
+        ->and($event->enrollmentPolicy->enrollment_method)->toBe(EnrollmentMethod::RsvpCheckin)
+        ->and($event->enrollmentPolicy->check_in_method)->toBe(CheckInMethod::NumericCode)
+        ->and($event->enrollmentPolicy->capacity)->toBe(50)
+        ->and($event->enrollmentPolicy->has_waitlist)->toBeTrue()
+        ->and($event->enrollmentPolicy->attendance_requirement)->toBe(AttendanceRequirement::AllDays)
+        ->and($event->enrollmentPolicy->xp_on_confirmed)->toBe(100);
+});
+
+test('when creating a meetup via factory preset, then event has open rsvp enrollment policy', function (): void {
+    $event = Event::factory()->asMeetup()->create();
+
+    $event->load('enrollmentPolicy');
+
+    expect($event->event_type)->toBe(EventType::Meetup)
+        ->and($event->enrollmentPolicy->enrollment_method)->toBe(EnrollmentMethod::Rsvp)
+        ->and($event->enrollmentPolicy->check_in_method)->toBe(CheckInMethod::Manual)
+        ->and($event->enrollmentPolicy->capacity)->toBeNull()
+        ->and($event->enrollmentPolicy->has_waitlist)->toBeFalse();
+});
+
+test('when creating a conference via factory preset, then event has application enrollment with waitlist', function (): void {
+    $event = Event::factory()->asConference()->past()->create();
+
+    $event->load('enrollmentPolicy');
+
+    expect($event->event_type)->toBe(EventType::Conference)
+        ->and($event->enrollmentPolicy->enrollment_method)->toBe(EnrollmentMethod::Application)
+        ->and($event->enrollmentPolicy->check_in_method)->toBe(CheckInMethod::QrCode)
+        ->and($event->enrollmentPolicy->capacity)->toBe(200)
+        ->and($event->enrollmentPolicy->has_waitlist)->toBeTrue()
+        ->and($event->enrollmentPolicy->attendance_requirement)->toBe(AttendanceRequirement::MinimumDays)
+        ->and($event->enrollmentPolicy->minimum_days)->toBe(2)
+        ->and($event->enrollmentPolicy->cancellation_deadline_hours)->toBe(48);
+});
+
+test('when creating multiple meetup presets, then each event gets its own enrollment policy', function (): void {
+    $events = Event::factory()->count(3)->asMeetup()->create();
+
+    expect($events)->toHaveCount(3);
+
+    foreach ($events as $event) {
+        $event->load('enrollmentPolicy');
+
+        expect($event->enrollmentPolicy)->not->toBeNull()
+            ->and($event->enrollmentPolicy->enrollment_method)->toBe(EnrollmentMethod::Rsvp);
+    }
 });

--- a/app-modules/events/tests/Feature/EventFactoriesTest.php
+++ b/app-modules/events/tests/Feature/EventFactoriesTest.php
@@ -49,7 +49,7 @@ test('when creating a check-in via factory, then it is linked to an enrollment',
 
     expect($checkIn->id)->not->toBeNull()
         ->and($checkIn->enrollment_id)->not->toBeNull()
-        ->and($checkIn->check_in_date)->not->toBeNull();
+        ->and($checkIn->event_date)->not->toBeNull();
 });
 
 test('when creating a check-in code via factory, then it is linked to an event with valid dates', function (): void {

--- a/app-modules/events/tests/Feature/EventFactoriesTest.php
+++ b/app-modules/events/tests/Feature/EventFactoriesTest.php
@@ -49,7 +49,7 @@ test('when creating a check-in via factory, then it is linked to an enrollment',
 
     expect($checkIn->id)->not->toBeNull()
         ->and($checkIn->enrollment_id)->not->toBeNull()
-        ->and($checkIn->check_in)->not->toBeNull();
+        ->and($checkIn->check_in_date)->not->toBeNull();
 });
 
 test('when creating a check-in code via factory, then it is linked to an event with valid dates', function (): void {

--- a/app-modules/events/tests/Feature/EventResourceTest.php
+++ b/app-modules/events/tests/Feature/EventResourceTest.php
@@ -88,6 +88,33 @@ test('when submitting the create form with valid data, then event and enrollment
         ->and($event->enrollmentPolicy->enrollment_method)->toBe(EnrollmentMethod::Rsvp);
 });
 
+test('when submitting the create form with a duplicate slug for the same tenant, then validation fails', function (): void {
+    $tenant = Filament::getTenant();
+    $startsAt = now()->addDay();
+
+    Event::factory()->for($tenant)->create(['slug' => 'duplicate-slug']);
+
+    livewire(CreateEvent::class)
+        ->fillForm([
+            'title' => 'Another Event',
+            'slug' => 'duplicate-slug',
+            'tenant_id' => $tenant->getKey(),
+            'event_type' => EventType::Meetup,
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->addHours(3),
+            'enrollmentPolicy' => [
+                'enrollment_method' => EnrollmentMethod::Rsvp,
+                'check_in_method' => CheckInMethod::Manual,
+                'attendance_requirement' => AttendanceRequirement::AllDays,
+                'xp_on_confirmed' => 0,
+                'xp_on_checked_in' => 0,
+                'xp_on_attended' => 0,
+            ],
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['slug' => 'unique']);
+});
+
 test('when submitting the edit form with a new title, then it is updated in the database', function (): void {
     $event = Event::factory()
         ->has(EnrollmentPolicy::factory(), 'enrollmentPolicy')

--- a/app-modules/events/tests/Unit/EnrollmentStatusTest.php
+++ b/app-modules/events/tests/Unit/EnrollmentStatusTest.php
@@ -59,3 +59,18 @@ test('when enrollment statuses are evaluated, then terminal states are correctly
         ->and(EnrollmentStatus::Waitlisted->isTerminal())->toBeFalse()
         ->and(EnrollmentStatus::CheckedIn->isTerminal())->toBeFalse();
 });
+
+test('when enrollment status helpers are evaluated, then is and named checks work', function (): void {
+    expect(EnrollmentStatus::Confirmed->isConfirmed())->toBeTrue()
+        ->and(EnrollmentStatus::Confirmed->is(EnrollmentStatus::Confirmed))->toBeTrue()
+        ->and(EnrollmentStatus::Confirmed->is(EnrollmentStatus::Waitlisted))->toBeFalse()
+        ->and(EnrollmentStatus::Waitlisted->isWaitlisted())->toBeTrue()
+        ->and(EnrollmentStatus::Pending->is(EnrollmentStatus::Confirmed, EnrollmentStatus::Waitlisted))->toBeFalse();
+});
+
+test('when rsvp enrollment status is evaluated, then response message matches status', function (EnrollmentStatus $status, string $expectedKey): void {
+    expect($status->getResponseMessage())->toBe(__($expectedKey));
+})->with([
+    [EnrollmentStatus::Confirmed, 'events::pages.confirm_presence_success'],
+    [EnrollmentStatus::Waitlisted, 'events::pages.waitlist_success'],
+]);

--- a/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
@@ -18,6 +18,8 @@ use He4rt\Events\Enrollment\Enums\AttendanceRequirement;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Enums\EventType;
+use He4rt\Events\Event\Models\Event;
+use Illuminate\Validation\Rules\Unique;
 
 final class EventForm
 {
@@ -35,7 +37,19 @@ final class EventForm
                 TextInput::make('slug')
                     ->label('Slug')
                     ->required()
-                    ->maxLength(120),
+                    ->maxLength(120)
+                    ->unique(
+                        table: Event::class,
+                        column: 'slug',
+                        ignoreRecord: true,
+                        modifyRuleUsing: function (Unique $rule, Get $get): Unique {
+                            $tenantId = $get('tenant_id');
+
+                            return filled($tenantId)
+                                ? $rule->where('tenant_id', $tenantId)
+                                : $rule->whereNull('tenant_id');
+                        },
+                    ),
 
                 Select::make('event_type')
                     ->label('Type')

--- a/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
@@ -16,6 +16,7 @@ use Filament\Schemas\Schema;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\Enrollment\Enums\AttendanceRequirement;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Enums\EventType;
 
 final class EventForm
@@ -65,9 +66,11 @@ final class EventForm
                     ->required()
                     ->after('starts_at'),
 
-                Toggle::make('active')
-                    ->label('Published')
-                    ->default(false)
+                Select::make('status')
+                    ->label('Status')
+                    ->options(EventStatus::class)
+                    ->default(EventStatus::Draft)
+                    ->required()
                     ->columnSpanFull(),
 
                 Section::make('Enrollment Policy')

--- a/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventInfolist.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventInfolist.php
@@ -45,9 +45,9 @@ final class EventInfolist
                     ->label('Ends At')
                     ->dateTime(),
 
-                IconEntry::make('active')
-                    ->label('Published')
-                    ->boolean(),
+                TextEntry::make('status')
+                    ->label('Status')
+                    ->badge(),
 
                 TextEntry::make('created_at')
                     ->label('Created At')

--- a/app-modules/panel-admin/src/Filament/Resources/Events/Tables/EventsTable.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/Tables/EventsTable.php
@@ -8,10 +8,10 @@ use Filament\Actions\BulkActionGroup;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
-use Filament\Tables\Columns\IconColumn;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Enums\EventType;
 
 final class EventsTable
@@ -45,9 +45,10 @@ final class EventsTable
                     ->dateTime()
                     ->sortable(),
 
-                IconColumn::make('active')
-                    ->label('Published')
-                    ->boolean(),
+                TextColumn::make('status')
+                    ->label('Status')
+                    ->badge()
+                    ->sortable(),
 
                 TextColumn::make('created_at')
                     ->label('Created At')
@@ -59,6 +60,10 @@ final class EventsTable
                 SelectFilter::make('event_type')
                     ->label('Type')
                     ->options(EventType::class),
+
+                SelectFilter::make('status')
+                    ->label('Status')
+                    ->options(EventStatus::class),
             ])
             ->recordActions([
                 EditAction::make(),

--- a/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
@@ -1,0 +1,49 @@
+<div class="space-y-6">
+    <div class="rounded-xl border border-gray-200 p-6 dark:border-white/10">
+        <div class="flex flex-wrap items-start justify-between gap-4">
+            <div class="space-y-2">
+                <h2 class="text-xl font-semibold text-gray-950 dark:text-white">{{ $this->event->title }}</h2>
+
+                <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm text-gray-500 dark:text-gray-400">
+                    <span>{{ $this->event->starts_at->format('d/m/Y H:i') }}</span>
+                    <span>—</span>
+                    <span>{{ $this->event->ends_at->format('d/m/Y H:i') }}</span>
+
+                    @if ($this->event->location)
+                        <span>{{ $this->event->location }}</span>
+                    @endif
+                </div>
+            </div>
+
+            <x-filament::badge :color="$this->event->event_type->getColor()">
+                {{ $this->event->event_type->getLabel() }}
+            </x-filament::badge>
+        </div>
+
+        @if ($this->event->description)
+            <p class="mt-4 text-sm leading-relaxed text-gray-600 dark:text-gray-300">{{ $this->event->description }}</p>
+        @endif
+    </div>
+
+    @if ($this->enrollment)
+        <div class="rounded-xl border border-gray-200 p-5 dark:border-white/10">
+            <div class="flex items-center justify-between gap-4">
+                <p class="text-sm text-gray-600 dark:text-gray-300">
+                    {{ __('events::pages.enrollment_status_label') }}
+                </p>
+
+                <x-filament::badge :color="$this->enrollment->status->getColor()">
+                    {{ $this->enrollment->status->getLabel() }}
+                </x-filament::badge>
+            </div>
+        </div>
+    @elseif ($this->canConfirmPresence)
+        <div class="rounded-xl border border-gray-200 p-5 dark:border-white/10">
+            <p class="mb-4 text-sm text-gray-600 dark:text-gray-300">{{ __('events::pages.confirm_presence_hint') }}</p>
+
+            <x-filament::button wire:click="confirmPresence" wire:loading.attr="disabled">
+                {{ __('events::pages.confirm_presence') }}
+            </x-filament::button>
+        </div>
+    @endif
+</div>

--- a/app-modules/panel-app/resources/views/livewire/events/events-list.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/events-list.blade.php
@@ -1,0 +1,43 @@
+<div>
+    <section class="space-y-4">
+        @forelse ($this->events as $event)
+            <a
+                href="{{ $this->eventUrl($event) }}"
+                wire:key="event-{{ $event->id }}"
+                class="hover:border-primary-300 dark:hover:border-primary-500/50 block rounded-xl border border-gray-200 p-5 transition hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
+            >
+                <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0 space-y-1">
+                        <h3 class="truncate text-base font-semibold text-gray-950 dark:text-white">
+                            {{ $event->title }}
+                        </h3>
+
+                        @if ($event->description)
+                            <p class="line-clamp-2 text-sm text-gray-500 dark:text-gray-400">
+                                {{ $event->description }}
+                            </p>
+                        @endif
+
+                        <div
+                            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
+                        >
+                            <span>{{ $event->starts_at->format('d/m/Y H:i') }}</span>
+
+                            @if ($event->location)
+                                <span>{{ $event->location }}</span>
+                            @endif
+                        </div>
+                    </div>
+
+                    <x-filament::badge :color="$event->event_type->getColor()">
+                        {{ $event->event_type->getLabel() }}
+                    </x-filament::badge>
+                </div>
+            </a>
+        @empty
+            <div class="rounded-xl border border-gray-200 p-8 text-center dark:border-white/10">
+                <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('events::pages.no_upcoming_events') }}</p>
+            </div>
+        @endforelse
+    </section>
+</div>

--- a/app-modules/panel-app/resources/views/livewire/events/my-events-list.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/my-events-list.blade.php
@@ -1,0 +1,41 @@
+<div>
+    <section class="space-y-4">
+        @forelse ($this->enrollments as $enrollment)
+            <a
+                href="{{ $this->eventUrl($enrollment) }}"
+                wire:key="enrollment-{{ $enrollment->id }}"
+                class="hover:border-primary-300 dark:hover:border-primary-500/50 block rounded-xl border border-gray-200 p-5 transition hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
+            >
+                <div class="flex items-start justify-between gap-4">
+                    <div class="min-w-0 space-y-1">
+                        <h3 class="truncate text-base font-semibold text-gray-950 dark:text-white">
+                            {{ $enrollment->event->title }}
+                        </h3>
+
+                        <div
+                            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
+                        >
+                            <span>{{ $enrollment->event->starts_at->format('d/m/Y H:i') }}</span>
+
+                            @if ($enrollment->enrolled_at)
+                                <span>{{
+                                    __('events::pages.enrolled_at', [
+                                        'date' => $enrollment->enrolled_at->format('d/m/Y H:i'),
+                                    ])
+                                }}</span>
+                            @endif
+                        </div>
+                    </div>
+
+                    <x-filament::badge :color="$enrollment->status->getColor()">
+                        {{ $enrollment->status->getLabel() }}
+                    </x-filament::badge>
+                </div>
+            </a>
+        @empty
+            <div class="rounded-xl border border-gray-200 p-8 text-center dark:border-white/10">
+                <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('events::pages.no_enrollments') }}</p>
+            </div>
+        @endforelse
+    </section>
+</div>

--- a/app-modules/panel-app/resources/views/livewire/events/my-events-list.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/my-events-list.blade.php
@@ -1,37 +1,22 @@
 <div>
     <section class="space-y-4">
         @forelse ($this->enrollments as $enrollment)
-            <a
-                href="{{ $this->eventUrl($enrollment) }}"
-                wire:key="enrollment-{{ $enrollment->id }}"
-                class="hover:border-primary-300 dark:hover:border-primary-500/50 block rounded-xl border border-gray-200 p-5 transition hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
-            >
-                <div class="flex items-start justify-between gap-4">
-                    <div class="min-w-0 space-y-1">
-                        <h3 class="truncate text-base font-semibold text-gray-950 dark:text-white">
-                            {{ $enrollment->event->title }}
-                        </h3>
-
-                        <div
-                            class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400"
-                        >
-                            <span>{{ $enrollment->event->starts_at->format('d/m/Y H:i') }}</span>
-
-                            @if ($enrollment->enrolled_at)
-                                <span>{{
-                                    __('events::pages.enrolled_at', [
-                                        'date' => $enrollment->enrolled_at->format('d/m/Y H:i'),
-                                    ])
-                                }}</span>
-                            @endif
-                        </div>
-                    </div>
-
-                    <x-filament::badge :color="$enrollment->status->getColor()">
-                        {{ $enrollment->status->getLabel() }}
-                    </x-filament::badge>
+            @if ($this->canOpenEvent($enrollment))
+                <a
+                    href="{{ $this->eventUrl($enrollment) }}"
+                    wire:key="enrollment-{{ $enrollment->id }}"
+                    class="hover:border-primary-300 dark:hover:border-primary-500/50 block rounded-xl border border-gray-200 p-5 transition hover:bg-gray-50 dark:border-white/10 dark:hover:bg-white/5"
+                >
+                    @include ('panel-app::livewire.events.partials.my-events-list-item', ['enrollment' => $enrollment])
+                </a>
+            @else
+                <div
+                    wire:key="enrollment-{{ $enrollment->id }}"
+                    class="block rounded-xl border border-gray-200 p-5 dark:border-white/10"
+                >
+                    @include ('panel-app::livewire.events.partials.my-events-list-item', ['enrollment' => $enrollment])
                 </div>
-            </a>
+            @endif
         @empty
             <div class="rounded-xl border border-gray-200 p-8 text-center dark:border-white/10">
                 <p class="text-sm text-gray-500 dark:text-gray-400">{{ __('events::pages.no_enrollments') }}</p>

--- a/app-modules/panel-app/resources/views/livewire/events/partials/my-events-list-item.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/partials/my-events-list-item.blade.php
@@ -1,0 +1,27 @@
+<div class="flex items-start justify-between gap-4">
+    <div class="min-w-0 space-y-1">
+        <h3 class="truncate text-base font-semibold text-gray-950 dark:text-white">{{ $enrollment->event->title }}</h3>
+
+        <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs text-gray-500 dark:text-gray-400">
+            <span>{{ $enrollment->event->starts_at->format('d/m/Y H:i') }}</span>
+
+            @if ($enrollment->enrolled_at)
+                <span>{{
+                    __('events::pages.enrolled_at', [
+                        'date' => $enrollment->enrolled_at->format('d/m/Y H:i'),
+                    ])
+                }}</span>
+            @endif
+        </div>
+    </div>
+
+    <div class="flex shrink-0 flex-col items-end gap-2">
+        <x-filament::badge :color="$enrollment->status->getColor()">
+            {{ $enrollment->status->getLabel() }}
+        </x-filament::badge>
+
+        <x-filament::badge :color="$enrollment->event->status->getColor()">
+            {{ $enrollment->event->status->getLabel() }}
+        </x-filament::badge>
+    </div>
+</div>

--- a/app-modules/panel-app/resources/views/pages/event.blade.php
+++ b/app-modules/panel-app/resources/views/pages/event.blade.php
@@ -1,0 +1,13 @@
+<x-filament-panels::page>
+    <div class="mx-auto w-full max-w-4xl space-y-4">
+        <a
+            href="{{ \He4rt\PanelApp\Pages\EventsPage::getUrl() }}"
+            class="inline-flex items-center gap-1.5 text-sm text-gray-500 transition hover:text-gray-900 dark:text-gray-400 dark:hover:text-white"
+        >
+            <x-heroicon-o-arrow-left class="h-4 w-4" />
+            {{ __('events::pages.back_to_events') }}
+        </a>
+
+        <livewire:event-detail :event-id="$this->record" :key="'event-detail-' . $this->record" />
+    </div>
+</x-filament-panels::page>

--- a/app-modules/panel-app/resources/views/pages/events.blade.php
+++ b/app-modules/panel-app/resources/views/pages/events.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="mx-auto w-full max-w-4xl">
+        <livewire:events-list />
+    </div>
+</x-filament-panels::page>

--- a/app-modules/panel-app/resources/views/pages/my-events.blade.php
+++ b/app-modules/panel-app/resources/views/pages/my-events.blade.php
@@ -1,0 +1,5 @@
+<x-filament-panels::page>
+    <div class="mx-auto w-full max-w-4xl">
+        <livewire:my-events-list />
+    </div>
+</x-filament-panels::page>

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Livewire\Events;
+
+use Filament\Notifications\Notification;
+use He4rt\Events\Enrollment\Actions\EnrollUserAction;
+use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Contracts\View\View;
+use Livewire\Attributes\Computed;
+use Livewire\Component;
+
+final class EventDetail extends Component
+{
+    public string $eventId;
+
+    public function mount(string $eventId): void
+    {
+        $this->eventId = $eventId;
+    }
+
+    #[Computed]
+    public function event(): Event
+    {
+        return Event::query()
+            ->with('enrollmentPolicy')
+            ->where('id', $this->eventId)
+            ->where('tenant_id', filament()->getTenant()->getKey())
+            ->where('status', EventStatus::Published)
+            ->firstOrFail();
+    }
+
+    #[Computed]
+    public function enrollment(): ?Enrollment
+    {
+        return Enrollment::query()
+            ->where('event_id', $this->eventId)
+            ->where('user_id', auth()->id())
+            ->first();
+    }
+
+    #[Computed]
+    public function canConfirmPresence(): bool
+    {
+        if ($this->enrollment !== null) {
+            return false;
+        }
+
+        $method = $this->event->enrollmentPolicy?->enrollment_method;
+
+        if (!in_array($method, [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin], strict: true)) {
+            return false;
+        }
+
+        return $this->event->starts_at->isFuture();
+    }
+
+    public function confirmPresence(): void
+    {
+        /** @var User $user */
+        $user = auth()->user();
+
+        try {
+            resolve(EnrollUserAction::class)->handle($this->event, $user);
+
+            unset($this->enrollment, $this->canConfirmPresence);
+
+            Notification::make()
+                ->success()
+                ->title(__('events::pages.confirm_presence_success'))
+                ->send();
+        } catch (EnrollmentException $enrollmentException) {
+            Notification::make()
+                ->danger()
+                ->title($enrollmentException->getMessage())
+                ->send();
+        }
+    }
+
+    public function render(): View
+    {
+        return view('panel-app::livewire.events.event-detail');
+    }
+}

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -96,13 +96,9 @@ final class EventDetail extends Component
 
             unset($this->enrollment, $this->canConfirmPresence);
 
-            $successMessage = $enrollment->status === EnrollmentStatus::Confirmed
-                ? __('events::pages.confirm_presence_success')
-                : __('events::pages.waitlist_success');
-
             Notification::make()
                 ->success()
-                ->title($successMessage)
+                ->title($enrollment->status->getResponseMessage())
                 ->send();
         } catch (EnrollmentException $enrollmentException) {
             Notification::make()

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -33,7 +33,7 @@ final class EventDetail extends Component
             ->with('enrollmentPolicy')
             ->where('id', $this->eventId)
             ->where('tenant_id', filament()->getTenant()->getKey())
-            ->where('status', EventStatus::Published)
+            ->whereIn('status', [EventStatus::Published, EventStatus::Completed])
             ->firstOrFail();
     }
 

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -8,6 +8,7 @@ use Filament\Notifications\Notification;
 use He4rt\Events\Enrollment\Actions\EnrollUserAction;
 use He4rt\Events\Enrollment\DTOs\EnrollUserDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Event\Enums\EventStatus;
@@ -33,7 +34,7 @@ final class EventDetail extends Component
             ->with('enrollmentPolicy')
             ->where('id', $this->eventId)
             ->where('tenant_id', filament()->getTenant()->getKey())
-            ->whereIn('status', [EventStatus::Published, EventStatus::Completed])
+            ->viewableByParticipant()
             ->firstOrFail();
     }
 
@@ -49,17 +50,38 @@ final class EventDetail extends Component
     #[Computed]
     public function canConfirmPresence(): bool
     {
+        if ($this->event->status !== EventStatus::Published) {
+            return false;
+        }
+
         if ($this->enrollment !== null) {
             return false;
         }
 
-        $method = $this->event->enrollmentPolicy?->enrollment_method;
+        $policy = $this->event->enrollmentPolicy;
 
-        if (!in_array($method, [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin], strict: true)) {
+        if (!in_array($policy?->enrollment_method, [EnrollmentMethod::Rsvp, EnrollmentMethod::RsvpCheckin], strict: true)) {
             return false;
         }
 
-        return $this->event->starts_at->isFuture();
+        if (!$this->event->starts_at->isFuture()) {
+            return false;
+        }
+
+        if ($policy->capacity === null) {
+            return true;
+        }
+
+        $confirmedCount = Enrollment::query()
+            ->where('event_id', $this->eventId)
+            ->where('status', EnrollmentStatus::Confirmed)
+            ->count();
+
+        if ($confirmedCount < $policy->capacity) {
+            return true;
+        }
+
+        return $policy->has_waitlist;
     }
 
     public function confirmPresence(): void
@@ -68,15 +90,19 @@ final class EventDetail extends Component
         $user = auth()->user();
 
         try {
-            resolve(EnrollUserAction::class)->handle(
+            $enrollment = resolve(EnrollUserAction::class)->handle(
                 EnrollUserDTO::fromModels($this->event, $user),
             );
 
             unset($this->enrollment, $this->canConfirmPresence);
 
+            $successMessage = $enrollment->status === EnrollmentStatus::Confirmed
+                ? __('events::pages.confirm_presence_success')
+                : __('events::pages.waitlist_success');
+
             Notification::make()
                 ->success()
-                ->title(__('events::pages.confirm_presence_success'))
+                ->title($successMessage)
                 ->send();
         } catch (EnrollmentException $enrollmentException) {
             Notification::make()

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -6,6 +6,7 @@ namespace He4rt\PanelApp\Livewire\Events;
 
 use Filament\Notifications\Notification;
 use He4rt\Events\Enrollment\Actions\EnrollUserAction;
+use He4rt\Events\Enrollment\DTOs\EnrollUserDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
 use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
@@ -67,7 +68,9 @@ final class EventDetail extends Component
         $user = auth()->user();
 
         try {
-            resolve(EnrollUserAction::class)->handle($this->event, $user);
+            resolve(EnrollUserAction::class)->handle(
+                EnrollUserDTO::fromModels($this->event, $user),
+            );
 
             unset($this->enrollment, $this->canConfirmPresence);
 

--- a/app-modules/panel-app/src/Livewire/Events/EventsList.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventsList.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Livewire\Events;
+
+use He4rt\Events\Event\Models\Event;
+use He4rt\PanelApp\Pages\EventPage;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Component;
+
+final class EventsList extends Component
+{
+    /** @return Collection<int, Event> */
+    public function getEventsProperty(): Collection
+    {
+        return Event::query()
+            ->with('enrollmentPolicy')
+            ->where('tenant_id', filament()->getTenant()->getKey())
+            ->active()
+            ->orderBy('starts_at')
+            ->get();
+    }
+
+    public function eventUrl(Event $event): string
+    {
+        return EventPage::getUrl(['record' => $event->getKey()]);
+    }
+
+    public function render(): View
+    {
+        return view('panel-app::livewire.events.events-list');
+    }
+}

--- a/app-modules/panel-app/src/Livewire/Events/MyEventsList.php
+++ b/app-modules/panel-app/src/Livewire/Events/MyEventsList.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Livewire\Events;
+
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\PanelApp\Pages\EventPage;
+use Illuminate\Contracts\Database\Query\Builder;
+use Illuminate\Contracts\View\View;
+use Illuminate\Database\Eloquent\Collection;
+use Livewire\Component;
+
+final class MyEventsList extends Component
+{
+    /** @return Collection<int, Enrollment> */
+    public function getEnrollmentsProperty(): Collection
+    {
+        return Enrollment::query()
+            ->with(['event'])
+            ->where('user_id', auth()->id())
+            ->whereHas('event', fn (Builder $query) => $query->where('tenant_id', filament()->getTenant()->getKey()))
+            ->latest('enrolled_at')
+            ->get();
+    }
+
+    public function eventUrl(Enrollment $enrollment): string
+    {
+        return EventPage::getUrl(['record' => $enrollment->event_id]);
+    }
+
+    public function render(): View
+    {
+        return view('panel-app::livewire.events.my-events-list');
+    }
+}

--- a/app-modules/panel-app/src/Livewire/Events/MyEventsList.php
+++ b/app-modules/panel-app/src/Livewire/Events/MyEventsList.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\PanelApp\Livewire\Events;
 
 use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Event\Models\Event;
 use He4rt\PanelApp\Pages\EventPage;
 use Illuminate\Contracts\Database\Query\Builder;
 use Illuminate\Contracts\View\View;
@@ -22,6 +23,14 @@ final class MyEventsList extends Component
             ->whereHas('event', fn (Builder $query) => $query->where('tenant_id', filament()->getTenant()->getKey()))
             ->latest('enrolled_at')
             ->get();
+    }
+
+    public function canOpenEvent(Enrollment $enrollment): bool
+    {
+        /** @var Event $event */
+        $event = $enrollment->event;
+
+        return $event->status->isViewableByParticipant();
     }
 
     public function eventUrl(Enrollment $enrollment): string

--- a/app-modules/panel-app/src/Pages/EventPage.php
+++ b/app-modules/panel-app/src/Pages/EventPage.php
@@ -6,7 +6,6 @@ namespace He4rt\PanelApp\Pages;
 
 use BackedEnum;
 use Filament\Pages\Page;
-use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Models\Event;
 
 class EventPage extends Page
@@ -28,7 +27,7 @@ class EventPage extends Page
         $exists = Event::query()
             ->where('id', $record)
             ->where('tenant_id', filament()->getTenant()->getKey())
-            ->where('status', EventStatus::Published)
+            ->viewableByParticipant()
             ->exists();
 
         abort_unless($exists, 404);

--- a/app-modules/panel-app/src/Pages/EventPage.php
+++ b/app-modules/panel-app/src/Pages/EventPage.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+
+class EventPage extends Page
+{
+    public string $record;
+
+    protected static string|null|BackedEnum $navigationIcon = null;
+
+    protected static bool $shouldRegisterNavigation = false;
+
+    protected static ?string $slug = 'events/{record}';
+
+    protected static ?string $title = 'Event';
+
+    protected string $view = 'panel-app::pages.event';
+
+    public function mount(string $record): void
+    {
+        $exists = Event::query()
+            ->where('id', $record)
+            ->where('tenant_id', filament()->getTenant()->getKey())
+            ->where('status', EventStatus::Published)
+            ->exists();
+
+        abort_unless($exists, 404);
+
+        $this->record = $record;
+    }
+}

--- a/app-modules/panel-app/src/Pages/EventsPage.php
+++ b/app-modules/panel-app/src/Pages/EventsPage.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+
+class EventsPage extends Page
+{
+    protected static string|null|BackedEnum $navigationIcon = 'heroicon-o-calendar-days';
+
+    protected static ?string $navigationLabel = 'Events';
+
+    protected static ?string $title = 'Events';
+
+    protected static ?int $navigationSort = 2;
+
+    protected string $view = 'panel-app::pages.events';
+}

--- a/app-modules/panel-app/src/Pages/MyEventsPage.php
+++ b/app-modules/panel-app/src/Pages/MyEventsPage.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelApp\Pages;
+
+use BackedEnum;
+use Filament\Pages\Page;
+
+class MyEventsPage extends Page
+{
+    protected static string|null|BackedEnum $navigationIcon = 'heroicon-o-ticket';
+
+    protected static ?string $navigationLabel = 'My Events';
+
+    protected static ?string $title = 'My Events';
+
+    protected static ?int $navigationSort = 3;
+
+    protected string $view = 'panel-app::pages.my-events';
+}

--- a/app-modules/panel-app/src/PanelAppServiceProvider.php
+++ b/app-modules/panel-app/src/PanelAppServiceProvider.php
@@ -4,6 +4,9 @@ declare(strict_types=1);
 
 namespace He4rt\PanelApp;
 
+use He4rt\PanelApp\Livewire\Events\EventDetail;
+use He4rt\PanelApp\Livewire\Events\EventsList;
+use He4rt\PanelApp\Livewire\Events\MyEventsList;
 use He4rt\PanelApp\Livewire\Timeline\Composer;
 use He4rt\PanelApp\Livewire\Timeline\Feed;
 use He4rt\PanelApp\Livewire\Timeline\PostShow;
@@ -20,6 +23,10 @@ class PanelAppServiceProvider extends ServiceProvider
     {
         $this->loadViewsFrom(__DIR__.'/../resources/views', 'panel-app');
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'panel-app');
+
+        Livewire::component('events-list', EventsList::class);
+        Livewire::component('my-events-list', MyEventsList::class);
+        Livewire::component('event-detail', EventDetail::class);
 
         Livewire::component('timeline-composer', Composer::class);
         Livewire::component('timeline-feed', Feed::class);

--- a/app-modules/panel-app/tests/Feature/Events/RsvpEnrollmentTest.php
+++ b/app-modules/panel-app/tests/Feature/Events/RsvpEnrollmentTest.php
@@ -6,10 +6,12 @@ use Filament\Facades\Filament;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
+use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Models\Event;
 use He4rt\Identity\Tenant\Models\Tenant;
 use He4rt\Identity\User\Models\User;
 use He4rt\PanelApp\Livewire\Events\EventDetail;
+use He4rt\PanelApp\Livewire\Events\MyEventsList;
 use He4rt\PanelApp\Pages\EventPage;
 use He4rt\PanelApp\Pages\EventsPage;
 use He4rt\PanelApp\Pages\MyEventsPage;
@@ -88,6 +90,82 @@ test('event page returns 404 for event from another tenant', function (): void {
 
     $this->get(EventPage::getUrl(['record' => $otherEvent->id]))
         ->assertNotFound();
+});
+
+test('when event is at capacity without waitlist, then confirm presence button is hidden', function (): void {
+    $this->event->enrollmentPolicy->update([
+        'capacity' => 1,
+        'has_waitlist' => false,
+    ]);
+
+    $otherUser = User::factory()->create();
+    Enrollment::factory()->create([
+        'event_id' => $this->event->id,
+        'user_id' => $otherUser->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->assertSet('canConfirmPresence', false)
+        ->assertDontSee(__('events::pages.confirm_presence'));
+});
+
+test('when event is at capacity with waitlist, then confirm presence button is still shown', function (): void {
+    $this->event->enrollmentPolicy->update([
+        'capacity' => 1,
+        'has_waitlist' => true,
+    ]);
+
+    $otherUser = User::factory()->create();
+    Enrollment::factory()->create([
+        'event_id' => $this->event->id,
+        'user_id' => $otherUser->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->assertSet('canConfirmPresence', true)
+        ->assertSee(__('events::pages.confirm_presence'));
+});
+
+test('when enrolled event is completed, then event detail page is accessible', function (): void {
+    $this->event->update(['status' => EventStatus::Completed]);
+
+    Enrollment::factory()->create([
+        'event_id' => $this->event->id,
+        'user_id' => $this->user->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    $this->get(EventPage::getUrl(['record' => $this->event->id]))
+        ->assertSuccessful()
+        ->assertSee('He4rt Meetup RSVP');
+
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->assertSet('canConfirmPresence', false);
+});
+
+test('when enrolled event is draft, then my events list does not link to detail', function (): void {
+    $this->event->update(['status' => EventStatus::Draft]);
+
+    Enrollment::factory()->create([
+        'event_id' => $this->event->id,
+        'user_id' => $this->user->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'enrolled_at' => now(),
+        'confirmed_at' => now(),
+    ]);
+
+    livewire(MyEventsList::class)
+        ->assertSet('enrollments', fn ($enrollments): bool => $enrollments->count() === 1)
+        ->assertSee('He4rt Meetup RSVP')
+        ->assertDontSee(EventPage::getUrl(['record' => $this->event->id]), false);
 });
 
 test('past event does not show confirm presence button', function (): void {

--- a/app-modules/panel-app/tests/Feature/Events/RsvpEnrollmentTest.php
+++ b/app-modules/panel-app/tests/Feature/Events/RsvpEnrollmentTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelApp\Livewire\Events\EventDetail;
+use He4rt\PanelApp\Pages\EventPage;
+use He4rt\PanelApp\Pages\EventsPage;
+use He4rt\PanelApp\Pages\MyEventsPage;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $this->user = User::factory()->create();
+    $this->tenant = Tenant::factory()->create(['slug' => 'test-tenant']);
+    $this->tenant->members()->attach($this->user);
+
+    $this->actingAs($this->user);
+
+    Filament::setCurrentPanel(Filament::getPanel('app'));
+    Filament::setTenant($this->tenant);
+
+    $this->event = Event::factory()
+        ->published()
+        ->upcoming()
+        ->for($this->tenant)
+        ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
+        ->create(['title' => 'He4rt Meetup RSVP']);
+});
+
+test('events page renders successfully', function (): void {
+    $this->get(EventsPage::getUrl())
+        ->assertSuccessful()
+        ->assertSee('He4rt Meetup RSVP');
+});
+
+test('event page renders confirm presence button for rsvp event', function (): void {
+    $this->get(EventPage::getUrl(['record' => $this->event->id]))
+        ->assertSuccessful()
+        ->assertSee('He4rt Meetup RSVP')
+        ->assertSee(__('events::pages.confirm_presence'));
+});
+
+test('when user confirms presence, then enrollment is created and shown in my events', function (): void {
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->call('confirmPresence')
+        ->assertHasNoErrors();
+
+    $enrollment = Enrollment::query()
+        ->where('event_id', $this->event->id)
+        ->where('user_id', $this->user->id)
+        ->first();
+
+    expect($enrollment)->not->toBeNull()
+        ->and($enrollment->status)->toBe(EnrollmentStatus::Confirmed);
+
+    $this->get(MyEventsPage::getUrl())
+        ->assertSuccessful()
+        ->assertSee('He4rt Meetup RSVP')
+        ->assertSee(EnrollmentStatus::Confirmed->getLabel());
+});
+
+test('when user tries to confirm presence twice, then duplicate enrollment is rejected', function (): void {
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->call('confirmPresence');
+
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->call('confirmPresence')
+        ->assertNotified();
+
+    expect(Enrollment::query()->where('event_id', $this->event->id)->count())->toBe(1);
+});
+
+test('event page returns 404 for event from another tenant', function (): void {
+    $otherTenant = Tenant::factory()->create(['slug' => 'other-tenant']);
+    $otherEvent = Event::factory()
+        ->published()
+        ->upcoming()
+        ->for($otherTenant)
+        ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
+        ->create();
+
+    $this->get(EventPage::getUrl(['record' => $otherEvent->id]))
+        ->assertNotFound();
+});
+
+test('past event does not show confirm presence button', function (): void {
+    $pastEvent = Event::factory()
+        ->published()
+        ->past()
+        ->for($this->tenant)
+        ->has(EnrollmentPolicy::factory()->rsvp(), 'enrollmentPolicy')
+        ->create(['title' => 'Past Meetup']);
+
+    livewire(EventDetail::class, ['eventId' => $pastEvent->id])
+        ->assertSet('canConfirmPresence', false)
+        ->assertDontSee(__('events::pages.confirm_presence'));
+});

--- a/app/Providers/Filament/AppPanelProvider.php
+++ b/app/Providers/Filament/AppPanelProvider.php
@@ -14,6 +14,9 @@ use Filament\Panel;
 use Filament\PanelProvider;
 use Filament\Support\Colors\Color;
 use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\PanelApp\Pages\EventPage;
+use He4rt\PanelApp\Pages\EventsPage;
+use He4rt\PanelApp\Pages\MyEventsPage;
 use He4rt\PanelApp\Pages\ThreadPage;
 use He4rt\PanelApp\Pages\TimelinePage;
 use Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse;
@@ -49,6 +52,9 @@ class AppPanelProvider extends PanelProvider
             ->discoverWidgets(in: app_path('Filament/App/Widgets'), for: 'App\Filament\App\Widgets')
             ->pages([
                 TimelinePage::class,
+                EventsPage::class,
+                MyEventsPage::class,
+                EventPage::class,
                 ThreadPage::class,
             ])
             ->middleware([


### PR DESCRIPTION
## Summary

Implements the **Events** bounded context (foundation) and the **RSVP enrollment** flow end-to-end: participant confirms presence → enrollment created as `confirmed` or `waitlisted` (when at capacity with waitlist) → transition recorded in audit trail → enrollment visible in App and Admin panels.

### RSVP enrollment

- **`EnrollUserAction`**: validates event (published, upcoming, RSVP/rsvp_checkin), resolves initial status (`confirmed` vs `waitlisted` vs rejected when full), creates enrollment, writes `EnrollmentTransition` (`from_status=null`, `to_status=<initial>`, `triggered_by=user`), dispatches `EnrollmentConfirmed` only when status is `confirmed` — all inside `DB::transaction` with `lockForUpdate` on policy and duplicate handling via `UniqueConstraintViolationException`
- **`EnrollUserDTO`**: input object built from `Event` + `User` (status, dates, policy capacity/waitlist, XP reward)
- **Domain event**: `EnrollmentConfirmed` implements `ShouldDispatchAfterCommit` (payload: `enrollment_id`, `event_id`, `user_id`, `xpRewardOnConfirmed`) — no listener in this slice
- **`EnrollmentException`**: `alreadyEnrolled`, `eventPast`, `eventNotActive`, `invalidEnrollmentMethod`, `eventFull`

### Capacity & waitlist

- When `enrollment_policy.capacity` is set and confirmed count ≥ capacity:
  - **`has_waitlist=true`** → enrollment `waitlisted` with `waitlist_position` (no `EnrollmentConfirmed`)
  - **`has_waitlist=false`** → `EnrollmentException::eventFull()`
- App UI: **Confirm Presence** hidden when full without waitlist; success notification differs for confirmed vs waitlisted; **My Events** shows status badges (including waitlisted)

### App panel (participant)

- Events listing (`EventsPage` / `EventsList`) — published upcoming events
- Event detail (`EventPage` / `EventDetail`) — **Confirm Presence** button
- My Events (`MyEventsPage` / `MyEventsList`) — enrollments with status badges; enrolled users can open detail for `completed` events

### Admin

- **`EventResource`**: form/infolist/table aligned with `status` column (`EventStatus` enum) instead of legacy `active` toggle
- Unique event **slug per tenant** validation on create/edit
- Read-only **Enrollments** relation manager

### Foundation (Events module — same branch vs `4.x`)

Schema, models (`Event`, `Enrollment`, `EnrollmentPolicy`, `EnrollmentTransition`, check-in models), enums, factories, migrations, ADRs, `CONTEXT.md`, admin resource scaffolding, unit tests for enums.

### Architecture
Events module ├── Enrollment domain │ ├── EnrollUserAction │ ├── EnrollUserDTO │ ├── EnrollmentConfirmed (domain event) │ └── EnrollmentException ├── Event domain (scopes: published, upcoming, viewableByParticipant) └── Check-in models (schema only — no flow in this PR)

App panel ├── EventsPage / EventsList ├── EventPage / EventDetail (+ Confirm Presence) └── MyEventsPage / MyEventsList

Admin panel └── EventResource (+ EnrollmentsRelationManager)


### Files (high level)

| Area | Count / notes |
|------|----------------|
| Migrations | 7 (+ drop legacy tables) |
| Actions | `EnrollUserAction` |
| DTOs | `EnrollUserDTO` |
| Domain events | `EnrollmentConfirmed` |
| Exceptions + lang | `EnrollmentException`, en/pt_BR exceptions + pages + enums |
| App panel | 3 Filament pages, 3 Livewire components, 7 Blade views (incl. partial) |
| Admin | `EventResource` schemas + relation manager |
| Tests | `EnrollUserActionTest`, `RsvpEnrollmentTest`, `EventResourceTest`, `EventFactoriesTest`, enum unit tests |
| Docs | 5 ADRs, `CONTEXT.md`, `CONTEXT-MAP.md` |

### Out of scope (future slices)

- Gamification listener for XP (`EnrollmentConfirmed` subscriber)
- Application enrollment flow (approve/reject)
- Enrollment management actions in admin (promote from waitlist, cancel, etc.)
- Check-in / QR flows
- Bot integration

Closes #240  
Parent: #237  
Related foundation PR: #249 (included in this branch when targeting `4.x`)

---

## Test plan

- [ ] `php artisan migrate`
- [ ] `php artisan test --filter=EnrollUserActionTest`
- [ ] `php artisan test --filter=RsvpEnrollmentTest`
- [ ] `php artisan test --filter=EventResourceTest`
- [ ] `php artisan test --filter=EventFactoriesTest`
- [ ] `./vendor/bin/pint --test`

### Admin

- [ ] Create event: **Published**, future `starts_at`, enrollment method **RSVP**
- [ ] Set `capacity` and toggle `has_waitlist` on enrollment policy
- [ ] Edit event → **Enrollments** tab shows participants

### App — happy path

- [ ] `/app/{tenant}/events` — event appears in list
- [ ] Open event → **Confirm Presence** → success notification
- [ ] `/app/{tenant}/my-events` — enrollment shows **Confirmed** badge

### App — capacity / waitlist

- [ ] Fill event to capacity **without** waitlist → **Confirm Presence** hidden; direct enroll returns `event_full`
- [ ] Fill event to capacity **with** waitlist → button still visible; enroll creates **Waitlisted** badge and waitlist notification

### App — edge cases

- [ ] Duplicate RSVP → error notification (`already_enrolled`)
- [ ] Past event → no **Confirm Presence** button
- [ ] Draft / non-RSVP event → not enrollable via RSVP
- [ ] Enrolled user on **completed** event → detail page still accessible