### PR TITLE
feat(events): implement manual check-in

### DIFF
--- a/app-modules/events/database/factories/CheckInFactory.php
+++ b/app-modules/events/database/factories/CheckInFactory.php
@@ -22,6 +22,7 @@ final class CheckInFactory extends Factory
             'event_date' => Date::today(),
             'method' => fake()->randomElement(CheckInMethod::cases()),
             'payload' => null,
+            'checked_in_at' => Date::now(),
         ];
     }
 }

--- a/app-modules/events/database/migrations/2026_05_22_000001_add_checked_in_at_to_events_check_ins_table.php
+++ b/app-modules/events/database/migrations/2026_05_22_000001_add_checked_in_at_to_events_check_ins_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('events_check_ins', function (Blueprint $table): void {
+            $table->timestampTz('checked_in_at')->nullable()->after('payload');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('events_check_ins', function (Blueprint $table): void {
+            $table->dropColumn('checked_in_at');
+        });
+    }
+};

--- a/app-modules/events/lang/en/check_in.php
+++ b/app-modules/events/lang/en/check_in.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'invalid_check_in_status' => 'Only confirmed or checked-in enrollments can be checked in.',
+    'check_in_outside_event_date_range' => 'Check-in date must be within the event date range.',
+    'already_checked_in_for_date' => 'This enrollment has already checked in for this date.',
+    'invalid_check_in_actor' => 'Manual check-in requires the organizer user id.',
+];

--- a/app-modules/events/lang/en/exceptions.php
+++ b/app-modules/events/lang/en/exceptions.php
@@ -3,13 +3,10 @@
 declare(strict_types=1);
 
 return [
+    'invalid_transition' => 'Cannot transition enrollment from :from to :to.',
     'already_enrolled' => 'You are already enrolled in this event.',
     'event_past' => 'This event has already started and is no longer accepting enrollments.',
     'event_not_active' => 'This event is not available for enrollment.',
     'invalid_enrollment_method' => 'This event requires application enrollment, not RSVP.',
     'event_full' => 'This event has reached maximum capacity and does not have a waitlist.',
-    'invalid_check_in_status' => 'Only confirmed or checked-in enrollments can be checked in.',
-    'check_in_outside_event_date_range' => 'Check-in date must be within the event date range.',
-    'already_checked_in_for_date' => 'This enrollment has already checked in for this date.',
-    'invalid_check_in_actor' => 'Manual check-in requires the organizer user id.',
 ];

--- a/app-modules/events/lang/en/exceptions.php
+++ b/app-modules/events/lang/en/exceptions.php
@@ -9,4 +9,5 @@ return [
     'event_not_active' => 'This event is not available for enrollment.',
     'invalid_enrollment_method' => 'This event requires application enrollment, not RSVP.',
     'event_full' => 'This event has reached maximum capacity and does not have a waitlist.',
+    'response_message_not_implemented' => 'Response message is not implemented for enrollment status: :status.',
 ];

--- a/app-modules/events/lang/en/exceptions.php
+++ b/app-modules/events/lang/en/exceptions.php
@@ -8,4 +8,8 @@ return [
     'event_not_active' => 'This event is not available for enrollment.',
     'invalid_enrollment_method' => 'This event requires application enrollment, not RSVP.',
     'event_full' => 'This event has reached maximum capacity and does not have a waitlist.',
+    'invalid_check_in_status' => 'Only confirmed or checked-in enrollments can be checked in.',
+    'check_in_outside_event_date_range' => 'Check-in date must be within the event date range.',
+    'already_checked_in_for_date' => 'This enrollment has already checked in for this date.',
+    'invalid_check_in_actor' => 'Manual check-in requires the organizer user id.',
 ];

--- a/app-modules/events/lang/pt_BR/check_in.php
+++ b/app-modules/events/lang/pt_BR/check_in.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'invalid_check_in_status' => 'Apenas inscrições confirmadas ou com check-in realizado podem receber check-in.',
+    'check_in_outside_event_date_range' => 'A data do check-in deve estar dentro do período do evento.',
+    'already_checked_in_for_date' => 'Esta inscrição já possui check-in para essa data.',
+    'invalid_check_in_actor' => 'Check-in manual exige o ID do usuário organizador.',
+];

--- a/app-modules/events/lang/pt_BR/exceptions.php
+++ b/app-modules/events/lang/pt_BR/exceptions.php
@@ -8,4 +8,8 @@ return [
     'event_not_active' => 'Este evento não está disponível para inscrição.',
     'invalid_enrollment_method' => 'Esse evento exige inscrição via formulário, não RSVP.',
     'event_full' => 'Este evento atingiu a capacidade máxima e não possui lista de espera.',
+    'invalid_check_in_status' => 'Apenas inscrições confirmadas ou com check-in realizado podem receber check-in.',
+    'check_in_outside_event_date_range' => 'A data do check-in deve estar dentro do período do evento.',
+    'already_checked_in_for_date' => 'Esta inscrição já possui check-in para essa data.',
+    'invalid_check_in_actor' => 'Check-in manual exige o ID do usuário organizador.',
 ];

--- a/app-modules/events/lang/pt_BR/exceptions.php
+++ b/app-modules/events/lang/pt_BR/exceptions.php
@@ -3,13 +3,10 @@
 declare(strict_types=1);
 
 return [
+    'invalid_transition' => 'Não é possível transicionar inscrição de :from para :to.',
     'already_enrolled' => 'Você já está inscrito neste evento.',
     'event_past' => 'Este evento já começou e não aceita mais inscrições.',
     'event_not_active' => 'Este evento não está disponível para inscrição.',
     'invalid_enrollment_method' => 'Esse evento exige inscrição via formulário, não RSVP.',
     'event_full' => 'Este evento atingiu a capacidade máxima e não possui lista de espera.',
-    'invalid_check_in_status' => 'Apenas inscrições confirmadas ou com check-in realizado podem receber check-in.',
-    'check_in_outside_event_date_range' => 'A data do check-in deve estar dentro do período do evento.',
-    'already_checked_in_for_date' => 'Esta inscrição já possui check-in para essa data.',
-    'invalid_check_in_actor' => 'Check-in manual exige o ID do usuário organizador.',
 ];

--- a/app-modules/events/lang/pt_BR/exceptions.php
+++ b/app-modules/events/lang/pt_BR/exceptions.php
@@ -9,4 +9,5 @@ return [
     'event_not_active' => 'Este evento não está disponível para inscrição.',
     'invalid_enrollment_method' => 'Esse evento exige inscrição via formulário, não RSVP.',
     'event_full' => 'Este evento atingiu a capacidade máxima e não possui lista de espera.',
+    'response_message_not_implemented' => 'Mensagem de resposta não implementada para o status de inscrição: :status.',
 ];

--- a/app-modules/events/src/CheckIn/Actions/CheckInAction.php
+++ b/app-modules/events/src/CheckIn/Actions/CheckInAction.php
@@ -5,35 +5,26 @@ declare(strict_types=1);
 namespace He4rt\Events\CheckIn\Actions;
 
 use Carbon\CarbonInterface;
-use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\DTOs\CheckInDTO;
 use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
 use He4rt\Events\CheckIn\Exceptions\CheckInException;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Actions\TransitionEnrollmentAction;
+use He4rt\Events\Enrollment\DTOs\TransitionEnrollmentDTO;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
-use He4rt\Events\Enrollment\Enums\TriggeredBy;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
-final readonly class CheckInService
+final readonly class CheckInAction
 {
-    /**
-     * @param  array<string, mixed>  $payload
-     */
-    public function handle(
-        Enrollment $enrollment,
-        CheckInMethod $method,
-        array $payload,
-        CarbonInterface $eventDate,
-        string $actorUserId,
-        TriggeredBy $triggeredBy,
-    ): CheckIn {
-        return DB::transaction(function () use ($enrollment, $method, $payload, $eventDate, $actorUserId, $triggeredBy): CheckIn {
-            $enrollment = $this->loadLockedEnrollment($enrollment);
+    public function handle(CheckInDTO $dto): CheckIn
+    {
+        return DB::transaction(function () use ($dto): CheckIn {
+            $enrollment = $this->loadLockedEnrollment($dto->enrollment);
             $event = $enrollment->event;
-            $normalizedEventDate = Date::parse($eventDate->toDateString())->startOfDay();
+            $normalizedEventDate = Date::parse($dto->eventDate->toDateString())->startOfDay();
 
             $this->validateCommonRules($enrollment, $normalizedEventDate);
             $isFirstCheckIn = !CheckIn::query()
@@ -43,8 +34,8 @@ final readonly class CheckInService
             try {
                 $checkIn = CheckIn::query()->create([
                     'enrollment_id' => $enrollment->id,
-                    'method' => $method,
-                    'payload' => $payload,
+                    'method' => $dto->method,
+                    'payload' => $dto->payload,
                     'event_date' => $normalizedEventDate,
                     'checked_in_at' => now(),
                 ]);
@@ -54,11 +45,13 @@ final readonly class CheckInService
 
             if ($isFirstCheckIn && $enrollment->status === EnrollmentStatus::Confirmed) {
                 resolve(TransitionEnrollmentAction::class)->handle(
-                    enrollment: $enrollment,
-                    toStatus: EnrollmentStatus::CheckedIn,
-                    triggeredBy: $triggeredBy,
-                    actorId: $actorUserId,
-                    timestamp: $checkIn->checked_in_at,
+                    new TransitionEnrollmentDTO(
+                        enrollment: $enrollment,
+                        toStatus: EnrollmentStatus::CheckedIn,
+                        triggeredBy: $dto->triggeredBy,
+                        actorId: $dto->actorUserId,
+                        timestamp: $checkIn->checked_in_at,
+                    ),
                 );
             }
 

--- a/app-modules/events/src/CheckIn/Actions/CheckInAction.php
+++ b/app-modules/events/src/CheckIn/Actions/CheckInAction.php
@@ -7,12 +7,12 @@ namespace He4rt\Events\CheckIn\Actions;
 use Carbon\CarbonInterface;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
+use He4rt\Events\CheckIn\Exceptions\CheckInException;
 use He4rt\Events\CheckIn\Models\CheckIn;
+use He4rt\Events\Enrollment\Actions\TransitionEnrollmentAction;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Enums\TriggeredBy;
-use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
-use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
@@ -48,11 +48,17 @@ final readonly class CheckInAction
                     'checked_in_at' => now(),
                 ]);
             } catch (UniqueConstraintViolationException) {
-                throw EnrollmentException::alreadyCheckedInForDate();
+                throw CheckInException::alreadyCheckedInForDate();
             }
 
             if ($isFirstCheckIn && $enrollment->status === EnrollmentStatus::Confirmed) {
-                $this->transitionToCheckedIn($enrollment, is_string($actorUserId) ? $actorUserId : null);
+                resolve(TransitionEnrollmentAction::class)->handle(
+                    enrollment: $enrollment,
+                    toStatus: EnrollmentStatus::CheckedIn,
+                    triggeredBy: TriggeredBy::Admin,
+                    actorId: is_string($actorUserId) ? $actorUserId : null,
+                    timestamp: $checkIn->checked_in_at,
+                );
             }
 
             $xpRewardOnCheckedIn = (int) ($event->enrollmentPolicy->xp_on_checked_in ?? 0);
@@ -86,12 +92,12 @@ final readonly class CheckInAction
     {
         throw_if(
             $method === CheckInMethod::Manual && blank($payload['actor_user_id'] ?? null),
-            EnrollmentException::invalidCheckInActor(),
+            CheckInException::invalidCheckInActor(),
         );
 
         throw_unless(
             in_array($enrollment->status, [EnrollmentStatus::Confirmed, EnrollmentStatus::CheckedIn], strict: true),
-            EnrollmentException::invalidCheckInStatus(),
+            CheckInException::invalidCheckInStatus(),
         );
 
         $event = $enrollment->event;
@@ -99,7 +105,7 @@ final readonly class CheckInAction
 
         throw_unless(
             $eventDateString >= $event->starts_at->toDateString() && $eventDateString <= $event->ends_at->toDateString(),
-            EnrollmentException::checkInOutsideEventDateRange(),
+            CheckInException::checkInOutsideEventDateRange(),
         );
 
         throw_if(
@@ -107,30 +113,7 @@ final readonly class CheckInAction
                 ->where('enrollment_id', $enrollment->id)
                 ->whereDate('event_date', $eventDate->toDateString())
                 ->exists(),
-            EnrollmentException::alreadyCheckedInForDate(),
+            CheckInException::alreadyCheckedInForDate(),
         );
-    }
-
-    private function transitionToCheckedIn(Enrollment $enrollment, ?string $actorUserId): void
-    {
-        $fromStatus = $enrollment->status;
-
-        throw_unless(
-            $fromStatus->canTransitionTo(EnrollmentStatus::CheckedIn),
-            EnrollmentException::invalidCheckInStatus(),
-        );
-
-        $enrollment->forceFill([
-            'status' => EnrollmentStatus::CheckedIn,
-            'checked_in_at' => now(),
-        ])->save();
-
-        EnrollmentTransition::query()->create([
-            'enrollment_id' => $enrollment->id,
-            'from_status' => $fromStatus,
-            'to_status' => EnrollmentStatus::CheckedIn,
-            'actor_id' => $actorUserId,
-            'triggered_by' => TriggeredBy::Admin,
-        ]);
     }
 }

--- a/app-modules/events/src/CheckIn/Actions/CheckInAction.php
+++ b/app-modules/events/src/CheckIn/Actions/CheckInAction.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Actions;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
+use He4rt\Events\CheckIn\Models\CheckIn;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+use Illuminate\Database\UniqueConstraintViolationException;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+final readonly class CheckInAction
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function handle(
+        Enrollment $enrollment,
+        CheckInMethod $method,
+        array $payload,
+        CarbonInterface $eventDate,
+    ): CheckIn {
+        return DB::transaction(function () use ($enrollment, $method, $payload, $eventDate): CheckIn {
+            $enrollment = $this->loadLockedEnrollment($enrollment);
+            $event = $enrollment->event;
+            $normalizedEventDate = Date::parse($eventDate->toDateString())->startOfDay();
+            $actorUserId = $payload['actor_user_id'] ?? null;
+
+            $this->validate($enrollment, $method, $payload, $normalizedEventDate);
+            $isFirstCheckIn = !CheckIn::query()
+                ->where('enrollment_id', $enrollment->id)
+                ->exists();
+
+            try {
+                $checkIn = CheckIn::query()->create([
+                    'enrollment_id' => $enrollment->id,
+                    'method' => $method,
+                    'payload' => $payload,
+                    'event_date' => $normalizedEventDate,
+                    'checked_in_at' => now(),
+                ]);
+            } catch (UniqueConstraintViolationException) {
+                throw EnrollmentException::alreadyCheckedInForDate();
+            }
+
+            if ($isFirstCheckIn && $enrollment->status === EnrollmentStatus::Confirmed) {
+                $this->transitionToCheckedIn($enrollment, is_string($actorUserId) ? $actorUserId : null);
+            }
+
+            $xpRewardOnCheckedIn = (int) ($event->enrollmentPolicy->xp_on_checked_in ?? 0);
+
+            event(new ParticipantCheckedIn(
+                checkInId: $checkIn->id,
+                enrollmentId: $enrollment->id,
+                eventId: $enrollment->event_id,
+                userId: $enrollment->user_id,
+                eventDate: $normalizedEventDate->toDateString(),
+                xpRewardOnCheckedIn: $xpRewardOnCheckedIn,
+            ));
+
+            return $checkIn->load('enrollment');
+        });
+    }
+
+    private function loadLockedEnrollment(Enrollment $enrollment): Enrollment
+    {
+        return Enrollment::query()
+            ->with(['event.enrollmentPolicy'])
+            ->whereKey($enrollment->id)
+            ->lockForUpdate()
+            ->firstOrFail();
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function validate(Enrollment $enrollment, CheckInMethod $method, array $payload, CarbonInterface $eventDate): void
+    {
+        throw_if(
+            $method === CheckInMethod::Manual && blank($payload['actor_user_id'] ?? null),
+            EnrollmentException::invalidCheckInActor(),
+        );
+
+        throw_unless(
+            in_array($enrollment->status, [EnrollmentStatus::Confirmed, EnrollmentStatus::CheckedIn], strict: true),
+            EnrollmentException::invalidCheckInStatus(),
+        );
+
+        $event = $enrollment->event;
+        $eventDateString = $eventDate->toDateString();
+
+        throw_unless(
+            $eventDateString >= $event->starts_at->toDateString() && $eventDateString <= $event->ends_at->toDateString(),
+            EnrollmentException::checkInOutsideEventDateRange(),
+        );
+
+        throw_if(
+            CheckIn::query()
+                ->where('enrollment_id', $enrollment->id)
+                ->whereDate('event_date', $eventDate->toDateString())
+                ->exists(),
+            EnrollmentException::alreadyCheckedInForDate(),
+        );
+    }
+
+    private function transitionToCheckedIn(Enrollment $enrollment, ?string $actorUserId): void
+    {
+        $fromStatus = $enrollment->status;
+
+        throw_unless(
+            $fromStatus->canTransitionTo(EnrollmentStatus::CheckedIn),
+            EnrollmentException::invalidCheckInStatus(),
+        );
+
+        $enrollment->forceFill([
+            'status' => EnrollmentStatus::CheckedIn,
+            'checked_in_at' => now(),
+        ])->save();
+
+        EnrollmentTransition::query()->create([
+            'enrollment_id' => $enrollment->id,
+            'from_status' => $fromStatus,
+            'to_status' => EnrollmentStatus::CheckedIn,
+            'actor_id' => $actorUserId,
+            'triggered_by' => TriggeredBy::Admin,
+        ]);
+    }
+}

--- a/app-modules/events/src/CheckIn/Actions/CheckInService.php
+++ b/app-modules/events/src/CheckIn/Actions/CheckInService.php
@@ -17,7 +17,7 @@ use Illuminate\Database\UniqueConstraintViolationException;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 
-final readonly class CheckInAction
+final readonly class CheckInService
 {
     /**
      * @param  array<string, mixed>  $payload
@@ -27,14 +27,15 @@ final readonly class CheckInAction
         CheckInMethod $method,
         array $payload,
         CarbonInterface $eventDate,
+        string $actorUserId,
+        TriggeredBy $triggeredBy,
     ): CheckIn {
-        return DB::transaction(function () use ($enrollment, $method, $payload, $eventDate): CheckIn {
+        return DB::transaction(function () use ($enrollment, $method, $payload, $eventDate, $actorUserId, $triggeredBy): CheckIn {
             $enrollment = $this->loadLockedEnrollment($enrollment);
             $event = $enrollment->event;
             $normalizedEventDate = Date::parse($eventDate->toDateString())->startOfDay();
-            $actorUserId = $payload['actor_user_id'] ?? null;
 
-            $this->validate($enrollment, $method, $payload, $normalizedEventDate);
+            $this->validateCommonRules($enrollment, $normalizedEventDate);
             $isFirstCheckIn = !CheckIn::query()
                 ->where('enrollment_id', $enrollment->id)
                 ->exists();
@@ -55,8 +56,8 @@ final readonly class CheckInAction
                 resolve(TransitionEnrollmentAction::class)->handle(
                     enrollment: $enrollment,
                     toStatus: EnrollmentStatus::CheckedIn,
-                    triggeredBy: TriggeredBy::Admin,
-                    actorId: is_string($actorUserId) ? $actorUserId : null,
+                    triggeredBy: $triggeredBy,
+                    actorId: $actorUserId,
                     timestamp: $checkIn->checked_in_at,
                 );
             }
@@ -85,16 +86,8 @@ final readonly class CheckInAction
             ->firstOrFail();
     }
 
-    /**
-     * @param  array<string, mixed>  $payload
-     */
-    private function validate(Enrollment $enrollment, CheckInMethod $method, array $payload, CarbonInterface $eventDate): void
+    private function validateCommonRules(Enrollment $enrollment, CarbonInterface $eventDate): void
     {
-        throw_if(
-            $method === CheckInMethod::Manual && blank($payload['actor_user_id'] ?? null),
-            CheckInException::invalidCheckInActor(),
-        );
-
         throw_unless(
             in_array($enrollment->status, [EnrollmentStatus::Confirmed, EnrollmentStatus::CheckedIn], strict: true),
             CheckInException::invalidCheckInStatus(),

--- a/app-modules/events/src/CheckIn/Actions/ManualCheckInAction.php
+++ b/app-modules/events/src/CheckIn/Actions/ManualCheckInAction.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Actions;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Exceptions\CheckInException;
+use He4rt\Events\CheckIn\Models\CheckIn;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Models\Enrollment;
+
+final readonly class ManualCheckInAction
+{
+    public function handle(
+        Enrollment $enrollment,
+        string $actorUserId,
+        CarbonInterface $eventDate,
+    ): CheckIn {
+        throw_if(
+            blank($actorUserId),
+            CheckInException::invalidCheckInActor(),
+        );
+
+        return resolve(CheckInService::class)->handle(
+            enrollment: $enrollment,
+            method: CheckInMethod::Manual,
+            payload: ['actor_user_id' => $actorUserId],
+            eventDate: $eventDate,
+            actorUserId: $actorUserId,
+            triggeredBy: TriggeredBy::Admin,
+        );
+    }
+}

--- a/app-modules/events/src/CheckIn/Actions/ManualCheckInAction.php
+++ b/app-modules/events/src/CheckIn/Actions/ManualCheckInAction.php
@@ -4,32 +4,25 @@ declare(strict_types=1);
 
 namespace He4rt\Events\CheckIn\Actions;
 
-use Carbon\CarbonInterface;
+use He4rt\Events\CheckIn\DTOs\CheckInDTO;
+use He4rt\Events\CheckIn\DTOs\ManualCheckInDTO;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
-use He4rt\Events\CheckIn\Exceptions\CheckInException;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\TriggeredBy;
-use He4rt\Events\Enrollment\Models\Enrollment;
 
 final readonly class ManualCheckInAction
 {
-    public function handle(
-        Enrollment $enrollment,
-        string $actorUserId,
-        CarbonInterface $eventDate,
-    ): CheckIn {
-        throw_if(
-            blank($actorUserId),
-            CheckInException::invalidCheckInActor(),
-        );
-
-        return resolve(CheckInService::class)->handle(
-            enrollment: $enrollment,
-            method: CheckInMethod::Manual,
-            payload: ['actor_user_id' => $actorUserId],
-            eventDate: $eventDate,
-            actorUserId: $actorUserId,
-            triggeredBy: TriggeredBy::Admin,
+    public function handle(ManualCheckInDTO $dto): CheckIn
+    {
+        return resolve(CheckInAction::class)->handle(
+            new CheckInDTO(
+                enrollment: $dto->enrollment,
+                method: CheckInMethod::Manual,
+                payload: ['actor_user_id' => $dto->actorUserId],
+                eventDate: $dto->eventDate,
+                actorUserId: $dto->actorUserId,
+                triggeredBy: TriggeredBy::Admin,
+            ),
         );
     }
 }

--- a/app-modules/events/src/CheckIn/DTOs/CheckInDTO.php
+++ b/app-modules/events/src/CheckIn/DTOs/CheckInDTO.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\DTOs;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Models\Enrollment;
+
+final readonly class CheckInDTO
+{
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    public function __construct(
+        public Enrollment $enrollment,
+        public CheckInMethod $method,
+        public array $payload,
+        public CarbonInterface $eventDate,
+        public string $actorUserId,
+        public TriggeredBy $triggeredBy,
+    ) {}
+}

--- a/app-modules/events/src/CheckIn/DTOs/ManualCheckInDTO.php
+++ b/app-modules/events/src/CheckIn/DTOs/ManualCheckInDTO.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\DTOs;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\CheckIn\Exceptions\CheckInException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+
+final readonly class ManualCheckInDTO
+{
+    public function __construct(
+        public Enrollment $enrollment,
+        public string $actorUserId,
+        public CarbonInterface $eventDate,
+    ) {
+        throw_if(blank($this->actorUserId), CheckInException::invalidCheckInActor());
+    }
+}

--- a/app-modules/events/src/CheckIn/Events/ParticipantCheckedIn.php
+++ b/app-modules/events/src/CheckIn/Events/ParticipantCheckedIn.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Events;
+
+use Illuminate\Contracts\Events\ShouldDispatchAfterCommit;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class ParticipantCheckedIn implements ShouldDispatchAfterCommit
+{
+    use Dispatchable;
+
+    public function __construct(
+        public string $checkInId,
+        public string $enrollmentId,
+        public string $eventId,
+        public string $userId,
+        public string $eventDate,
+        public int $xpRewardOnCheckedIn,
+    ) {}
+}

--- a/app-modules/events/src/CheckIn/Exceptions/CheckInException.php
+++ b/app-modules/events/src/CheckIn/Exceptions/CheckInException.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Exceptions;
+
+use Exception;
+use Symfony\Component\HttpFoundation\Response;
+
+final class CheckInException extends Exception
+{
+    public static function invalidCheckInStatus(): self
+    {
+        return new self(
+            __('events::check_in.invalid_check_in_status'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function checkInOutsideEventDateRange(): self
+    {
+        return new self(
+            __('events::check_in.check_in_outside_event_date_range'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function alreadyCheckedInForDate(): self
+    {
+        return new self(
+            __('events::check_in.already_checked_in_for_date'),
+            Response::HTTP_CONFLICT,
+        );
+    }
+
+    public static function invalidCheckInActor(): self
+    {
+        return new self(
+            __('events::check_in.invalid_check_in_actor'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+}

--- a/app-modules/events/src/CheckIn/Models/CheckIn.php
+++ b/app-modules/events/src/CheckIn/Models/CheckIn.php
@@ -20,6 +20,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property Carbon $event_date
  * @property CheckInMethod $method
  * @property array<string, mixed>|null $payload
+ * @property Carbon $checked_in_at
  * @property Carbon $created_at
  * @property Carbon $updated_at
  */
@@ -35,6 +36,7 @@ final class CheckIn extends Model
         'event_date',
         'method',
         'payload',
+        'checked_in_at',
     ];
 
     /** @return BelongsTo<Enrollment, $this> */
@@ -55,6 +57,7 @@ final class CheckIn extends Model
             'event_date' => 'date',
             'method' => CheckInMethod::class,
             'payload' => 'array',
+            'checked_in_at' => 'datetime',
         ];
     }
 }

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -53,7 +53,7 @@ final readonly class EnrollUserAction
                         enrollmentId: $enrollment->id,
                         eventId: $dto->eventId,
                         userId: $dto->userId,
-                        xpRewardOnConfirmed: $policy?->xp_on_confirmed ?? 0,
+                        xpRewardOnConfirmed: $policy->xp_on_confirmed ?? 0,
                     ));
                 }
 

--- a/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
+++ b/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\Actions;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+
+final readonly class TransitionEnrollmentAction
+{
+    private const array TIMESTAMP_MAP = [
+        'confirmed' => 'confirmed_at',
+        'checked_in' => 'checked_in_at',
+        'attended' => 'attended_at',
+        'cancelled' => 'cancelled_at',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function handle(
+        Enrollment $enrollment,
+        EnrollmentStatus $toStatus,
+        TriggeredBy $triggeredBy,
+        ?string $actorId = null,
+        ?string $reason = null,
+        array $metadata = [],
+        ?CarbonInterface $timestamp = null,
+    ): EnrollmentTransition {
+        $fromStatus = $enrollment->status;
+
+        throw_unless(
+            $fromStatus->canTransitionTo($toStatus),
+            EnrollmentException::invalidTransition($fromStatus, $toStatus),
+        );
+
+        $timestampColumn = $this->resolveTimestampColumn($toStatus);
+
+        $enrollment->forceFill([
+            'status' => $toStatus,
+            $timestampColumn => $timestamp ?? now(),
+        ])->save();
+
+        return EnrollmentTransition::query()->create([
+            'enrollment_id' => $enrollment->id,
+            'from_status' => $fromStatus,
+            'to_status' => $toStatus,
+            'actor_id' => $actorId,
+            'triggered_by' => $triggeredBy,
+            'reason' => $reason,
+            'metadata' => $metadata ?: null,
+        ]);
+    }
+
+    private function resolveTimestampColumn(EnrollmentStatus $status): ?string
+    {
+        return self::TIMESTAMP_MAP[$status->value] ?? null;
+    }
+}

--- a/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
+++ b/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
@@ -4,61 +4,37 @@ declare(strict_types=1);
 
 namespace He4rt\Events\Enrollment\Actions;
 
-use Carbon\CarbonInterface;
-use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
-use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\DTOs\TransitionEnrollmentDTO;
 use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
-use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 
 final readonly class TransitionEnrollmentAction
 {
-    private const array TIMESTAMP_MAP = [
-        'confirmed' => 'confirmed_at',
-        'checked_in' => 'checked_in_at',
-        'attended' => 'attended_at',
-        'cancelled' => 'cancelled_at',
-    ];
-
-    /**
-     * @param  array<string, mixed>  $metadata
-     */
-    public function handle(
-        Enrollment $enrollment,
-        EnrollmentStatus $toStatus,
-        TriggeredBy $triggeredBy,
-        ?string $actorId = null,
-        ?string $reason = null,
-        array $metadata = [],
-        ?CarbonInterface $timestamp = null,
-    ): EnrollmentTransition {
-        $fromStatus = $enrollment->status;
+    public function handle(TransitionEnrollmentDTO $dto): EnrollmentTransition
+    {
+        $fromStatus = $dto->enrollment->status;
+        $toStatus = $dto->toStatus;
 
         throw_unless(
             $fromStatus->canTransitionTo($toStatus),
             EnrollmentException::invalidTransition($fromStatus, $toStatus),
         );
 
-        $timestampColumn = $this->resolveTimestampColumn($toStatus);
+        $timestampColumn = $toStatus->timestampColumn();
 
-        $enrollment->forceFill([
+        $dto->enrollment->forceFill([
             'status' => $toStatus,
-            $timestampColumn => $timestamp ?? now(),
+            $timestampColumn => $dto->timestamp ?? now(),
         ])->save();
 
         return EnrollmentTransition::query()->create([
-            'enrollment_id' => $enrollment->id,
+            'enrollment_id' => $dto->enrollment->id,
             'from_status' => $fromStatus,
             'to_status' => $toStatus,
-            'actor_id' => $actorId,
-            'triggered_by' => $triggeredBy,
-            'reason' => $reason,
-            'metadata' => $metadata ?: null,
+            'actor_id' => $dto->actorId,
+            'triggered_by' => $dto->triggeredBy,
+            'reason' => $dto->reason,
+            'metadata' => $dto->metadata ?: null,
         ]);
-    }
-
-    private function resolveTimestampColumn(EnrollmentStatus $status): ?string
-    {
-        return self::TIMESTAMP_MAP[$status->value] ?? null;
     }
 }

--- a/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
+++ b/app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php
@@ -20,12 +20,15 @@ final readonly class TransitionEnrollmentAction
             EnrollmentException::invalidTransition($fromStatus, $toStatus),
         );
 
-        $timestampColumn = $toStatus->timestampColumn();
-
-        $dto->enrollment->forceFill([
+        $attributes = [
             'status' => $toStatus,
-            $timestampColumn => $dto->timestamp ?? now(),
-        ])->save();
+        ];
+
+        if ($timestampColumn = $toStatus->timestampColumn()) {
+            $attributes[$timestampColumn] = $dto->timestamp ?? now();
+        }
+
+        $dto->enrollment->update($attributes);
 
         return EnrollmentTransition::query()->create([
             'enrollment_id' => $dto->enrollment->id,

--- a/app-modules/events/src/Enrollment/DTOs/TransitionEnrollmentDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/TransitionEnrollmentDTO.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\Enrollment\DTOs;
+
+use Carbon\CarbonInterface;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Models\Enrollment;
+
+final readonly class TransitionEnrollmentDTO
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function __construct(
+        public Enrollment $enrollment,
+        public EnrollmentStatus $toStatus,
+        public TriggeredBy $triggeredBy,
+        public ?string $actorId = null,
+        public ?string $reason = null,
+        public array $metadata = [],
+        public ?CarbonInterface $timestamp = null,
+    ) {}
+}

--- a/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
+++ b/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
@@ -9,6 +9,7 @@ use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
 use Filament\Support\Contracts\HasLabel;
 use Filament\Support\Icons\Heroicon;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 
 enum EnrollmentStatus: string implements HasColor, HasIcon, HasLabel
 {
@@ -98,7 +99,7 @@ enum EnrollmentStatus: string implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Confirmed => __('events::pages.confirm_presence_success'),
             self::Waitlisted => __('events::pages.waitlist_success'),
-            default => '',
+            default => throw EnrollmentException::responseMessageNotImplemented($this),
         };
     }
 }

--- a/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
+++ b/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
@@ -65,6 +65,14 @@ enum EnrollmentStatus: string implements HasColor, HasIcon, HasLabel
         };
     }
 
+    public function timestampColumn(): ?string
+    {
+        return match ($this) {
+            self::Confirmed, self::CheckedIn, self::Attended, self::Cancelled => $this->value.'_at',
+            default => null,
+        };
+    }
+
     public function isTerminal(): bool
     {
         return in_array($this, [self::Attended, self::Cancelled, self::Rejected, self::NoShow], strict: true);

--- a/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
+++ b/app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php
@@ -90,6 +90,7 @@ enum EnrollmentStatus: string implements HasColor, HasIcon, HasLabel
         return match ($this) {
             self::Confirmed => __('events::pages.confirm_presence_success'),
             self::Waitlisted => __('events::pages.waitlist_success'),
+            default => '',
         };
     }
 }

--- a/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
+++ b/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
@@ -57,4 +57,12 @@ final class EnrollmentException extends Exception
             Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
+
+    public static function responseMessageNotImplemented(EnrollmentStatus $status): self
+    {
+        return new self(
+            __('events::exceptions.response_message_not_implemented', ['status' => $status->value]),
+            Response::HTTP_INTERNAL_SERVER_ERROR,
+        );
+    }
 }

--- a/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
+++ b/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
@@ -5,10 +5,19 @@ declare(strict_types=1);
 namespace He4rt\Events\Enrollment\Exceptions;
 
 use Exception;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use Symfony\Component\HttpFoundation\Response;
 
 final class EnrollmentException extends Exception
 {
+    public static function invalidTransition(EnrollmentStatus $from, EnrollmentStatus $to): self
+    {
+        return new self(
+            __('events::exceptions.invalid_transition', ['from' => $from->value, 'to' => $to->value]),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
     public static function alreadyEnrolled(): self
     {
         return new self(
@@ -45,38 +54,6 @@ final class EnrollmentException extends Exception
     {
         return new self(
             __('events::exceptions.event_full'),
-            Response::HTTP_UNPROCESSABLE_ENTITY,
-        );
-    }
-
-    public static function invalidCheckInStatus(): self
-    {
-        return new self(
-            __('events::exceptions.invalid_check_in_status'),
-            Response::HTTP_UNPROCESSABLE_ENTITY,
-        );
-    }
-
-    public static function checkInOutsideEventDateRange(): self
-    {
-        return new self(
-            __('events::exceptions.check_in_outside_event_date_range'),
-            Response::HTTP_UNPROCESSABLE_ENTITY,
-        );
-    }
-
-    public static function alreadyCheckedInForDate(): self
-    {
-        return new self(
-            __('events::exceptions.already_checked_in_for_date'),
-            Response::HTTP_CONFLICT,
-        );
-    }
-
-    public static function invalidCheckInActor(): self
-    {
-        return new self(
-            __('events::exceptions.invalid_check_in_actor'),
             Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }

--- a/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
+++ b/app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php
@@ -48,4 +48,36 @@ final class EnrollmentException extends Exception
             Response::HTTP_UNPROCESSABLE_ENTITY,
         );
     }
+
+    public static function invalidCheckInStatus(): self
+    {
+        return new self(
+            __('events::exceptions.invalid_check_in_status'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function checkInOutsideEventDateRange(): self
+    {
+        return new self(
+            __('events::exceptions.check_in_outside_event_date_range'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
+
+    public static function alreadyCheckedInForDate(): self
+    {
+        return new self(
+            __('events::exceptions.already_checked_in_for_date'),
+            Response::HTTP_CONFLICT,
+        );
+    }
+
+    public static function invalidCheckInActor(): self
+    {
+        return new self(
+            __('events::exceptions.invalid_check_in_actor'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
 }

--- a/app-modules/events/src/Enrollment/Models/Enrollment.php
+++ b/app-modules/events/src/Enrollment/Models/Enrollment.php
@@ -97,16 +97,19 @@ final class Enrollment extends Model
         return EnrollmentFactory::new();
     }
 
+    /** @param  Builder<Enrollment>  $query */
     protected function scopeConfirmed(Builder $query): void
     {
         $query->where('status', EnrollmentStatus::Confirmed);
     }
 
+    /** @param  Builder<Enrollment>  $query */
     protected function scopeWaitlisted(Builder $query): void
     {
         $query->where('status', EnrollmentStatus::Waitlisted);
     }
 
+    /** @param  Builder<Enrollment>  $query */
     protected function scopeActive(Builder $query): void
     {
         $query->whereNotIn('status', [

--- a/app-modules/events/src/Event/Models/Event.php
+++ b/app-modules/events/src/Event/Models/Event.php
@@ -97,25 +97,25 @@ final class Event extends Model
         return EventFactory::new();
     }
 
-    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
+    /** @param  Builder<self>  $query */
     protected function scopePublished(Builder $query): void
     {
         $query->where('status', EventStatus::Published);
     }
 
-    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
+    /** @param  Builder<self>  $query */
     protected function scopeViewableByParticipant(Builder $query): void
     {
         $query->whereIn('status', EventStatus::viewableByParticipant());
     }
 
-    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
+    /** @param  Builder<self>  $query */
     protected function scopeUpcoming(Builder $query): void
     {
         $query->where('starts_at', '>', now());
     }
 
-    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
+    /** @param  Builder<self>  $query */
     protected function scopeActive(Builder $query): void
     {
         $query->where('status', EventStatus::Published)

--- a/app-modules/events/src/Event/Models/Event.php
+++ b/app-modules/events/src/Event/Models/Event.php
@@ -97,21 +97,25 @@ final class Event extends Model
         return EventFactory::new();
     }
 
+    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
     protected function scopePublished(Builder $query): void
     {
         $query->where('status', EventStatus::Published);
     }
 
+    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
     protected function scopeViewableByParticipant(Builder $query): void
     {
         $query->whereIn('status', EventStatus::viewableByParticipant());
     }
 
+    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
     protected function scopeUpcoming(Builder $query): void
     {
         $query->where('starts_at', '>', now());
     }
 
+    /** @param Builder<\Illuminate\Support\Facades\Event> $query */
     protected function scopeActive(Builder $query): void
     {
         $query->where('status', EventStatus::Published)

--- a/app-modules/events/tests/Feature/CheckInActionTest.php
+++ b/app-modules/events/tests/Feature/CheckInActionTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use He4rt\Events\CheckIn\Actions\ManualCheckInAction;
+use He4rt\Events\CheckIn\DTOs\ManualCheckInDTO;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
 use He4rt\Events\CheckIn\Exceptions\CheckInException;
@@ -46,9 +47,11 @@ test('when organizer checks in confirmed enrollment, then check-in is recorded a
     $enrollment = createConfirmedEnrollmentForCheckIn();
 
     $checkIn = resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: $organizer->id,
-        eventDate: now(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: $organizer->id,
+            eventDate: now(),
+        ),
     );
 
     expect($checkIn)->toBeInstanceOf(CheckIn::class)
@@ -94,9 +97,11 @@ test('when checked-in enrollment checks in on another event date, then only chec
     ]);
 
     $checkIn = resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: $organizer->id,
-        eventDate: $startsAt->clone()->addDay(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: $organizer->id,
+            eventDate: $startsAt->clone()->addDay(),
+        ),
     );
 
     expect($checkIn->event_date->isSameDay($startsAt->clone()->addDay()))->toBeTrue()
@@ -117,9 +122,11 @@ test('when enrollment already has check-in for event date, then duplicate is rej
     ]);
 
     expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: User::factory()->create()->id,
-        eventDate: now(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: User::factory()->create()->id,
+            eventDate: now(),
+        ),
     ))->toThrow(CheckInException::class);
 });
 
@@ -131,9 +138,11 @@ test('when check-in date is outside event date range, then check-in is rejected'
     ]);
 
     expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: User::factory()->create()->id,
-        eventDate: $startsAt->clone()->addDay(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: User::factory()->create()->id,
+            eventDate: $startsAt->clone()->addDay(),
+        ),
     ))->toThrow(CheckInException::class);
 });
 
@@ -144,9 +153,11 @@ test('when enrollment status is not confirmed or checked in, then check-in is re
     ]);
 
     expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: User::factory()->create()->id,
-        eventDate: now(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: User::factory()->create()->id,
+            eventDate: now(),
+        ),
     ))->toThrow(CheckInException::class);
 });
 
@@ -154,8 +165,10 @@ test('when manual check-in has no actor user id, then check-in is rejected', fun
     $enrollment = createConfirmedEnrollmentForCheckIn();
 
     expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
-        enrollment: $enrollment,
-        actorUserId: '',
-        eventDate: now(),
+        new ManualCheckInDTO(
+            enrollment: $enrollment,
+            actorUserId: '',
+            eventDate: now(),
+        ),
     ))->toThrow(CheckInException::class);
 });

--- a/app-modules/events/tests/Feature/CheckInActionTest.php
+++ b/app-modules/events/tests/Feature/CheckInActionTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Events\CheckIn\Actions\CheckInAction;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
+use He4rt\Events\CheckIn\Models\CheckIn;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Enums\TriggeredBy;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Enrollment\Models\EnrollmentTransition;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Event as EventFacade;
+
+function createConfirmedEnrollmentForCheckIn(array $eventAttributes = [], array $enrollmentAttributes = []): Enrollment
+{
+    $tenant = Tenant::factory()->create();
+    $participant = User::factory()->create();
+    $startsAt = now()->setTime(9, 0);
+
+    $event = Event::factory()
+        ->for($tenant)
+        ->create(array_merge([
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->setTime(18, 0),
+            'status' => EventStatus::Published,
+        ], $eventAttributes));
+
+    return Enrollment::factory()->create(array_merge([
+        'event_id' => $event->id,
+        'user_id' => $participant->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ], $enrollmentAttributes));
+}
+
+test('when organizer checks in confirmed enrollment, then check-in is recorded and enrollment transitions', function (): void {
+    EventFacade::fake([ParticipantCheckedIn::class]);
+
+    $organizer = User::factory()->create();
+    $enrollment = createConfirmedEnrollmentForCheckIn();
+
+    $checkIn = resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: ['actor_user_id' => $organizer->id],
+        eventDate: now(),
+    );
+
+    expect($checkIn)->toBeInstanceOf(CheckIn::class)
+        ->and($checkIn->enrollment_id)->toBe($enrollment->id)
+        ->and($checkIn->method)->toBe(CheckInMethod::Manual)
+        ->and($checkIn->event_date->isSameDay(now()))->toBeTrue()
+        ->and($checkIn->checked_in_at)->not->toBeNull()
+        ->and($checkIn->payload)->toBe(['actor_user_id' => $organizer->id])
+        ->and($enrollment->fresh()->status)->toBe(EnrollmentStatus::CheckedIn)
+        ->and($enrollment->fresh()->checked_in_at)->not->toBeNull();
+
+    $transition = EnrollmentTransition::query()
+        ->where('enrollment_id', $enrollment->id)
+        ->where('to_status', EnrollmentStatus::CheckedIn)
+        ->first();
+
+    expect($transition)->not->toBeNull()
+        ->and($transition->from_status)->toBe(EnrollmentStatus::Confirmed)
+        ->and($transition->actor_id)->toBe($organizer->id)
+        ->and($transition->triggered_by)->toBe(TriggeredBy::Admin);
+
+    EventFacade::assertDispatched(fn (ParticipantCheckedIn $event): bool => $event->enrollmentId === $enrollment->id
+        && $event->eventId === $enrollment->event_id
+        && $event->userId === $enrollment->user_id
+        && $event->checkInId === $checkIn->id);
+});
+
+test('when checked-in enrollment checks in on another event date, then only check-in record is created', function (): void {
+    $organizer = User::factory()->create();
+    $startsAt = now()->setTime(9, 0);
+    $enrollment = createConfirmedEnrollmentForCheckIn([
+        'starts_at' => $startsAt,
+        'ends_at' => $startsAt->clone()->addDay()->setTime(18, 0),
+    ], [
+        'status' => EnrollmentStatus::CheckedIn,
+        'checked_in_at' => now(),
+    ]);
+
+    CheckIn::factory()->create([
+        'enrollment_id' => $enrollment->id,
+        'event_date' => $startsAt->toDateString(),
+        'method' => CheckInMethod::Manual,
+    ]);
+
+    $checkIn = resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: ['actor_user_id' => $organizer->id],
+        eventDate: $startsAt->clone()->addDay(),
+    );
+
+    expect($checkIn->event_date->isSameDay($startsAt->clone()->addDay()))->toBeTrue()
+        ->and(CheckIn::query()->where('enrollment_id', $enrollment->id)->count())->toBe(2)
+        ->and(EnrollmentTransition::query()
+            ->where('enrollment_id', $enrollment->id)
+            ->where('to_status', EnrollmentStatus::CheckedIn)
+            ->count())->toBe(0);
+});
+
+test('when enrollment already has check-in for event date, then duplicate is rejected', function (): void {
+    $enrollment = createConfirmedEnrollmentForCheckIn();
+
+    CheckIn::factory()->create([
+        'enrollment_id' => $enrollment->id,
+        'event_date' => now()->toDateString(),
+        'method' => CheckInMethod::Manual,
+    ]);
+
+    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: ['actor_user_id' => User::factory()->create()->id],
+        eventDate: now(),
+    ))->toThrow(EnrollmentException::class);
+});
+
+test('when check-in date is outside event date range, then check-in is rejected', function (): void {
+    $startsAt = now()->setTime(9, 0);
+    $enrollment = createConfirmedEnrollmentForCheckIn([
+        'starts_at' => $startsAt,
+        'ends_at' => $startsAt->clone()->setTime(18, 0),
+    ]);
+
+    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: ['actor_user_id' => User::factory()->create()->id],
+        eventDate: $startsAt->clone()->addDay(),
+    ))->toThrow(EnrollmentException::class);
+});
+
+test('when enrollment status is not confirmed or checked in, then check-in is rejected', function (): void {
+    $enrollment = createConfirmedEnrollmentForCheckIn(enrollmentAttributes: [
+        'status' => EnrollmentStatus::Waitlisted,
+        'confirmed_at' => null,
+    ]);
+
+    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: ['actor_user_id' => User::factory()->create()->id],
+        eventDate: now(),
+    ))->toThrow(EnrollmentException::class);
+});
+
+test('when manual check-in has no actor user id, then check-in is rejected', function (): void {
+    $enrollment = createConfirmedEnrollmentForCheckIn();
+
+    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+        enrollment: $enrollment,
+        method: CheckInMethod::Manual,
+        payload: [],
+        eventDate: now(),
+    ))->toThrow(EnrollmentException::class);
+});

--- a/app-modules/events/tests/Feature/CheckInActionTest.php
+++ b/app-modules/events/tests/Feature/CheckInActionTest.php
@@ -5,10 +5,10 @@ declare(strict_types=1);
 use He4rt\Events\CheckIn\Actions\CheckInAction;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
+use He4rt\Events\CheckIn\Exceptions\CheckInException;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Enums\TriggeredBy;
-use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentTransition;
 use He4rt\Events\Event\Enums\EventStatus;
@@ -85,13 +85,13 @@ test('when checked-in enrollment checks in on another event date, then only chec
         'ends_at' => $startsAt->clone()->addDay()->setTime(18, 0),
     ], [
         'status' => EnrollmentStatus::CheckedIn,
-        'checked_in_at' => now(),
     ]);
 
     CheckIn::factory()->create([
         'enrollment_id' => $enrollment->id,
         'event_date' => $startsAt->toDateString(),
         'method' => CheckInMethod::Manual,
+        'checked_in_at' => now(),
     ]);
 
     $checkIn = resolve(CheckInAction::class)->handle(
@@ -123,7 +123,7 @@ test('when enrollment already has check-in for event date, then duplicate is rej
         method: CheckInMethod::Manual,
         payload: ['actor_user_id' => User::factory()->create()->id],
         eventDate: now(),
-    ))->toThrow(EnrollmentException::class);
+    ))->toThrow(CheckInException::class);
 });
 
 test('when check-in date is outside event date range, then check-in is rejected', function (): void {
@@ -138,7 +138,7 @@ test('when check-in date is outside event date range, then check-in is rejected'
         method: CheckInMethod::Manual,
         payload: ['actor_user_id' => User::factory()->create()->id],
         eventDate: $startsAt->clone()->addDay(),
-    ))->toThrow(EnrollmentException::class);
+    ))->toThrow(CheckInException::class);
 });
 
 test('when enrollment status is not confirmed or checked in, then check-in is rejected', function (): void {
@@ -152,7 +152,7 @@ test('when enrollment status is not confirmed or checked in, then check-in is re
         method: CheckInMethod::Manual,
         payload: ['actor_user_id' => User::factory()->create()->id],
         eventDate: now(),
-    ))->toThrow(EnrollmentException::class);
+    ))->toThrow(CheckInException::class);
 });
 
 test('when manual check-in has no actor user id, then check-in is rejected', function (): void {
@@ -163,5 +163,5 @@ test('when manual check-in has no actor user id, then check-in is rejected', fun
         method: CheckInMethod::Manual,
         payload: [],
         eventDate: now(),
-    ))->toThrow(EnrollmentException::class);
+    ))->toThrow(CheckInException::class);
 });

--- a/app-modules/events/tests/Feature/CheckInActionTest.php
+++ b/app-modules/events/tests/Feature/CheckInActionTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-use He4rt\Events\CheckIn\Actions\CheckInAction;
+use He4rt\Events\CheckIn\Actions\ManualCheckInAction;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
 use He4rt\Events\CheckIn\Events\ParticipantCheckedIn;
 use He4rt\Events\CheckIn\Exceptions\CheckInException;
@@ -45,10 +45,9 @@ test('when organizer checks in confirmed enrollment, then check-in is recorded a
     $organizer = User::factory()->create();
     $enrollment = createConfirmedEnrollmentForCheckIn();
 
-    $checkIn = resolve(CheckInAction::class)->handle(
+    $checkIn = resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: ['actor_user_id' => $organizer->id],
+        actorUserId: $organizer->id,
         eventDate: now(),
     );
 
@@ -94,10 +93,9 @@ test('when checked-in enrollment checks in on another event date, then only chec
         'checked_in_at' => now(),
     ]);
 
-    $checkIn = resolve(CheckInAction::class)->handle(
+    $checkIn = resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: ['actor_user_id' => $organizer->id],
+        actorUserId: $organizer->id,
         eventDate: $startsAt->clone()->addDay(),
     );
 
@@ -118,10 +116,9 @@ test('when enrollment already has check-in for event date, then duplicate is rej
         'method' => CheckInMethod::Manual,
     ]);
 
-    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+    expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: ['actor_user_id' => User::factory()->create()->id],
+        actorUserId: User::factory()->create()->id,
         eventDate: now(),
     ))->toThrow(CheckInException::class);
 });
@@ -133,10 +130,9 @@ test('when check-in date is outside event date range, then check-in is rejected'
         'ends_at' => $startsAt->clone()->setTime(18, 0),
     ]);
 
-    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+    expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: ['actor_user_id' => User::factory()->create()->id],
+        actorUserId: User::factory()->create()->id,
         eventDate: $startsAt->clone()->addDay(),
     ))->toThrow(CheckInException::class);
 });
@@ -147,10 +143,9 @@ test('when enrollment status is not confirmed or checked in, then check-in is re
         'confirmed_at' => null,
     ]);
 
-    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+    expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: ['actor_user_id' => User::factory()->create()->id],
+        actorUserId: User::factory()->create()->id,
         eventDate: now(),
     ))->toThrow(CheckInException::class);
 });
@@ -158,10 +153,9 @@ test('when enrollment status is not confirmed or checked in, then check-in is re
 test('when manual check-in has no actor user id, then check-in is rejected', function (): void {
     $enrollment = createConfirmedEnrollmentForCheckIn();
 
-    expect(fn (): CheckIn => resolve(CheckInAction::class)->handle(
+    expect(fn (): CheckIn => resolve(ManualCheckInAction::class)->handle(
         enrollment: $enrollment,
-        method: CheckInMethod::Manual,
-        payload: [],
+        actorUserId: '',
         eventDate: now(),
     ))->toThrow(CheckInException::class);
 });

--- a/app-modules/events/tests/Feature/EventResourceTest.php
+++ b/app-modules/events/tests/Feature/EventResourceTest.php
@@ -203,7 +203,6 @@ test('when enrollment has check-ins, then relation manager shows check-in histor
     $enrollment = Enrollment::factory()->create([
         'event_id' => $event->id,
         'status' => EnrollmentStatus::CheckedIn,
-        'checked_in_at' => now(),
     ]);
 
     CheckIn::factory()->create([

--- a/app-modules/events/tests/Feature/EventResourceTest.php
+++ b/app-modules/events/tests/Feature/EventResourceTest.php
@@ -4,8 +4,11 @@ declare(strict_types=1);
 
 use Filament\Facades\Filament;
 use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\AttendanceRequirement;
 use He4rt\Events\Enrollment\Enums\EnrollmentMethod;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Enrollment\Models\EnrollmentPolicy;
 use He4rt\Events\Event\Enums\EventType;
 use He4rt\Events\Event\Models\Event;
@@ -136,4 +139,89 @@ test('when visiting the enrollments relation manager, then it renders successful
         'pageClass' => EditEvent::class,
     ])
         ->assertSuccessful();
+});
+
+test('when admin checks in an enrollment from relation manager, then participant is checked in', function (): void {
+    $event = Event::factory()->create([
+        'starts_at' => now()->setTime(9, 0),
+        'ends_at' => now()->setTime(18, 0),
+    ]);
+
+    $enrollment = Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    livewire(EnrollmentsRelationManager::class, [
+        'ownerRecord' => $event,
+        'pageClass' => EditEvent::class,
+    ])
+        ->callTableAction('checkIn', $enrollment, data: [
+            'event_date' => now()->toDateString(),
+        ])
+        ->assertHasNoTableActionErrors();
+
+    expect($enrollment->fresh()->status)->toBe(EnrollmentStatus::CheckedIn)
+        ->and(CheckIn::query()->where('enrollment_id', $enrollment->id)->count())->toBe(1);
+});
+
+test('when admin bulk checks in selected enrollments, then all selected participants are checked in', function (): void {
+    $event = Event::factory()->create([
+        'starts_at' => now()->setTime(9, 0),
+        'ends_at' => now()->setTime(18, 0),
+    ]);
+
+    $enrollments = Enrollment::factory()
+        ->count(2)
+        ->create([
+            'event_id' => $event->id,
+            'status' => EnrollmentStatus::Confirmed,
+            'confirmed_at' => now(),
+        ]);
+
+    livewire(EnrollmentsRelationManager::class, [
+        'ownerRecord' => $event,
+        'pageClass' => EditEvent::class,
+    ])
+        ->callTableBulkAction('checkInSelected', $enrollments, data: [
+            'event_date' => now()->toDateString(),
+        ])
+        ->assertHasNoTableBulkActionErrors();
+
+    expect(Enrollment::query()->whereKey($enrollments->pluck('id'))->where('status', EnrollmentStatus::CheckedIn)->count())->toBe(2)
+        ->and(CheckIn::query()->whereIn('enrollment_id', $enrollments->pluck('id'))->count())->toBe(2);
+});
+
+test('when enrollment has check-ins, then relation manager shows check-in history', function (): void {
+    $startsAt = now()->setTime(9, 0);
+    $event = Event::factory()->create([
+        'starts_at' => $startsAt,
+        'ends_at' => $startsAt->clone()->addDay()->setTime(18, 0),
+    ]);
+
+    $enrollment = Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'status' => EnrollmentStatus::CheckedIn,
+        'checked_in_at' => now(),
+    ]);
+
+    CheckIn::factory()->create([
+        'enrollment_id' => $enrollment->id,
+        'event_date' => $startsAt->toDateString(),
+        'method' => CheckInMethod::Manual,
+    ]);
+
+    CheckIn::factory()->create([
+        'enrollment_id' => $enrollment->id,
+        'event_date' => $startsAt->clone()->addDay()->toDateString(),
+        'method' => CheckInMethod::Manual,
+    ]);
+
+    livewire(EnrollmentsRelationManager::class, [
+        'ownerRecord' => $event,
+        'pageClass' => EditEvent::class,
+    ])
+        ->assertSee($startsAt->toDateString())
+        ->assertSee($startsAt->clone()->addDay()->toDateString());
 });

--- a/app-modules/events/tests/Unit/EnrollmentStatusTest.php
+++ b/app-modules/events/tests/Unit/EnrollmentStatusTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Exceptions\EnrollmentException;
 
 test('when a pending enrollment is evaluated, then it can transition to confirmed, rejected, or cancelled', function (): void {
     expect(EnrollmentStatus::Pending->canTransitionTo(EnrollmentStatus::Confirmed))->toBeTrue()
@@ -74,3 +75,8 @@ test('when rsvp enrollment status is evaluated, then response message matches st
     [EnrollmentStatus::Confirmed, 'events::pages.confirm_presence_success'],
     [EnrollmentStatus::Waitlisted, 'events::pages.waitlist_success'],
 ]);
+
+test('when response message is requested for unsupported enrollment status, then it fails explicitly', function (): void {
+    expect(fn (): string => EnrollmentStatus::Pending->getResponseMessage())
+        ->toThrow(EnrollmentException::class);
+});

--- a/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
@@ -14,8 +14,7 @@ use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
-use He4rt\Events\CheckIn\Actions\CheckInAction;
-use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Actions\ManualCheckInAction;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Models\Enrollment;
@@ -154,10 +153,9 @@ final class EnrollmentsRelationManager extends RelationManager
      */
     private function checkIn(Enrollment $enrollment, array $data): CheckIn
     {
-        return resolve(CheckInAction::class)->handle(
+        return resolve(ManualCheckInAction::class)->handle(
             enrollment: $enrollment,
-            method: CheckInMethod::Manual,
-            payload: ['actor_user_id' => auth()->id()],
+            actorUserId: (string) auth()->id(),
             eventDate: Date::parse($data['event_date']),
         );
     }

--- a/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
@@ -15,6 +15,7 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use He4rt\Events\CheckIn\Actions\ManualCheckInAction;
+use He4rt\Events\CheckIn\DTOs\ManualCheckInDTO;
 use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Models\Enrollment;
@@ -154,9 +155,11 @@ final class EnrollmentsRelationManager extends RelationManager
     private function checkIn(Enrollment $enrollment, array $data): CheckIn
     {
         return resolve(ManualCheckInAction::class)->handle(
-            enrollment: $enrollment,
-            actorUserId: (string) auth()->id(),
-            eventDate: Date::parse($data['event_date']),
+            new ManualCheckInDTO(
+                enrollment: $enrollment,
+                actorUserId: (string) auth()->id(),
+                eventDate: Date::parse($data['event_date']),
+            ),
         );
     }
 }

--- a/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
@@ -4,11 +4,25 @@ declare(strict_types=1);
 
 namespace He4rt\PanelAdmin\Filament\Resources\Events\RelationManagers;
 
+use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Forms\Components\DatePicker;
+use Filament\Notifications\Notification;
 use Filament\Resources\RelationManagers\RelationManager;
+use Filament\Support\Icons\Heroicon;
 use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use He4rt\Events\CheckIn\Actions\CheckInAction;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Models\CheckIn;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Event\Models\Event;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Facades\Date;
 
 final class EnrollmentsRelationManager extends RelationManager
 {
@@ -23,6 +37,7 @@ final class EnrollmentsRelationManager extends RelationManager
     {
         return $table
             ->recordTitleAttribute('id')
+            ->modifyQueryUsing(fn (Builder $query): Builder => $query->with(['checkIns', 'user']))
             ->columns([
                 TextColumn::make('user.name')
                     ->label('Participant')
@@ -44,6 +59,15 @@ final class EnrollmentsRelationManager extends RelationManager
                     ->dateTime()
                     ->sortable(),
 
+                TextColumn::make('check_in_history')
+                    ->label('Check-in History')
+                    ->state(fn (Enrollment $record): string => $record->checkIns
+                        ->sortBy('event_date')
+                        ->map(fn (CheckIn $checkIn): string => $checkIn->event_date->toDateString())
+                        ->implode(', '))
+                    ->placeholder('-')
+                    ->toggleable(),
+
                 TextColumn::make('cancelled_at')
                     ->label('Cancelled At')
                     ->dateTime()
@@ -54,6 +78,87 @@ final class EnrollmentsRelationManager extends RelationManager
                 SelectFilter::make('status')
                     ->label('Status')
                     ->options(EnrollmentStatus::class),
+            ])
+            ->recordActions([
+                $this->checkInAction(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    $this->bulkCheckInAction(),
+                ]),
             ]);
+    }
+
+    private function checkInAction(): Action
+    {
+        return Action::make('checkIn')
+            ->label('Check In')
+            ->icon(Heroicon::OutlinedCheckCircle)
+            ->color('success')
+            ->visible(fn (Enrollment $record): bool => $record->status->is(EnrollmentStatus::Confirmed, EnrollmentStatus::CheckedIn))
+            ->schema($this->checkInSchema())
+            ->action(function (Enrollment $record, array $data): void {
+                $this->checkIn($record, $data);
+
+                Notification::make()
+                    ->success()
+                    ->title('Participant checked in.')
+                    ->send();
+            });
+    }
+
+    private function bulkCheckInAction(): BulkAction
+    {
+        return BulkAction::make('checkInSelected')
+            ->label('Check In Selected')
+            ->icon(Heroicon::OutlinedCheckCircle)
+            ->color('success')
+            ->schema($this->checkInSchema())
+            ->action(function (Collection $records, array $data): void {
+                foreach ($records as $record) {
+                    if (!$record instanceof Enrollment) {
+                        continue;
+                    }
+
+                    $this->checkIn($record, $data);
+                }
+
+                Notification::make()
+                    ->success()
+                    ->title('Selected participants checked in.')
+                    ->send();
+            })
+            ->deselectRecordsAfterCompletion();
+    }
+
+    /**
+     * @return array<int, DatePicker>
+     */
+    private function checkInSchema(): array
+    {
+        /** @var Event $event */
+        $event = $this->getOwnerRecord();
+
+        return [
+            DatePicker::make('event_date')
+                ->label('Date')
+                ->default(now())
+                ->minDate($event->starts_at->toDateString())
+                ->maxDate($event->ends_at->toDateString())
+                ->required(),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    private function checkIn(Enrollment $enrollment, array $data): CheckIn
+    {
+        return resolve(CheckInAction::class)->handle(
+            enrollment: $enrollment,
+            method: CheckInMethod::Manual,
+            payload: ['actor_user_id' => auth()->id()],
+            eventDate: Date::parse($data['event_date']),
+        );
     }
 }


### PR DESCRIPTION
## Summary
### Solve: #244 

Implements manual check-in: organizers mark participants as present via the Admin panel. Creates a check-in record and transitions enrollment status. Covers single-day and multi-day events with duplicate prevention, date range validation, audit trail, and bulk check-in.

## What was implemented

### `CheckInAction` — Core action

- Accepts enrollment, method (enum), payload (array), event_date (Carbon date)
- Validates enrollment status is `confirmed` or `checked_in`
- Validates event_date is within the event's date range
- Validates no existing check-in for the same enrollment + date
- Creates `events_check_ins` record with `method=manual`, `payload={actor_user_id}`, `event_date`, `checked_in_at=now`
- First check-in transitions enrollment from `confirmed` → `checked_in`
- Subsequent check-ins (multi-day) only create the check-in record
- Records audit trail (`triggered_by=admin`, `actor_user_id=organizer`)
- Dispatches `ParticipantCheckedIn` domain event (`ShouldDispatchAfterCommit`)

### Admin panel — `EnrollmentsRelationManager`

- "Check In" action on enrollment records (visible when status is `confirmed` or `checked_in`)
- Date picker defaulting to today, constrained to event date range
- Bulk "Check In Selected" action for multiple participants
- Check-in history column per enrollment

### `TransitionEnrollmentAction`

Extracted reusable action for enrollment status transitions, used by the check-in flow and available for future transitions (`attended`, `cancelled`).

### `CheckInException`

Check-in validation errors moved to the CheckIn module boundary (`CheckIn/Exceptions/`) instead of leaking into `EnrollmentException`.

## Acceptance criteria

- [x] Organizer can mark a participant as checked in from Admin panel
- [x] Check-in record created in `events_check_ins` with method=manual and correct date
- [x] First check-in transitions enrollment from `confirmed` → `checked_in`
- [x] Subsequent check-ins (multi-day) create records without re-transitioning
- [x] Duplicate check-in on same date is rejected
- [x] Check-in outside event date range is rejected
- [x] Bulk check-in action works for multiple participants
- [x] `ParticipantCheckedIn` domain event is dispatched
- [x] Transition audit trail records the organizer
- [x] Feature tests: single, multi-day, duplicate, date range, status validation
- [x] Pint passes

## Files changed

### New (8 files)

| File | Purpose |
|---|---|
| `app-modules/events/src/CheckIn/Actions/CheckInAction.php` | Core check-in action (validate, create record, transition, dispatch) |
| `app-modules/events/src/CheckIn/Exceptions/CheckInException.php` | Check-in specific exceptions (invalid status, outside range, duplicate, invalid actor) |
| `app-modules/events/src/CheckIn/Events/ParticipantCheckedIn.php` | Domain event dispatched after check-in (`ShouldDispatchAfterCommit`) |
| `app-modules/events/src/Enrollment/Actions/TransitionEnrollmentAction.php` | Reusable action for enrollment status transitions with audit trail |
| `app-modules/events/lang/en/check_in.php` | English check-in exception messages |
| `app-modules/events/lang/pt_BR/check_in.php` | Brazilian Portuguese check-in exception messages |
| `app-modules/events/database/factories/CheckInFactory.php` | Factory for CheckIn model |
| `app-modules/events/tests/Feature/CheckInActionTest.php` | 6 feature tests (single, multi-day, duplicate, date range, status, actor) |

### Modified (11 files)

| File | What changed |
|---|---|
| `app-modules/events/src/CheckIn/Models/CheckIn.php` | Added `checked_in_at` to fillable, casts, phpdocs |
| `app-modules/events/database/migrations/2026_05_22_000001_add_checked_in_at_to_events_check_ins_table.php` | Added `checked_in_at` column to `events_check_ins` |
| `app-modules/events/src/Enrollment/Models/Enrollment.php` | Added `checkIns()` hasMany relationship |
| `app-modules/events/src/Enrollment/Enums/EnrollmentStatus.php` | Added `CheckedIn` case with transition rules |
| `app-modules/events/src/Enrollment/Exceptions/EnrollmentException.php` | Added `invalidTransition()`; removed check-in exceptions (moved to CheckInException) |
| `app-modules/events/src/Enrollment/Actions/EnrollUserAction.php` | Import adjustment |
| `app-modules/events/src/Event/Models/Event.php` | Relationship additions for enrollment policy |
| `app-modules/events/lang/en/exceptions.php` | Added `invalid_transition` key; removed check-in keys |
| `app-modules/events/lang/pt_BR/exceptions.php` | Added `invalid_transition` key; removed check-in keys |
| `app-modules/events/tests/Feature/EventResourceTest.php` | 5 tests: Filament CRUD, single + bulk check-in, check-in history |
| `app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php` | "Check In" action, bulk "Check In Selected", check-in history column, date picker |