### PR TITLE
fix(identity): create TenantUser pivot in ResolveUserContext for new users

### DIFF
--- a/app-modules/bot-discord/tests/Feature/SlashCommands/IntroductionCommandTest.php
+++ b/app-modules/bot-discord/tests/Feature/SlashCommands/IntroductionCommandTest.php
@@ -50,8 +50,6 @@ describe('persistence flow', function (): void {
 
         $userContext = resolve(ResolveUserContext::class)->handle($userDto);
 
-        $userContext->user->tenants()->syncWithoutDetaching([$data['tenant']->id]);
-
         $userContext->user->update(['name' => 'TestName']);
 
         $profile = Profile::query()
@@ -81,7 +79,7 @@ describe('persistence flow', function (): void {
             ->firstOrFail();
     })->throws(ModelNotFoundException::class);
 
-    test('profile not found when user is not attached to tenant', function (): void {
+    test('new user gets tenant pivot and profile via ResolveUserContext', function (): void {
         $data = createIntroductionScenario();
 
         $tenantProvider = ExternalIdentity::query()
@@ -100,9 +98,13 @@ describe('persistence flow', function (): void {
 
         $userContext = resolve(ResolveUserContext::class)->handle($userDto);
 
-        Profile::query()
+        expect($userContext->user->tenants()->where('tenants.id', $data['tenant']->id)->exists())->toBeTrue();
+
+        $profile = Profile::query()
             ->where('user_id', $userContext->user->id)
             ->where('tenant_id', $tenantProvider->tenant_id)
-            ->firstOrFail();
-    })->throws(ModelNotFoundException::class);
+            ->first();
+
+        expect($profile)->not->toBeNull();
+    });
 });

--- a/app-modules/identity/src/User/Actions/ResolveUserContext.php
+++ b/app-modules/identity/src/User/Actions/ResolveUserContext.php
@@ -22,6 +22,7 @@ readonly class ResolveUserContext
     {
         $provider = $this->providerResolver->handle($dto);
         $user = $this->userResolver->handle($provider);
+        $user->tenants()->syncWithoutDetaching([$dto->tenantId]);
         $character = $this->characterInitializer->ensure($user, $dto->tenantId);
 
         return UserContext::make(user: $user, character: $character, provider: $provider);


### PR DESCRIPTION
## Summary

- `ResolveUserContext::handle()` now calls `$user->tenants()->syncWithoutDetaching([$dto->tenantId])` after resolving the user, ensuring the `TenantUser` pivot exists before anything else runs
- This triggers `TenantUserObserver::created()` which creates the `Profile` — fixing `ModelNotFoundException` for new users on `/apresentar`
- `syncWithoutDetaching` is idempotent, so existing users with the pivot are unaffected

## Root cause

PR #282 (May 24) migrated `IntroductionCommand` from the single-tenant `Information` model to the pivot-dependent `Profile` model, but `ResolveUserContext` never created the `TenantUser` pivot. The `Profile` is only created by `TenantUserObserver::created()`, which fires on pivot insertion — so new users who joined after the ETL import had no profile.

## Test plan

- [x] Flipped test from `throws(ModelNotFoundException)` to asserting pivot and profile ARE created
- [x] Removed manual `syncWithoutDetaching` workaround from happy-path test
- [x] Full suite: 586 tests pass (585 passed, 1 pre-existing skip)
- [x] Pint clean, no new PHPStan errors