### PR TITLE
ci: add Pest TIA (Test Impact Analysis) PoC

### DIFF
--- a/.github/workflows/_pest-tia.yml
+++ b/.github/workflows/_pest-tia.yml
@@ -108,4 +108,4 @@ jobs:
           XDEBUG_MODE: coverage
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          vendor/bin/pest --ci --tia --parallel
+          vendor/bin/pest --ci --tia

--- a/.github/workflows/_pest-tia.yml
+++ b/.github/workflows/_pest-tia.yml
@@ -108,4 +108,4 @@ jobs:
           XDEBUG_MODE: coverage
           DB_PORT: ${{ job.services.postgres.ports['5432'] }}
         run: |
-          vendor/bin/pest --ci --tia
+          vendor/bin/pest --ci --tia --parallel

--- a/.github/workflows/_pest-tia.yml
+++ b/.github/workflows/_pest-tia.yml
@@ -31,7 +31,7 @@ jobs:
       contents: read
 
     concurrency:
-      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-tia
+      group: pest-tia-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
 
     services:
@@ -99,7 +99,7 @@ jobs:
         uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: ~/.pest
-          key: pest-tia-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          key: pest-tia-${{ runner.os }}-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             pest-tia-${{ runner.os }}-${{ github.ref_name }}-
 

--- a/.github/workflows/_pest-tia.yml
+++ b/.github/workflows/_pest-tia.yml
@@ -1,0 +1,111 @@
+name: Pest TIA (Test Impact Analysis)
+
+on:
+  workflow_call:
+    inputs:
+      PHP_VERSION:
+        required: true
+        type: string
+      PHP_EXTENSIONS:
+        required: true
+        type: string
+      PHP_INI_PROPERTIES:
+        required: true
+        type: string
+      COMPOSER_FLAGS:
+        required: true
+        type: string
+      CACHE_KEY:
+        required: true
+        type: string
+
+permissions: {}
+
+jobs:
+  tia:
+    name: Run
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    continue-on-error: true
+    permissions:
+      contents: read
+
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}-tia
+      cancel-in-progress: true
+
+    services:
+      postgres:
+        # pinning skipped: we always test against the latest patch to match production
+        image: postgres:18-alpine # zizmor: ignore[unpinned-images]
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_he4rtbot
+        ports:
+          - 5432/tcp
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2.37.1
+        with:
+          php-version: ${{ inputs.PHP_VERSION }}
+          extensions: ${{ inputs.PHP_EXTENSIONS }}
+          ini-values: ${{ inputs.PHP_INI_PROPERTIES }}
+          coverage: xdebug
+          tools: composer:v2
+
+      - name: Setup Problem Matches
+        env:
+          TOOL_CACHE: ${{ runner.tool_cache }}
+        run: |
+          echo "::add-matcher::${TOOL_CACHE}/php.json"
+          echo "::add-matcher::${TOOL_CACHE}/phpunit.json"
+
+      - name: Install composer dependencies
+        uses: ramsey/composer-install@65e4f84970763564f46a70b8a54b90d033b3bdda # v4.0.0
+        with:
+          composer-options: ${{ inputs.COMPOSER_FLAGS }}
+          custom-cache-key: ${{ inputs.CACHE_KEY }}
+
+      - name: Install Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          package-manager-cache: false
+          node-version-file: '.nvmrc'
+          cache: 'npm'
+
+      - name: Install node dependencies
+        run: |
+          npm ci
+          npm run build
+
+      - name: Copy .env file
+        run: |
+          cp .env.testing.example .env.testing
+
+      - name: Restore TIA cache
+        uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
+        with:
+          path: ~/.pest
+          key: pest-tia-${{ runner.os }}-${{ github.ref_name }}-${{ github.run_id }}
+          restore-keys: |
+            pest-tia-${{ runner.os }}-${{ github.ref_name }}-
+
+      - name: Run Tests with TIA
+        env:
+          XDEBUG_MODE: coverage
+          DB_PORT: ${{ job.services.postgres.ports['5432'] }}
+        run: |
+          vendor/bin/pest --ci --tia

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -126,3 +126,19 @@ jobs:
       PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
       PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
       PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}
+
+  pest-tia:
+    name: Pest TIA (PoC)
+    needs: [setup]
+    if: >-
+      !github.event.pull_request.draft &&
+      (vars.RUN_TIA == 'true' || contains(github.event.pull_request.labels.*.name, 'run-tia'))
+    permissions:
+      contents: read
+    uses: ./.github/workflows/_pest-tia.yml
+    with:
+      CACHE_KEY: ${{ needs.setup.outputs.CACHE_KEY }}
+      COMPOSER_FLAGS: ${{ needs.setup.outputs.COMPOSER_FLAGS }}
+      PHP_EXTENSIONS: ${{ needs.setup.outputs.PHP_EXTENSIONS }}
+      PHP_INI_PROPERTIES: ${{ needs.setup.outputs.PHP_INI_PROPERTIES }}
+      PHP_VERSION: ${{ needs.setup.outputs.PHP_VERSION }}


### PR DESCRIPTION
## Summary

- Adds a non-blocking CI job for Pest's **TIA (Test Impact Analysis)** beta engine
- TIA builds a per-test coverage dependency graph (`~/.pest/tia/`) to identify which tests are affected by code changes
- Job is **conditional** — controlled by `vars.RUN_TIA` repository variable or `run-tia` PR label
- Job is **non-blocking** (`continue-on-error: true`) — failures show as ⚠ warning, never block PRs
- TIA graph is cached between runs via `actions/cache` (keyed by git origin SHA256, stable across environments)
- Also adds a local `make test-tia` target in `Makefile.local` for experimentation

## How to activate

**Option A — Global toggle:**
Settings → Secrets and variables → Actions → Variables → New repository variable
- Name: `RUN_TIA` / Value: `true`

**Option B — Per-PR:**
Add label `run-tia` to the PR before pushing

## Prior art

Based on [Pinkary's TIA baseline workflow](https://github.com/pinkary-project/pinkary.com/blob/2c40ed66ac1bb38a36da0cda59b9646194d48448/.github/workflows/tia-baseline.yml), adapted as a reusable workflow integrated into the existing CI orchestrator.

## Test plan

- [ ] Without `vars.RUN_TIA` and without `run-tia` label: `pest-tia` job should be skipped
- [ ] With `vars.RUN_TIA=true` or `run-tia` label: job runs and shows TIA output
- [ ] On TIA failure: PR is not blocked (continue-on-error)
- [ ] `make test-tia` runs locally with xdebug coverage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
Adds a non-blocking CI proof-of-concept job that runs Pest's Test Impact Analysis (TIA) to build per-test coverage dependency graphs (stored under ~/.pest/tia/) and identify tests affected by code changes. Execution is conditional (repo var RUN_TIA=true or PR label run-tia), uses cached graphs keyed by a stable SHA256, and reports failures as warnings (continue-on-error).

## References
- Pinkary's TIA baseline workflow (adapted)
- Pest TIA: vendor/bin/pest --ci --tia

## Dependencies & Requirements
- Postgres 18 (Alpine) service with health checks
- PHP with xdebug coverage enabled
- Composer v2 (uses ramsey/composer-install action)
- Node.js (npm ci, npm run build)
- Cache: ~/.pest/tia (actions/cache keyed by git origin SHA256 / computed CACHE_KEY)
- Environment variables: XDEBUG_MODE=coverage; DB_PORT wired from Postgres service
- Conditional flags: repo variable RUN_TIA or PR label run-tia

## Contributor Summary
| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| gvieira18 | 127 | 0 | 2 |

## Changes Summary
| File Path | Change Description |
|---|---|
| .github/workflows/_pest-tia.yml | New reusable workflow: sets up PHP (xdebug), Postgres service, installs deps, restores ~/.pest cache, runs Pest with TIA enabled (adds ~111 lines) |
| .github/workflows/continuous-integration.yml | Added jobs.pest-tia reusable workflow call, gated to non-draft PRs and conditioned on RUN_TIA or run-tia label (adds ~16 lines) |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/he4rt/heartdevs.com/pull/279?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->