### PR TITLE
feat(profile): polymorphic address system

### DIFF
--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Identity\User\Models;
 
+use App\Concerns\HasAddress;
 use Filament\Models\Contracts\FilamentUser;
 use Filament\Models\Contracts\HasName;
 use Filament\Models\Contracts\HasTenants;
@@ -39,6 +40,7 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 #[Table(name: 'users')]
 final class User extends Authenticatable implements FilamentUser, HasMedia, HasName, HasTenants
 {
+    use HasAddress;
     /** @use HasFactory<UserFactory> */
     use HasFactory;
     use HasUuids;
@@ -49,14 +51,6 @@ final class User extends Authenticatable implements FilamentUser, HasMedia, HasN
     public function isAdmin(): bool
     {
         return in_array($this->username, str(config('he4rt.admins'))->explode(',')->toArray(), true);
-    }
-
-    /**
-     * @return HasOne<Address, $this>
-     */
-    public function address(): HasOne
-    {
-        return $this->hasOne(Address::class);
     }
 
     /**

--- a/app-modules/identity/src/User/Observers/UserObserver.php
+++ b/app-modules/identity/src/User/Observers/UserObserver.php
@@ -15,7 +15,7 @@ class UserObserver
         }
     }
 
-    public function deleting(User $user): void
+    public function deleted(User $user): void
     {
         $user->address()->delete();
     }

--- a/app-modules/identity/src/User/Observers/UserObserver.php
+++ b/app-modules/identity/src/User/Observers/UserObserver.php
@@ -14,4 +14,9 @@ class UserObserver
             $user->username = str($user->name)->snake()->toString();
         }
     }
+
+    public function deleting(User $user): void
+    {
+        $user->address()->delete();
+    }
 }

--- a/app/Concerns/HasAddress.php
+++ b/app/Concerns/HasAddress.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Concerns;
+
+use App\Models\Address;
+use Illuminate\Database\Eloquent\Relations\MorphOne;
+
+trait HasAddress
+{
+    /**
+     * @return MorphOne<Address, $this>
+     */
+    public function address(): MorphOne
+    {
+        return $this->morphOne(Address::class, 'addressable');
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -4,26 +4,17 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 
+#[Table(name: 'addresses')]
 final class Address extends Model
 {
     use HasFactory;
     use HasUuids;
-
-    protected $table = 'addresses';
-
-    protected $fillable = [
-        'addressable_type',
-        'addressable_id',
-        'country',
-        'state',
-        'city',
-        'zip_code',
-    ];
 
     public function addressable(): MorphTo
     {

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+
+final class Address extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    protected $table = 'addresses';
+
+    protected $fillable = [
+        'addressable_type',
+        'addressable_id',
+        'country',
+        'state',
+        'city',
+        'zip_code',
+    ];
+
+    public function addressable(): MorphTo
+    {
+        return $this->morphTo();
+    }
+}

--- a/app/Models/Address.php
+++ b/app/Models/Address.php
@@ -4,18 +4,35 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Database\Factories\AddressFactory;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Support\Carbon;
 
+/**
+ * @property string $id
+ * @property string $addressable_type
+ * @property string $addressable_id
+ * @property string|null $country
+ * @property string|null $state
+ * @property string|null $city
+ * @property string|null $zip_code
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ */
 #[Table(name: 'addresses')]
 final class Address extends Model
 {
+    /** @use HasFactory<AddressFactory> */
     use HasFactory;
     use HasUuids;
 
+    /**
+     * @return MorphTo<Model, $this>
+     */
     public function addressable(): MorphTo
     {
         return $this->morphTo();

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Contracts\Paginator as PaginatorInterface;
+use App\Models\Address;
 use App\Providers\Tools\DebugbarServiceProvider;
 use App\Providers\Tools\TelescopeServiceProvider;
 use App\Support\Paginator;
@@ -40,6 +41,7 @@ final class AppServiceProvider extends ServiceProvider
         $this->configureHttp();
         $this->configureVite();
         $this->configureUrl();
+        $this->configureMorphMap();
     }
 
     private function configureCommands(): void
@@ -88,5 +90,12 @@ final class AppServiceProvider extends ServiceProvider
     private function registerTelescope(): void
     {
         $this->app->register(TelescopeServiceProvider::class);
+    }
+
+    private function configureMorphMap(): void
+    {
+        Relation::morphMap([
+            'address' => Address::class,
+        ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -5,10 +5,11 @@ declare(strict_types=1);
 namespace App\Providers;
 
 use App\Contracts\Paginator as PaginatorInterface;
-use App\Models\Address;
 use App\Providers\Tools\DebugbarServiceProvider;
 use App\Providers\Tools\TelescopeServiceProvider;
 use App\Support\Paginator;
+use He4rt\Events\Models\EventModel;
+use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Facades\DB;
@@ -95,7 +96,8 @@ final class AppServiceProvider extends ServiceProvider
     private function configureMorphMap(): void
     {
         Relation::morphMap([
-            'address' => Address::class,
+            'user' => User::class,
+            'event' => EventModel::class,
         ]);
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -8,7 +8,6 @@ use App\Contracts\Paginator as PaginatorInterface;
 use App\Providers\Tools\DebugbarServiceProvider;
 use App\Providers\Tools\TelescopeServiceProvider;
 use App\Support\Paginator;
-use He4rt\Events\Models\EventModel;
 use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\Relation;
@@ -97,7 +96,6 @@ final class AppServiceProvider extends ServiceProvider
     {
         Relation::morphMap([
             'user' => User::class,
-            'event' => EventModel::class,
         ]);
     }
 }

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -4,6 +4,14 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\Address;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * @extends Factory<Address>
+ */
 final class AddressFactory extends Factory
 {
     protected $model = Address::class;
@@ -29,8 +37,8 @@ final class AddressFactory extends Factory
     public function forUser(User $user): self
     {
         return $this->state([
-            'addressable_type' => 'user',
-            'addressable_id' => $user->id,
+            'addressable_type' => $user->getMorphClass(),
+            'addressable_id' => $user->getKey(),
         ]);
     }
 }

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -8,6 +8,7 @@ use App\Models\Address;
 use He4rt\Identity\User\Models\User;
 use Illuminate\Database\Eloquent\Factories\Factory;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 
 /**
  * @extends Factory<Address>
@@ -28,6 +29,8 @@ final class AddressFactory extends Factory
 
     public function forModel(Model $model): self
     {
+        throw_if(!$model->exists || $model->getKey() === null, InvalidArgumentException::class, 'Model must be persisted before using forModel().');
+
         return $this->state([
             'addressable_type' => $model->getMorphClass(),
             'addressable_id' => $model->getKey(),
@@ -36,9 +39,6 @@ final class AddressFactory extends Factory
 
     public function forUser(User $user): self
     {
-        return $this->state([
-            'addressable_type' => $user->getMorphClass(),
-            'addressable_id' => $user->getKey(),
-        ]);
+        return $this->forModel($user);
     }
 }

--- a/database/factories/AddressFactory.php
+++ b/database/factories/AddressFactory.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+final class AddressFactory extends Factory
+{
+    protected $model = Address::class;
+
+    public function definition(): array
+    {
+        return [
+            'country' => 'BR',
+            'state' => 'SP',
+            'city' => fake()->city(),
+            'zip_code' => fake()->postcode(),
+        ];
+    }
+
+    public function forModel(Model $model): self
+    {
+        return $this->state([
+            'addressable_type' => $model->getMorphClass(),
+            'addressable_id' => $model->getKey(),
+        ]);
+    }
+
+    public function forUser(User $user): self
+    {
+        return $this->state([
+            'addressable_type' => 'user',
+            'addressable_id' => $user->id,
+        ]);
+    }
+}

--- a/database/migrations/2026_05_21_180107_create_addresses_table.php
+++ b/database/migrations/2026_05_21_180107_create_addresses_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->string('state', 4)->nullable();
             $table->string('city')->nullable();
             $table->string('zip_code')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/database/migrations/2026_05_21_180107_create_addresses_table.php
+++ b/database/migrations/2026_05_21_180107_create_addresses_table.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('addresses', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+
+            $table->uuidMorphs('addressable'); // addressable_type && addressable_id
+
+            $table->string('country', 4)->nullable();
+            $table->string('state', 4)->nullable();
+            $table->string('city')->nullable();
+            $table->string('zip_code')->nullable();
+            $table->timestamps();
+        });
+    }
+};

--- a/database/migrations/2026_05_21_180107_create_addresses_table.php
+++ b/database/migrations/2026_05_21_180107_create_addresses_table.php
@@ -25,4 +25,9 @@ return new class extends Migration
             $table->timestamps();
         });
     }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('addresses');
+    }
 };

--- a/tests/Feature/AddressTest.php
+++ b/tests/Feature/AddressTest.php
@@ -8,17 +8,20 @@ use He4rt\Identity\User\Models\User;
 it('user tem um endereço polimórfico', function (): void {
     $user = User::factory()->create();
 
-    $address = Address::factory()->forUser($user)->create([
+    Address::factory()->forUser($user)->create([
         'country' => 'BR',
         'state' => 'SP',
         'city' => 'São Paulo',
     ]);
 
-    expect($user->fresh()->address)->not->toBeNull();
-    expect($user->fresh()->address->addressable_type)->toBe('user');
-    expect($user->fresh()->address->addressable_id)->toBe($user->id);
-    expect($user->fresh()->address->country)->toBe('BR');
-    expect($user->fresh()->address->state)->toBe('SP');
+    $address = $user->fresh()->address;
+
+    expect($address)
+        ->not->toBeNull()
+        ->addressable_type->toBe('user')
+        ->addressable_id->toBe($user->id)
+        ->country->toBe('BR')
+        ->state->toBe('SP');
 });
 
 it('user sem endereço retorna null', function (): void {
@@ -44,8 +47,9 @@ it('factory cria address válido para user', function (): void {
 
     $address = Address::factory()->forUser($user)->create();
 
-    expect($address->addressable_type)->toBe('user');
-    expect($address->addressable_id)->toBe($user->id);
-    expect($address->country)->toBe('BR');
-    expect($address->state)->toBe('SP');
+    expect($address)
+        ->addressable_type->toBe('user')
+        ->addressable_id->toBe($user->id)
+        ->country->toBe('BR')
+        ->state->toBe('SP');
 });

--- a/tests/Feature/Adress.php
+++ b/tests/Feature/Adress.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Models\Address;
+use He4rt\Events\Models\EventModel;
+use He4rt\Identity\User\Models\User;
+
+it('user tem um endereço polimórfico', function (): void {
+    $user = User::factory()->create();
+
+    $address = Address::factory()->forUser($user)->create([
+        'country' => 'BR',
+        'state' => 'SP',
+        'city' => 'São Paulo',
+    ]);
+
+    expect($user->fresh()->address)->not->toBeNull();
+    expect($user->fresh()->address->addressable_type)->toBe('user');
+    expect($user->fresh()->address->addressable_id)->toBe($user->id);
+    expect($user->fresh()->address->country)->toBe('BR');
+    expect($user->fresh()->address->state)->toBe('SP');
+});
+
+it('múltiplas entidades podem ter endereços distintos', function (): void {
+    $user = User::factory()->create();
+    $event = EventModel::factory()->create();
+
+    Address::factory()->forUser($user)->create();
+    Address::factory()->forModel($event)->create();
+
+    $userAddress = Address::query()->where('addressable_id', $user->id)->first();
+    $eventAddress = Address::query()->where('addressable_id', $event->id)->first();
+
+    expect($userAddress->addressable_type)->not->toBe($eventAddress->addressable_type);
+    expect($userAddress->addressable_id)->not->toBe($eventAddress->addressable_id);
+});
+
+it('user sem endereço retorna null', function (): void {
+    $user = User::factory()->create();
+
+    expect($user->address)->toBeNull();
+});
+
+it('deletar user deleta address via cascade', function (): void {
+    $user = User::factory()->create();
+
+    Address::factory()->forUser($user)->create();
+
+    expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeTrue();
+
+    $user->delete();
+
+    expect(Address::query()->where('addressable_id', $user->id)->exists())->toBeFalse();
+});
+
+it('factory cria address válido para user', function (): void {
+    $user = User::factory()->create();
+
+    $address = Address::factory()->forUser($user)->create();
+
+    expect($address->addressable_type)->toBe('user');
+    expect($address->addressable_id)->toBe($user->id);
+    expect($address->country)->toBe('BR');
+    expect($address->state)->toBe('SP');
+});

--- a/tests/Feature/Adress.php
+++ b/tests/Feature/Adress.php
@@ -3,7 +3,6 @@
 declare(strict_types=1);
 
 use App\Models\Address;
-use He4rt\Events\Models\EventModel;
 use He4rt\Identity\User\Models\User;
 
 it('user tem um endereço polimórfico', function (): void {
@@ -20,20 +19,6 @@ it('user tem um endereço polimórfico', function (): void {
     expect($user->fresh()->address->addressable_id)->toBe($user->id);
     expect($user->fresh()->address->country)->toBe('BR');
     expect($user->fresh()->address->state)->toBe('SP');
-});
-
-it('múltiplas entidades podem ter endereços distintos', function (): void {
-    $user = User::factory()->create();
-    $event = EventModel::factory()->create();
-
-    Address::factory()->forUser($user)->create();
-    Address::factory()->forModel($event)->create();
-
-    $userAddress = Address::query()->where('addressable_id', $user->id)->first();
-    $eventAddress = Address::query()->where('addressable_id', $event->id)->first();
-
-    expect($userAddress->addressable_type)->not->toBe($eventAddress->addressable_type);
-    expect($userAddress->addressable_id)->not->toBe($eventAddress->addressable_id);
 });
 
 it('user sem endereço retorna null', function (): void {


### PR DESCRIPTION
## Summary

- Implements a polymorphic address system with `HasAddress` trait and `Address` model (`morphOne`)
- Adds `AddressFactory` with `forModel()` / `forUser()` helpers and unsaved-model guard
- Cascade-deletes address on user deletion via `UserObserver::deleted()`
- Includes reversible migration with `down()` and full `@property` PHPDoc on the model

Closes #252

## Test plan

- [x] User can have a polymorphic address (`morphOne`)
- [x] User without address returns `null`
- [x] Deleting a user cascade-deletes the address
- [x] Factory creates valid address for user
- [x] PHPStan passes
- [x] Pint formatting passes