### PR TITLE
feat(profile): UpsertProfile and ToggleAvailability actions

### DIFF
--- a/app-modules/profile/src/Actions/ToggleAvailability.php
+++ b/app-modules/profile/src/Actions/ToggleAvailability.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Actions;
+
+use He4rt\Profile\Enums\StartAvailability;
+use He4rt\Profile\Models\Profile;
+use InvalidArgumentException;
+
+final class ToggleAvailability
+{
+    public function handle(Profile $profile, bool $available, ?StartAvailability $startAvailability = null): Profile
+    {
+        throw_if($available && !$startAvailability instanceof StartAvailability, InvalidArgumentException::class, 'O prazo de disponibilidade é obrigatório ao ativar a disponibilidade.');
+
+        $profile->update([
+            'available_for_proposals' => $available,
+            ...($available ? ['start_availability' => $startAvailability] : []),
+        ]);
+
+        return $profile->fresh();
+    }
+}

--- a/app-modules/profile/src/Actions/UpsertProfile.php
+++ b/app-modules/profile/src/Actions/UpsertProfile.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Actions;
+
+use Carbon\Carbon;
+use He4rt\Profile\DTOs\UpsertProfileDTO;
+use He4rt\Profile\Enums\SeniorityLevel;
+use He4rt\Profile\Enums\SocialPlatform;
+use He4rt\Profile\Models\Profile;
+use InvalidArgumentException;
+
+final class UpsertProfile
+{
+    public function handle(Profile $profile, UpsertProfileDTO $dto): Profile
+    {
+        $this->validate($dto);
+
+        $profile->update(array_filter([
+            'nickname' => $dto->nickname,
+            'birthdate' => $dto->birthdate,
+            'about' => $dto->about,
+            'headline' => $dto->headline,
+            'seniority_level' => $dto->seniorityLevel,
+            'years_experience' => $dto->yearsExperience,
+            'social_links' => $dto->socialLinks,
+        ], fn (Carbon|string|SeniorityLevel|int|array|null $value) => !is_null($value)));
+
+        return $profile->fresh();
+    }
+
+    private function validate(UpsertProfileDTO $dto): void
+    {
+        throw_if($dto->about !== null && mb_strlen($dto->about) > 500, InvalidArgumentException::class, 'O campo "sobre" não pode ultrapassar 500 caracteres.');
+
+        throw_if($dto->headline !== null && mb_strlen($dto->headline) > 100, InvalidArgumentException::class, 'O título não pode ultrapassar 100 caracteres.');
+
+        throw_if($dto->yearsExperience !== null && ($dto->yearsExperience < 0 || $dto->yearsExperience > 50), InvalidArgumentException::class, 'Os anos de experiência devem estar entre 0 e 50.');
+
+        if ($dto->socialLinks !== null) {
+            $validPlatforms = array_column(SocialPlatform::cases(), 'value');
+
+            foreach ($dto->socialLinks as $key => $value) {
+                throw_unless(in_array($key, $validPlatforms, true), InvalidArgumentException::class, sprintf('Plataforma social inválida: %s.', $key));
+
+                throw_if(!is_string($value) || $value === '', InvalidArgumentException::class, sprintf('O valor para a plataforma %s deve ser uma string não vazia.', $key));
+            }
+        }
+    }
+}

--- a/app-modules/profile/src/DTOs/UpsertProfileDTO.php
+++ b/app-modules/profile/src/DTOs/UpsertProfileDTO.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\DTOs;
+
+use Carbon\Carbon;
+use He4rt\Profile\Enums\SeniorityLevel;
+use Illuminate\Support\Facades\Date;
+
+final readonly class UpsertProfileDTO
+{
+    public function __construct(
+        public ?string $nickname = null,
+        public ?Carbon $birthdate = null,
+        public ?string $about = null,
+        public ?string $headline = null,
+        public ?SeniorityLevel $seniorityLevel = null,
+        public ?int $yearsExperience = null,
+        public ?array $socialLinks = null,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $data
+     */
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            nickname: $data['nickname'] ?? null,
+            birthdate: isset($data['birthdate']) ? Date::parse($data['birthdate']) : null,
+            about: $data['about'] ?? null,
+            headline: $data['headline'] ?? null,
+            seniorityLevel: isset($data['seniority_level']) ? SeniorityLevel::from($data['seniority_level']) : null,
+            yearsExperience: $data['years_experience'] ?? null,
+            socialLinks: $data['social_links'] ?? null,
+        );
+    }
+}

--- a/app-modules/profile/tests/Feature/UpsertProfileTest.php
+++ b/app-modules/profile/tests/Feature/UpsertProfileTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Actions\ToggleAvailability;
+use He4rt\Profile\Actions\UpsertProfile;
+use He4rt\Profile\DTOs\UpsertProfileDTO;
+use He4rt\Profile\Enums\StartAvailability;
+use He4rt\Profile\Models\Profile;
+
+test('atualiza todos os campos do perfil', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $profile = Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+    ]);
+
+    $dto = UpsertProfileDTO::fromArray([
+        'headline' => 'Backend Developer',
+        'seniority_level' => 'mid',
+        'years_experience' => 5,
+        'about' => 'Dev PHP',
+        'nickname' => 'Dan',
+    ]);
+
+    $updated = resolve(UpsertProfile::class)->handle($profile, $dto);
+
+    expect($updated->headline)->toBe('Backend Developer')
+        ->and($updated->nickname)->toBe('Dan')
+        ->and($updated->about)->toBe('Dev PHP')
+        ->and($updated->years_experience)->toBe(5);
+});
+
+test('atualiza parcialmente apenas o headline', function (): void {
+    $user = User::factory()->create();
+    $tenant = Tenant::factory()->create();
+    $profile = Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'nickname' => 'Dan',
+        'about' => 'Dev PHP',
+        'headline' => 'Old Headline',
+    ]);
+
+    $dto = UpsertProfileDTO::fromArray(['headline' => 'Senior Dev']);
+
+    $updated = resolve(UpsertProfile::class)->handle($profile, $dto);
+
+    expect($updated->headline)->toBe('Senior Dev')
+        ->and($updated->nickname)->toBe('Dan')
+        ->and($updated->about)->toBe('Dev PHP');
+});
+
+test('rejeita bio acima de 500 caracteres', function (): void {
+    $profile = Profile::factory()->create();
+    $dto = UpsertProfileDTO::fromArray(['about' => str_repeat('a', 501)]);
+
+    expect(fn () => resolve(UpsertProfile::class)->handle($profile, $dto))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('rejeita headline acima de 100 caracteres', function (): void {
+    $profile = Profile::factory()->create();
+    $dto = UpsertProfileDTO::fromArray(['headline' => str_repeat('a', 101)]);
+
+    expect(fn () => resolve(UpsertProfile::class)->handle($profile, $dto))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('salva social_links com plataformas validas', function (): void {
+    $profile = Profile::factory()->create();
+    $dto = UpsertProfileDTO::fromArray([
+        'social_links' => ['instagram' => '@dan', 'website' => 'https://dan.dev'],
+    ]);
+
+    $updated = resolve(UpsertProfile::class)->handle($profile, $dto);
+
+    expect($updated->social_links)->toMatchArray(['instagram' => '@dan', 'website' => 'https://dan.dev']);
+});
+
+test('rejeita social_links com plataforma invalida', function (): void {
+    $profile = Profile::factory()->create();
+    $dto = UpsertProfileDTO::fromArray([
+        'social_links' => ['tiktok' => '@dan'],
+    ]);
+
+    expect(fn () => resolve(UpsertProfile::class)->handle($profile, $dto))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('rejeita years_experience fora do range', function (): void {
+    $profile = Profile::factory()->create();
+    $dto = UpsertProfileDTO::fromArray(['years_experience' => 51]);
+
+    expect(fn () => resolve(UpsertProfile::class)->handle($profile, $dto))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('ativa disponibilidade com prazo', function (): void {
+    $profile = Profile::factory()->create(['available_for_proposals' => false]);
+
+    $updated = resolve(ToggleAvailability::class)->handle($profile, true, StartAvailability::Immediate);
+
+    expect($updated->available_for_proposals)->toBeTrue()
+        ->and($updated->start_availability)->toBe(StartAvailability::Immediate);
+});
+
+test('rejeita ativar disponibilidade sem prazo', function (): void {
+    $profile = Profile::factory()->create(['available_for_proposals' => false]);
+
+    expect(fn () => resolve(ToggleAvailability::class)->handle($profile, true))
+        ->toThrow(InvalidArgumentException::class);
+});
+
+test('desativar disponibilidade mantem prazo anterior', function (): void {
+    $profile = Profile::factory()->create([
+        'available_for_proposals' => true,
+        'start_availability' => StartAvailability::OneWeek,
+    ]);
+
+    $updated = resolve(ToggleAvailability::class)->handle($profile, false);
+
+    expect($updated->available_for_proposals)->toBeFalse()
+        ->and($updated->start_availability)->toBe(StartAvailability::OneWeek);
+});
+
+test('altera prazo sem mudar disponibilidade', function (): void {
+    $profile = Profile::factory()->create([
+        'available_for_proposals' => true,
+        'start_availability' => StartAvailability::Immediate,
+    ]);
+
+    $updated = resolve(ToggleAvailability::class)->handle($profile, true, StartAvailability::TwoWeeks);
+
+    expect($updated->start_availability)->toBe(StartAvailability::TwoWeeks)
+        ->and($updated->available_for_proposals)->toBeTrue();
+});


### PR DESCRIPTION
Closes #253

## What was done

Implements the domain logic of the Profile module with two distinct actions and a DTO:

- `UpsertProfileDTO` — DTO with the editable profile fields (nickname, birthdate, about, headline, seniorityLevel, yearsExperience, socialLinks) with a `fromArray()` factory method.
- `UpsertProfile` — Action that receives an existing Profile and a DTO, validates the fields and performs a pure update. Validates `about` (max 500), `headline` (max 100), `years_experience` (0-50) and `social_links` against the `SocialPlatform` enum.
- `ToggleAvailability` — Atomic action that toggles availability for proposals. When enabled, `start_availability` is required. When disabled, preserves the previous value.

## Tests

11 feature tests covering all BDD scenarios from the issue:

- updates all profile fields
- partially updates only the headline
- rejects bio above 500 characters
- rejects headline above 100 characters
- saves social_links with valid platforms
- rejects social_links with invalid platform
- rejects years_experience out of range
- activates availability with a start date
- rejects activating availability without a start date
- deactivating availability preserves the previous start date
- changes start date without changing availability status

## Files created

- `app-modules/profile/src/Actions/UpsertProfile.php`
- `app-modules/profile/src/Actions/ToggleAvailability.php`
- `app-modules/profile/src/DTOs/UpsertProfileDTO.php`
- `app-modules/profile/tests/Feature/UpsertProfileTest.php`.php

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Implements domain logic for the Profile module by introducing UpsertProfile and ToggleAvailability actions to replace legacy Identity-based profile update flows. The PR adds a DTO with factory method for profile editing, two domain actions with comprehensive validation rules, and 11 feature tests covering all BDD scenarios. Resolves issue `#253`.

## References

- Issue `#253`: Profile domain actions

## Dependencies & Requirements

No new external dependencies are introduced. The implementation uses existing Laravel/Illuminate facades and the SeniorityLevel and SocialPlatform enums already present in the codebase.

## Contributor Summary

| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---|---|---|
| Hadzab | 253 | 0 | 4 |

## Changes Summary

| File Path | Change Description |
|---|---|
| `app-modules/profile/src/DTOs/UpsertProfileDTO.php` | New DTO with nullable fields (nickname, birthdate, about, headline, seniorityLevel, yearsExperience, socialLinks) and fromArray() factory for mapping input data |
| `app-modules/profile/src/Actions/UpsertProfile.php` | Domain action to update Profile with validation: about ≤500 chars, headline ≤100 chars, yearsExperience 0–50, socialLinks keys validated against SocialPlatform enum |
| `app-modules/profile/src/Actions/ToggleAvailability.php` | Atomic action to toggle available_for_proposals with required start_availability when enabling and preservation when disabling |
| `app-modules/profile/tests/Feature/UpsertProfileTest.php` | Feature test suite with 11 tests covering full/partial updates, validation failures, social link validation, and availability toggle behaviors |

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/he4rt/heartdevs.com/pull/283?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->