### PR TITLE
fix(bot-discord): guild guard and Profile ensure

### DIFF
--- a/app-modules/bot-discord/src/SlashCommands/AbstractSlashCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/AbstractSlashCommand.php
@@ -20,6 +20,20 @@ abstract class AbstractSlashCommand extends SlashCommand
 
     protected ?ExternalIdentity $tenantProvider = null;
 
+    public function maybeHandle(Interaction $interaction): void
+    {
+        if ($interaction->guild_id === null) {
+            $interaction->respondWithMessage(
+                'Este comando só pode ser usado em um servidor.',
+                true
+            );
+
+            return;
+        }
+
+        parent::maybeHandle($interaction);
+    }
+
     protected function processMiddleware(Interaction $interaction): mixed
     {
         $context = new Context(

--- a/app-modules/bot-discord/src/SlashCommands/CargoDelasCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/CargoDelasCommand.php
@@ -8,9 +8,8 @@ use Discord\Parts\Guild\Role;
 use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
 use Discord\Parts\User\Member;
-use Laracord\Commands\SlashCommand;
 
-class CargoDelasCommand extends SlashCommand
+class CargoDelasCommand extends AbstractSlashCommand
 {
     /**
      * The command name.

--- a/app-modules/bot-discord/src/SlashCommands/CodeCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/CodeCommand.php
@@ -5,9 +5,8 @@ declare(strict_types=1);
 namespace He4rt\BotDiscord\SlashCommands;
 
 use Discord\Parts\Interactions\Interaction;
-use Laracord\Commands\SlashCommand;
 
-class CodeCommand extends SlashCommand
+class CodeCommand extends AbstractSlashCommand
 {
     /**
      * The command name.

--- a/app-modules/bot-discord/src/SlashCommands/DontAskCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/DontAskCommand.php
@@ -7,9 +7,8 @@ namespace He4rt\BotDiscord\SlashCommands;
 use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
 use Illuminate\Support\Facades\Date;
-use Laracord\Commands\SlashCommand;
 
-class DontAskCommand extends SlashCommand
+class DontAskCommand extends AbstractSlashCommand
 {
     /**
      * The command name.

--- a/app-modules/bot-discord/src/SlashCommands/DynamicVoiceCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/DynamicVoiceCommand.php
@@ -11,11 +11,10 @@ use Discord\Parts\Embed\Embed;
 use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
 use He4rt\BotDiscord\DTO\VoiceChannelDTO;
-use Laracord\Commands\SlashCommand;
 
 use function React\Async\await;
 
-class DynamicVoiceCommand extends SlashCommand
+class DynamicVoiceCommand extends AbstractSlashCommand
 {
     /**
      * The command name.

--- a/app-modules/bot-discord/src/SlashCommands/EditVoiceChannelLimitCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/EditVoiceChannelLimitCommand.php
@@ -7,11 +7,10 @@ namespace He4rt\BotDiscord\SlashCommands;
 use Discord\Parts\Interactions\Command\Option;
 use Discord\Parts\Interactions\Interaction;
 use Exception;
-use Laracord\Commands\SlashCommand;
 
 use function React\Async\await;
 
-class EditVoiceChannelLimitCommand extends SlashCommand
+class EditVoiceChannelLimitCommand extends AbstractSlashCommand
 {
     protected $name = 'sala-limite';
 

--- a/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
+++ b/app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php
@@ -18,10 +18,9 @@ use He4rt\Profile\DTOs\UpsertProfileDTO;
 use He4rt\Profile\Models\Profile;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\Log;
-use Laracord\Commands\SlashCommand;
 use Throwable;
 
-class IntroductionCommand extends SlashCommand
+class IntroductionCommand extends AbstractSlashCommand
 {
     protected $name = 'apresentar';
 
@@ -142,10 +141,7 @@ class IntroductionCommand extends SlashCommand
 
         $userContext->user->update(['name' => $name]);
 
-        $profile = Profile::query()
-            ->where('user_id', $userContext->user->id)
-            ->where('tenant_id', $tenantProvider->tenant_id)
-            ->firstOrFail();
+        $profile = Profile::ensureExists($userContext->user->id, $tenantProvider->tenant_id);
 
         $dto = UpsertProfileDTO::fromArray([
             'nickname' => $nickname,

--- a/app-modules/identity/src/Tenant/Observers/TenantUserObserver.php
+++ b/app-modules/identity/src/Tenant/Observers/TenantUserObserver.php
@@ -11,11 +11,6 @@ final class TenantUserObserver
 {
     public function created(TenantUser $pivot): void
     {
-        Profile::query()->firstOrCreate([
-            'user_id' => $pivot->user_id,
-            'tenant_id' => $pivot->tenant_id,
-        ], [
-            'available_for_proposals' => false,
-        ]);
+        Profile::ensureExists($pivot->user_id, $pivot->tenant_id);
     }
 }

--- a/app-modules/identity/src/Tenant/Observers/TenantUserObserver.php
+++ b/app-modules/identity/src/Tenant/Observers/TenantUserObserver.php
@@ -11,6 +11,6 @@ final class TenantUserObserver
 {
     public function created(TenantUser $pivot): void
     {
-        Profile::ensureExists($pivot->user_id, $pivot->tenant_id);
+        Profile::ensureExists((string) $pivot->user_id, (string) $pivot->tenant_id);
     }
 }

--- a/app-modules/profile/src/Models/Profile.php
+++ b/app-modules/profile/src/Models/Profile.php
@@ -56,6 +56,19 @@ final class Profile extends Model
         'start_availability',
     ];
 
+    public static function ensureExists(string $userId, string $tenantId): self
+    {
+        /** @var Profile $profile */
+        $profile = self::query()->firstOrCreate([
+            'user_id' => $userId,
+            'tenant_id' => $tenantId,
+        ], [
+            'available_for_proposals' => false,
+        ]);
+
+        return $profile;
+    }
+
     /**
      * @return BelongsTo<User, $this>
      */


### PR DESCRIPTION
## Summary

- **Guild guard**: Added `maybeHandle()` override in `AbstractSlashCommand` that rejects interactions without `guild_id` (DM context), responding with an ephemeral message
- **Unified hierarchy**: All 6 slash commands that extended Laracord's `SlashCommand` directly now extend `AbstractSlashCommand`, so every command gets the guild guard
- **Profile::ensureExists()**: Extracted `firstOrCreate` logic into a static method on `Profile`, replacing both the `TenantUserObserver` inline call and `IntroductionCommand`'s `firstOrFail()` — fixes `ModelNotFoundException` for users whose TenantUser pivot predates the observer

## Root cause

Slash commands were registered globally (no `$guild` property), making them available in DMs where `$interaction->guild_id` and `$interaction->member` are null. Additionally, `syncWithoutDetaching()` only fires the `created` pivot event for **new** records — users who already had a TenantUser pivot but no Profile (created before the observer existed) hit `firstOrFail()` crash.

## Test plan

- [x] `php artisan test --compact --filter=IntroductionCommand` — 3 tests pass
- [x] `php artisan test --compact --filter=EditProfileCommand` — 4 tests pass
- [x] `vendor/bin/pint --dirty` — clean
- [x] `vendor/bin/phpstan analyse app-modules/bot-discord/src/SlashCommands/` — 0 errors
- [ ] Verify `/apresentar` works for users with existing TenantUser pivot but no Profile (e.g. andredss, garreiz)
- [ ] Verify slash commands are rejected gracefully if somehow invoked from DM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
Guards Discord slash commands from DM (guild-less) invocations by adding a guild check in AbstractSlashCommand::maybeHandle(), updates six slash commands to extend the new base, and adds Profile::ensureExists() to avoid ModelNotFoundException for users whose TenantUser pivot predates the Profile observer.

## References
- https://github.com/he4rt/heartdevs.com/pull/302
- https://github.com/he4rt/heartdevs.com/pull/300

## Dependencies & Requirements
- No new dependencies or environment/configuration changes required.

## Contributor Summary
| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| gvieira18 | 35 | 22 | 9 |

## Changes Summary
| File Path | Change Description |
|---|---|
| app-modules/bot-discord/src/SlashCommands/AbstractSlashCommand.php | Added public override maybeHandle() to reject guild-less (DM) interactions with an ephemeral Portuguese message. |
| app-modules/bot-discord/src/SlashCommands/CargoDelasCommand.php | Switched base class to AbstractSlashCommand (inheritance change). |
| app-modules/bot-discord/src/SlashCommands/CodeCommand.php | Switched base class to AbstractSlashCommand (inheritance change). |
| app-modules/bot-discord/src/SlashCommands/DontAskCommand.php | Switched base class to AbstractSlashCommand (inheritance change). |
| app-modules/bot-discord/src/SlashCommands/DynamicVoiceCommand.php | Switched base class to AbstractSlashCommand (inheritance change). |
| app-modules/bot-discord/src/SlashCommands/EditVoiceChannelLimitCommand.php | Switched base class to AbstractSlashCommand (inheritance change). |
| app-modules/bot-discord/src/SlashCommands/IntroductionCommand.php | Switched base class to AbstractSlashCommand and replaced firstOrFail() profile lookup with Profile::ensureExists(). |
| app-modules/identity/src/Tenant/Observers/TenantUserObserver.php | Replaced inline firstOrCreate with Profile::ensureExists() in created() observer. |
| app-modules/profile/src/Models/Profile.php | Added public static ensureExists(string|Stringable $userId, string|Stringable $tenantId): self to create-or-return Profile safely. |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->