### PR TITLE
feat: Public Profile Page (#257)

### DIFF
--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -125,13 +125,9 @@
                             'bg-green-50 text-green-700 dark:bg-green-500/10 dark:text-green-400' =>
                                 $seniority === \He4rt\Profile\Enums\SeniorityLevel::Junior,
                             'bg-blue-50 text-blue-700 dark:bg-blue-500/10 dark:text-blue-400' =>
-                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Mid,
+                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Pleno,
                             'bg-purple-50 text-purple-700 dark:bg-purple-500/10 dark:text-purple-400' =>
-                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Senior,
-                            'bg-amber-50 text-amber-700 dark:bg-amber-500/10 dark:text-amber-400' =>
-                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Specialist,
-                            'bg-red-50 text-red-700 dark:bg-red-500/10 dark:text-red-400' =>
-                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Lead
+                                $seniority === \He4rt\Profile\Enums\SeniorityLevel::Senior
                         ])
                     >
                         {{ $seniority->getLabel() }}

--- a/app-modules/panel-app/tests/Feature/ProfilePageTest.php
+++ b/app-modules/panel-app/tests/Feature/ProfilePageTest.php
@@ -36,14 +36,14 @@ test('profile page renders successfully', function (): void {
 test('profile page loads existing profile data', function (): void {
     $this->profile->update([
         'headline' => 'Backend Developer',
-        'seniority_level' => SeniorityLevel::Mid,
+        'seniority_level' => SeniorityLevel::Pleno,
     ]);
 
     livewire(ProfilePage::class)
         ->assertOk()
         ->assertSchemaStateSet([
             'headline' => 'Backend Developer',
-            'seniority_level' => SeniorityLevel::Mid,
+            'seniority_level' => SeniorityLevel::Pleno,
         ]);
 });
 
@@ -52,7 +52,7 @@ test('profile page saves all fields', function (): void {
         ->set('data.nickname', 'Dan')
         ->fillForm([
             'headline' => 'Backend Developer',
-            'seniority_level' => 'mid',
+            'seniority_level' => 'pleno',
             'years_experience' => 5,
             'about' => 'Dev PHP apaixonado por Laravel',
         ])
@@ -63,7 +63,7 @@ test('profile page saves all fields', function (): void {
 
     expect($this->profile->nickname)->toBe('Dan')
         ->and($this->profile->headline)->toBe('Backend Developer')
-        ->and($this->profile->seniority_level)->toBe(SeniorityLevel::Mid)
+        ->and($this->profile->seniority_level)->toBe(SeniorityLevel::Pleno)
         ->and($this->profile->years_experience)->toBe(5)
         ->and($this->profile->about)->toBe('Dev PHP apaixonado por Laravel');
 });

--- a/app-modules/portal/resources/views/components/layouts/app.blade.php
+++ b/app-modules/portal/resources/views/components/layouts/app.blade.php
@@ -1,12 +1,13 @@
 @props (['title' => null])
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="icon" href="{{ asset('favicon.ico') }}" />
     <title>{{ $title ? $title . ' - ' : '' }}{{ config('app.name') }}</title>
     @vite (['app-modules/he4rt/resources/css/theme.css'])
+    @stack ('styles')
     @fluxAppearance
 </head>
 <body class="min-h-screen antialiased">

--- a/app-modules/portal/resources/views/components/layouts/app.blade.php
+++ b/app-modules/portal/resources/views/components/layouts/app.blade.php
@@ -1,6 +1,6 @@
 @props (['title' => null])
 <!DOCTYPE html>
-<html lang="{{ str_replace('_', '-', app()->getLocale()) }}" class="dark">
+<html lang="{{ str_replace('_', '-', app()->getLocale()) }}">
 <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/app-modules/profile/database/factories/ProfileFactory.php
+++ b/app-modules/profile/database/factories/ProfileFactory.php
@@ -33,6 +33,9 @@ final class ProfileFactory extends Factory
             'social_links' => null,
             'available_for_proposals' => false,
             'start_availability' => null,
+            'skills' => null,
+            'work_types' => null,
+            'languages' => null,
         ];
     }
 
@@ -51,6 +54,16 @@ final class ProfileFactory extends Factory
             ],
             'available_for_proposals' => true,
             'start_availability' => fake()->randomElement(StartAvailability::cases()),
+            'skills' => [
+                ['name' => 'PHP', 'category' => 'languages_frameworks'],
+                ['name' => 'Laravel', 'category' => 'languages_frameworks'],
+                ['name' => 'PostgreSQL', 'category' => 'infra_databases'],
+                ['name' => 'Docker', 'category' => 'infra_databases'],
+            ],
+            'work_types' => ['immediate', 'remote'],
+            'languages' => [
+                ['name' => 'Português', 'level' => 'Nativo'],
+            ],
         ]);
     }
 }

--- a/app-modules/profile/database/migrations/2026_06_11_000000_add_skills_to_user_profiles_table.php
+++ b/app-modules/profile/database/migrations/2026_06_11_000000_add_skills_to_user_profiles_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->jsonb('skills')->nullable()->after('start_availability');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->dropColumn('skills');
+        });
+    }
+};

--- a/app-modules/profile/database/migrations/2026_06_14_000001_add_work_types_to_user_profiles_table.php
+++ b/app-modules/profile/database/migrations/2026_06_14_000001_add_work_types_to_user_profiles_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->jsonb('work_types')->nullable()->after('available_for_proposals');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->dropColumn('work_types');
+        });
+    }
+};

--- a/app-modules/profile/database/migrations/2026_06_14_000002_add_languages_to_user_profiles_table.php
+++ b/app-modules/profile/database/migrations/2026_06_14_000002_add_languages_to_user_profiles_table.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->jsonb('languages')->nullable()->after('work_types');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('user_profiles', function (Blueprint $table): void {
+            $table->dropColumn('languages');
+        });
+    }
+};

--- a/app-modules/profile/database/migrations/2026_06_14_000003_create_user_projects_table.php
+++ b/app-modules/profile/database/migrations/2026_06_14_000003_create_user_projects_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_projects', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignUuid('tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->string('name');
+            $table->text('description')->nullable();
+            $table->string('url')->nullable();
+            $table->jsonb('tags')->nullable();
+            $table->unsignedInteger('stars')->nullable();
+            $table->unsignedInteger('forks')->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['user_id', 'tenant_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_projects');
+    }
+};

--- a/app-modules/profile/database/migrations/2026_06_14_000004_create_user_pull_requests_table.php
+++ b/app-modules/profile/database/migrations/2026_06_14_000004_create_user_pull_requests_table.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('user_pull_requests', function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignUuid('tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->string('title');
+            $table->string('repo');
+            $table->enum('status', ['open', 'merged', 'closed']);
+            $table->unsignedInteger('number');
+            $table->string('url')->nullable();
+            $table->timestamp('pr_created_at')->nullable();
+            $table->unsignedInteger('sort_order')->default(0);
+            $table->timestamps();
+
+            $table->index(['user_id', 'tenant_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('user_pull_requests');
+    }
+};

--- a/app-modules/profile/lang/en/enums.php
+++ b/app-modules/profile/lang/en/enums.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 return [
     'seniority_level' => [
         'junior' => 'Junior',
-        'mid' => 'Mid-Level',
+        'pleno' => 'Pleno',
         'senior' => 'Senior',
-        'specialist' => 'Specialist',
-        'lead' => 'Lead',
     ],
 
     'social_platform' => [
@@ -17,15 +15,27 @@ return [
         'website' => 'Website',
         'youtube' => 'YouTube',
         'bluesky' => 'Bluesky',
+        'whatsapp' => 'WhatsApp',
+        'linkedin' => 'LinkedIn',
+        'github' => 'GitHub',
+        'devto' => 'Dev.to',
     ],
 
     'start_availability' => [
         'immediate' => 'Immediate',
-        '1_week' => '1 Week',
-        '2_weeks' => '2 Weeks',
-        '3_weeks' => '3 Weeks',
-        '1_month' => '1 Month',
-        '2_months' => '2 Months',
+        '1_week' => '1 week',
+        '2_weeks' => '2 weeks',
+        '3_weeks' => '3 weeks',
+        '1_month' => '1 month',
+        '2_months' => '2 months',
         'negotiable' => 'Negotiable',
+    ],
+
+    'work_type' => [
+        'immediate' => 'Immediate start',
+        'remote' => 'Remote',
+        'clt' => 'CLT',
+        'pj' => 'PJ',
+        'freelance' => 'Freelance',
     ],
 ];

--- a/app-modules/profile/lang/pt_BR/enums.php
+++ b/app-modules/profile/lang/pt_BR/enums.php
@@ -5,10 +5,8 @@ declare(strict_types=1);
 return [
     'seniority_level' => [
         'junior' => 'Júnior',
-        'mid' => 'Pleno',
+        'pleno' => 'Pleno',
         'senior' => 'Sênior',
-        'specialist' => 'Especialista',
-        'lead' => 'Lead',
     ],
 
     'social_platform' => [
@@ -17,6 +15,10 @@ return [
         'website' => 'Website',
         'youtube' => 'YouTube',
         'bluesky' => 'Bluesky',
+        'whatsapp' => 'WhatsApp',
+        'linkedin' => 'LinkedIn',
+        'github' => 'GitHub',
+        'devto' => 'Dev.to',
     ],
 
     'start_availability' => [
@@ -27,5 +29,13 @@ return [
         '1_month' => '1 mês',
         '2_months' => '2 meses',
         'negotiable' => 'Negociável',
+    ],
+
+    'work_type' => [
+        'immediate' => 'Início imediato',
+        'remote' => 'Remoto',
+        'clt' => 'CLT',
+        'pj' => 'PJ',
+        'freelance' => 'Freelance',
     ],
 ];

--- a/app-modules/profile/resources/css/profile.css
+++ b/app-modules/profile/resources/css/profile.css
@@ -1,0 +1,409 @@
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@400;500;600;700;800&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap');
+
+:root {
+    --primary: #9b5de5;
+    --primary2: #782bf1;
+    /* Light mode (default) */
+    --bg: #f5f5f7;
+    --card: #ffffff;
+    --e2: #ede8f5;
+    --ol: rgba(124, 58, 237, 0.18);
+    --tm: #3d3654;
+    --tl: #706888;
+    --text-main: #1e1833;
+    --text-heading: #130f24;
+    --chip-purple-bg: rgba(124, 58, 237, 0.14);
+    --chip-purple-border: rgba(124, 58, 237, 0.35);
+    --chip-purple-text: #6d28d9;
+    --chip-cyan-bg: rgba(6, 182, 212, 0.12);
+    --chip-cyan-border: rgba(6, 182, 212, 0.35);
+    --chip-cyan-text: #0891b2;
+    --chip-gray-bg: #ede8f5;
+    --chip-gray-border: rgba(124, 58, 237, 0.2);
+    --chip-gray-text: #3d3654;
+    --badge-bg: rgba(124, 58, 237, 0.1);
+    --icon-hover-bg: rgba(124, 58, 237, 0.12);
+    --divider: rgba(124, 58, 237, 0.14);
+    --status-green-bg: rgba(34, 197, 94, 0.12);
+    --status-green-border: rgba(34, 197, 94, 0.35);
+    --status-green-text: #16a34a;
+    --skill-chip-hover-border: #7c3aed;
+    --overlay: rgba(255, 255, 255, 0.85);
+}
+
+:root.dark {
+    --bg: #000000;
+    --card: #0a0a0a;
+    --e2: #111111;
+    --ol: rgba(155, 93, 229, 0.16);
+    --tm: #a8a0c0;
+    --tl: #6e6590;
+    --text-main: #e8e4f0;
+    --text-heading: #f0ecf8;
+    --chip-purple-bg: rgba(120, 43, 241, 0.12);
+    --chip-purple-border: rgba(120, 43, 241, 0.25);
+    --chip-purple-text: #c4a3f0;
+    --chip-cyan-bg: rgba(6, 182, 212, 0.12);
+    --chip-cyan-border: rgba(6, 182, 212, 0.25);
+    --chip-cyan-text: #67d8ef;
+    --chip-gray-bg: #111111;
+    --chip-gray-border: rgba(155, 93, 229, 0.16);
+    --chip-gray-text: #a8a0c0;
+    --badge-bg: rgba(155, 93, 229, 0.1);
+    --icon-hover-bg: rgba(155, 93, 229, 0.12);
+    --divider: rgba(155, 93, 229, 0.16);
+    --status-green-bg: rgba(34, 197, 94, 0.1);
+    --status-green-border: rgba(34, 197, 94, 0.3);
+    --status-green-text: #86efac;
+    --skill-chip-hover-border: #9b5de5;
+    --overlay: rgba(0, 0, 0, 0.6);
+}
+
+/* Light body — default */
+body:has(.profile-page) {
+    background: #f5f5f7 !important;
+    color: var(--text-main) !important;
+}
+
+/* Dark body via .dark class (Flux sets this based on OS) */
+.dark body:has(.profile-page) {
+    background:
+        radial-gradient(ellipse at 15% 0%, rgba(120, 43, 241, 0.08), transparent 50%),
+        radial-gradient(ellipse at 85% 20%, rgba(88, 28, 180, 0.05), transparent 45%), #000000 !important;
+    color: var(--text-main) !important;
+}
+
+/* Dark body via prefers-color-scheme (native OS detection) */
+@media (prefers-color-scheme: dark) {
+    :root {
+        --bg: #000000;
+        --card: #0a0a0a;
+        --e2: #111111;
+        --ol: rgba(155, 93, 229, 0.16);
+        --tm: #a8a0c0;
+        --tl: #6e6590;
+        --text-main: #e8e4f0;
+        --text-heading: #f0ecf8;
+        --chip-purple-bg: rgba(120, 43, 241, 0.12);
+        --chip-purple-border: rgba(120, 43, 241, 0.25);
+        --chip-purple-text: #c4a3f0;
+        --chip-cyan-bg: rgba(6, 182, 212, 0.12);
+        --chip-cyan-border: rgba(6, 182, 212, 0.25);
+        --chip-cyan-text: #67d8ef;
+        --chip-gray-bg: #111111;
+        --chip-gray-border: rgba(155, 93, 229, 0.16);
+        --chip-gray-text: #a8a0c0;
+        --badge-bg: rgba(155, 93, 229, 0.1);
+        --icon-hover-bg: rgba(155, 93, 229, 0.12);
+        --divider: rgba(155, 93, 229, 0.16);
+        --status-green-bg: rgba(34, 197, 94, 0.1);
+        --status-green-border: rgba(34, 197, 94, 0.3);
+        --status-green-text: #86efac;
+        --skill-chip-hover-border: #9b5de5;
+        --overlay: rgba(0, 0, 0, 0.6);
+    }
+
+    body:has(.profile-page) {
+        background:
+            radial-gradient(ellipse at 15% 0%, rgba(120, 43, 241, 0.08), transparent 50%),
+            radial-gradient(ellipse at 85% 20%, rgba(88, 28, 180, 0.05), transparent 45%), #000000 !important;
+        color: var(--text-main) !important;
+    }
+}
+
+.profile-page {
+    min-height: 100vh;
+    color: var(--text-main);
+}
+
+/* ============================================
+   TAILWIND UTILITY CLASSES (CSS var driven)
+   ============================================ */
+
+.font-display {
+    font-family: 'Outfit', sans-serif;
+}
+
+.bg-bg {
+    background-color: var(--bg);
+}
+.bg-card {
+    background-color: var(--card);
+}
+.bg-e2 {
+    background-color: var(--e2);
+}
+.bg-primary\/10 {
+    background-color: var(--badge-bg);
+}
+.bg-primary\/20 {
+    background-color: var(--icon-hover-bg);
+}
+.bg-primary2 {
+    background-color: var(--primary2);
+}
+
+.text-primary {
+    color: var(--primary);
+}
+.text-tm {
+    color: var(--tm);
+}
+.text-tl {
+    color: var(--tl);
+}
+
+.border-ol {
+    border-color: var(--ol);
+}
+
+/* ============================================
+   OVERRIDES
+   ============================================ */
+
+body:has(.profile-page) .hp-button-outline {
+    color: var(--tm) !important;
+    border-color: var(--ol) !important;
+}
+
+body:has(.profile-page) .hp-button-outline:hover {
+    color: var(--primary) !important;
+    border-color: var(--primary2) !important;
+    background: var(--icon-hover-bg) !important;
+}
+
+body:has(.profile-page) .hp-button-solid {
+    color: #fff !important;
+}
+
+/* ============================================
+   AVATAR NEON RING
+   ============================================ */
+
+.avatar-wrap {
+    position: relative;
+    width: 11rem;
+    height: 11rem;
+}
+
+.avatar-wrap::before {
+    content: '';
+    position: absolute;
+    inset: -10px;
+    border-radius: 9999px;
+    background: conic-gradient(
+        from 0deg,
+        transparent 0deg,
+        #8b5cf6 8deg,
+        #8b5cf6 58deg,
+        #5b3a8c 108deg,
+        transparent 113deg,
+        transparent 117deg,
+        transparent 117deg,
+        #8b5cf6 125deg,
+        #8b5cf6 178deg,
+        #5b3a8c 228deg,
+        transparent 233deg,
+        transparent 237deg,
+        transparent 237deg,
+        #8b5cf6 245deg,
+        #8b5cf6 298deg,
+        #5b3a8c 348deg,
+        transparent 353deg,
+        transparent 357deg
+    );
+    animation: spin 18s linear infinite;
+    z-index: 0;
+    -webkit-mask: radial-gradient(
+        farthest-side,
+        transparent calc(100% - 1px),
+        #000 calc(100% - 1px),
+        #000 100%,
+        transparent 100%
+    );
+    mask: radial-gradient(
+        farthest-side,
+        transparent calc(100% - 1px),
+        #000 calc(100% - 1px),
+        #000 100%,
+        transparent 100%
+    );
+}
+
+.avatar-wrap::after {
+    content: '';
+    position: absolute;
+    inset: -10px;
+    border-radius: 9999px;
+    background: conic-gradient(
+        from 0deg,
+        transparent 0deg,
+        #8b5cf6 8deg,
+        #8b5cf6 58deg,
+        #5b3a8c 108deg,
+        transparent 113deg,
+        transparent 117deg,
+        transparent 117deg,
+        #8b5cf6 125deg,
+        #8b5cf6 178deg,
+        #5b3a8c 228deg,
+        transparent 233deg,
+        transparent 237deg,
+        transparent 237deg,
+        #8b5cf6 245deg,
+        #8b5cf6 298deg,
+        #5b3a8c 348deg,
+        transparent 353deg,
+        transparent 357deg
+    );
+    filter: blur(3px);
+    opacity: 0.6;
+    animation: spin 18s linear infinite;
+    z-index: 0;
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 calc(100% - 1px), transparent 100%);
+    mask: radial-gradient(farthest-side, transparent calc(100% - 4px), #000 calc(100% - 1px), transparent 100%);
+}
+
+.avatar-ring-glow {
+    position: absolute;
+    inset: -10px;
+    border-radius: 9999px;
+    background: conic-gradient(
+        from 0deg,
+        transparent 0deg,
+        #8b5cf6 8deg,
+        #8b5cf6 58deg,
+        #5b3a8c 108deg,
+        transparent 113deg,
+        transparent 117deg,
+        transparent 117deg,
+        #8b5cf6 125deg,
+        #8b5cf6 178deg,
+        #5b3a8c 228deg,
+        transparent 233deg,
+        transparent 237deg,
+        transparent 237deg,
+        #8b5cf6 245deg,
+        #8b5cf6 298deg,
+        #5b3a8c 348deg,
+        transparent 353deg,
+        transparent 357deg
+    );
+    filter: blur(9px);
+    opacity: 0.35;
+    animation: spin 18s linear infinite;
+    z-index: 0;
+    -webkit-mask: radial-gradient(farthest-side, transparent calc(100% - 6px), #000 calc(100% - 1px), transparent 100%);
+    mask: radial-gradient(farthest-side, transparent calc(100% - 6px), #000 calc(100% - 1px), transparent 100%);
+}
+
+.avatar-core {
+    position: relative;
+    z-index: 1;
+    width: 100%;
+    height: 100%;
+    border-radius: 9999px;
+    background: linear-gradient(135deg, #782bf1, #9b5de5);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: 'Outfit', sans-serif;
+    font-weight: 700;
+    font-size: 3rem;
+    color: #fff;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .avatar-wrap::before,
+    .avatar-wrap::after,
+    .avatar-ring-glow {
+        animation: none;
+    }
+}
+
+/* ============================================
+   GLOW RULE (underline under name)
+   ============================================ */
+
+.glow-rule {
+    height: 2px;
+    width: 48px;
+    background: linear-gradient(90deg, #782bf1, #00f0ff);
+    border-radius: 2px;
+}
+
+/* ============================================
+   SKILL DIVIDER
+   ============================================ */
+
+.skill-divider {
+    height: 1px;
+    width: 100%;
+    background: var(--divider);
+    border-radius: 1px;
+}
+
+/* ============================================
+   SKILL CHIP HOVER
+   ============================================ */
+
+.skill-chip {
+    transition:
+        transform 0.15s ease,
+        border-color 0.15s ease;
+}
+
+.skill-chip:hover {
+    transform: translateY(-2px);
+    border-color: var(--skill-chip-hover-border);
+}
+
+.skill-chip-lang {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 14px;
+    border-radius: 8px;
+    font-size: 12px;
+    font-weight: 500;
+    background: var(--chip-gray-bg);
+    border: 1px solid var(--chip-gray-border);
+    color: var(--chip-gray-text);
+}
+
+/* ============================================
+   CARD
+   ============================================ */
+
+.card {
+    background: var(--card);
+    border: 1px solid var(--ol);
+    border-radius: 0.9rem;
+}
+
+/* ============================================
+   XP PROGRESS BAR
+   ============================================ */
+
+.xp-track {
+    background: var(--ol);
+}
+
+.xp-bar {
+    background: linear-gradient(90deg, #782bf1, #9b5de5);
+    transition: width 0.6s ease;
+}
+
+/* ============================================
+   STATUS DOT
+   ============================================ */
+
+.status-dot {
+    box-shadow: 0 0 0 4px rgba(74, 222, 128, 0.15);
+}

--- a/app-modules/profile/resources/views/public-profile.blade.php
+++ b/app-modules/profile/resources/views/public-profile.blade.php
@@ -1,0 +1,343 @@
+<x-portal::layouts.app title="{{ $profile->nickname ?? $user->name }} — He4rt Devs">
+    <div class="min-h-screen bg-gray-50 dark:bg-[#0d1117]">
+        <div class="mx-auto max-w-5xl px-4 pt-8 pb-6">
+            <div class="flex flex-col items-center gap-4 sm:flex-row sm:items-center sm:gap-6">
+                <div class="shrink-0">
+                    <div
+                        class="flex size-24 items-center justify-center rounded-full bg-purple-600 text-3xl font-bold text-white ring-4 ring-gray-50 sm:size-28 dark:ring-[#0d1117]"
+                    >
+                        {{ strtoupper(substr($user->name, 0, 1)) }}{{
+                            strtoupper(
+                                substr(explode(' ', $user->name)[1] ?? '', 0, 1),
+                            )
+                        }}
+                    </div>
+                </div>
+
+                <div class="flex-1 text-center sm:text-left">
+                    @if ($profile->available_for_proposals)
+                        <h1 class="text-text-high text-2xl font-bold">{{ $profile->nickname ?? $user->name }}</h1>
+                        <p class="text-text-medium mt-1 text-sm">
+                            @if ($profile->headline)
+                                {{ $profile->headline }}
+                            @elseif ($profile->seniority_level)
+                                {{
+                                    __(
+                                        'profile::enums.seniority_level.' . $profile->seniority_level->value,
+                                    )
+                                }}
+                                @if ($profile->years_experience) ·{{ $profile->years_experience }}anos de experiência @endif
+                            @endif
+                        </p>
+                        <span
+                            class="mt-2 -ml-1 inline-flex items-center gap-1.5 rounded-full border border-green-500/30 bg-green-500/10 px-3 py-1 text-xs font-medium text-green-600 dark:text-green-400"
+                        >
+                            Disponível para propostas
+                            <x-filament::icon icon="heroicon-s-check-circle" class="size-3.5" />
+                        </span>
+                    @else
+                        <h1 class="text-text-high mt-8 text-2xl font-bold">{{ $profile->nickname ?? $user->name }}</h1>
+                        <p class="text-text-medium mt-2 text-sm">
+                            @if ($profile->headline)
+                                {{ $profile->headline }}
+                            @elseif ($profile->seniority_level)
+                                {{
+                                    __(
+                                        'profile::enums.seniority_level.' . $profile->seniority_level->value,
+                                    )
+                                }}
+                                @if ($profile->years_experience) ·{{ $profile->years_experience }}anos de experiência @endif
+                            @endif
+                        </p>
+                    @endif
+
+                    <div class="mt-3 flex items-center justify-center gap-2 sm:justify-start">
+                        @if ($profile->social_links)
+                            @foreach (['github', 'linkedin'] as $platform)
+                                @if ($url = $profile->social_links[$platform] ?? null)
+                                    <a
+                                        href="{{ $url }}"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="text-text-medium hover:text-text-high flex size-8 items-center justify-center rounded-full bg-gray-100 transition-colors dark:bg-white/5"
+                                    >
+                                        @switch ($platform)
+                                            @case ('github')
+                                                <x-filament::icon icon="fab-github" class="size-4" />
+                                                @break
+                                            @case ('linkedin')
+                                                <x-filament::icon icon="fab-linkedin" class="size-4" />
+                                                @break
+                                        @endswitch
+                                    </a>
+                                @endif
+                            @endforeach
+                        @endif
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <div class="mx-auto max-w-5xl px-4 pb-16">
+            <div class="flex flex-col gap-6 lg:grid lg:grid-cols-3">
+                <div class="flex flex-col gap-6 lg:col-span-2">
+                    @if ($profile->about || $profile->seniority_level || $profile->years_experience)
+                        <div
+                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
+                        >
+                            <h2 class="text-text-high mb-3 text-base font-semibold">Sobre</h2>
+                            @if ($profile->about)
+                                <p class="text-text-medium text-sm leading-relaxed">{{ $profile->about }}</p>
+                            @endif
+                        </div>
+                    @endif
+
+                    <div class="rounded-xl border border-purple-500/20 bg-white p-5 lg:hidden dark:bg-[#161b22]">
+                        <h2 class="text-text-high mb-4 flex items-center gap-2 text-sm font-semibold">
+                            Resumo para Recrutadores
+                            <x-filament::icon icon="heroicon-s-document-text" class="size-4 text-purple-400" />
+                        </h2>
+                        <div class="grid grid-cols-2 gap-4">
+                            @if ($profile->seniority_level)
+                                <div>
+                                    <p class="text-text-medium text-xs">Senioridade</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{
+                                        __(
+                                            'profile::enums.seniority_level.' . $profile->seniority_level->value,
+                                        )
+                                    }}</p>
+                                </div>
+                            @endif
+                            @if ($profile->years_experience)
+                                <div>
+                                    <p class="text-text-medium text-xs">Experiência</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $profile->years_experience }} anos</p>
+                                </div>
+                            @endif
+                            @if ($user->address)
+                                <div>
+                                    <p class="text-text-medium text-xs">Localização</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $user->address->city }}{{
+                                        $user->address->state
+                                            ? ', ' . $user->address->state
+                                            : ''
+                                    }}</p>
+                                </div>
+                            @endif
+                            @if ($profile->start_availability)
+                                <div>
+                                    <p class="text-text-medium text-xs">Início</p>
+                                    <p class="mt-0.5 rounded-md bg-gradient-to-r from-purple-600 to-indigo-600 px-2 py-0.5 text-sm font-semibold text-white">
+                                        {{
+                                            __(
+                                                'profile::enums.start_availability.' . $profile->start_availability->value,
+                                            )
+                                        }}
+                                    </p>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+
+                    @if ($user->character)
+                        <div
+                            class="rounded-xl border border-gray-200 bg-white p-5 lg:hidden dark:border-white/5 dark:bg-[#161b22]"
+                        >
+                            <div class="flex items-center gap-3">
+                                <div
+                                    class="flex size-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-600/20"
+                                >
+                                    <x-filament::icon
+                                        icon="heroicon-s-star"
+                                        class="size-5 text-purple-500 dark:text-purple-400"
+                                    />
+                                </div>
+                                <div>
+                                    <p class="text-text-medium text-xs">Nível da Comunidade</p>
+                                    <p class="text-text-high text-lg font-bold">{{ $user->character->level }}</p>
+                                </div>
+                            </div>
+                            <div class="mt-3">
+                                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-white/5">
+                                    <div
+                                        class="h-full rounded-full bg-purple-500"
+                                        style="width: {{ $user->character->percentage_experience }}%"
+                                    ></div>
+                                </div>
+                                <p class="text-text-medium mt-1 text-xs">{{ number_format($user->character->experience) }} XP · {{ number_format($user->character->experience_progress) }} para o próximo nível</p>
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($user->character && $user->character->badges->isNotEmpty())
+                        <div
+                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
+                        >
+                            <h2 class="text-text-high mb-3 text-base font-semibold">Badges He4rt</h2>
+                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                @foreach ($user->character->badges as $badge)
+                                    <div
+                                        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-white/5 dark:bg-[#1c2128]"
+                                    >
+                                        <div
+                                            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-600/20"
+                                        >
+                                            @if ($badge->getFirstMediaUrl('badge'))
+                                                <img
+                                                    src="{{ $badge->getFirstMediaUrl('badge') }}"
+                                                    alt="{{ $badge->name }}"
+                                                    class="size-5 object-contain"
+                                                />
+                                            @else
+                                                <x-filament::icon
+                                                    icon="heroicon-s-star"
+                                                    class="size-5 text-purple-500 dark:text-purple-400"
+                                                />
+                                            @endif
+                                        </div>
+                                        <div class="min-w-0 flex-1">
+                                            <h4 class="text-text-high text-sm font-medium">{{ $badge->name }}</h4>
+                                            @if ($badge->description)
+                                                <p class="text-text-medium mt-0.5 line-clamp-2 text-xs">{{ $badge->description }}</p>
+                                            @endif
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endif
+
+                    @if ($connectedAccounts->isNotEmpty())
+                        <div
+                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
+                        >
+                            <h2 class="text-text-high mb-3 text-base font-semibold">Contas Conectadas</h2>
+                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                @foreach ($connectedAccounts as $account)
+                                    <a
+                                        href="{{ $account['url'] }}"
+                                        target="_blank"
+                                        rel="noopener noreferrer"
+                                        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 transition-colors hover:bg-gray-100 dark:border-white/5 dark:bg-[#1c2128] dark:hover:bg-[#21262d]"
+                                    >
+                                        <div class="text-text-medium flex size-8 shrink-0 items-center justify-center">
+                                            @switch ($account['provider'])
+                                                @case ('github')
+                                                    <x-filament::icon icon="fab-github" class="size-5" />
+                                                    @break
+                                                @case ('discord')
+                                                    <x-filament::icon icon="fab-discord" class="size-5" />
+                                                    @break
+                                                @case ('linkedin')
+                                                    <x-filament::icon icon="fab-linkedin" class="size-5" />
+                                                    @break
+                                                @case ('twitter')
+                                                    <x-filament::icon icon="fab-x-twitter" class="size-5" />
+                                                    @break
+                                                @case ('devto')
+                                                    <x-filament::icon icon="fab-dev" class="size-5" />
+                                                    @break
+                                                @case ('youtube')
+                                                    <x-filament::icon icon="fab-youtube" class="size-5" />
+                                                    @break
+                                                @case ('instagram')
+                                                    <x-filament::icon icon="fab-instagram" class="size-5" />
+                                                    @break
+                                                @default
+                                                    <x-filament::icon icon="heroicon-o-link" class="size-5" />
+                                            @endswitch
+                                        </div>
+                                        <div class="min-w-0 flex-1">
+                                            <p class="text-text-high text-sm font-medium">{{ ucfirst($account['label']) }}</p>
+                                            <p class="text-text-medium truncate text-xs">{{ parse_url($account['url'], PHP_URL_HOST) }}</p>
+                                        </div>
+                                    </a>
+                                @endforeach
+                            </div>
+                        </div>
+                    @endif
+                </div>
+
+                <div class="hidden flex-col gap-6 lg:flex">
+                    <div class="rounded-xl border border-purple-500/20 bg-white p-5 dark:bg-[#161b22]">
+                        <h2 class="text-text-high mb-4 flex items-center gap-2 text-sm font-semibold">
+                            Resumo para Recrutadores
+                            <x-filament::icon icon="heroicon-s-document-text" class="size-4 text-purple-400" />
+                        </h2>
+                        <div class="grid grid-cols-2 gap-4">
+                            @if ($profile->seniority_level)
+                                <div>
+                                    <p class="text-text-medium text-xs">Senioridade</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{
+                                        __(
+                                            'profile::enums.seniority_level.' . $profile->seniority_level->value,
+                                        )
+                                    }}</p>
+                                </div>
+                            @endif
+                            @if ($profile->years_experience)
+                                <div>
+                                    <p class="text-text-medium text-xs">Experiência</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $profile->years_experience }} anos</p>
+                                </div>
+                            @endif
+                            @if ($user->address)
+                                <div>
+                                    <p class="text-text-medium text-xs">Localização</p>
+                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $user->address->city }}{{
+                                        $user->address->state
+                                            ? ', ' . $user->address->state
+                                            : ''
+                                    }}</p>
+                                </div>
+                            @endif
+                            @if ($profile->start_availability)
+                                <div>
+                                    <p class="text-text-medium text-xs">Início</p>
+                                    <p class="mt-0.5 rounded-md bg-gradient-to-r from-purple-600 to-indigo-600 px-2 py-0.5 text-sm font-semibold text-white">
+                                        {{
+                                            __(
+                                                'profile::enums.start_availability.' . $profile->start_availability->value,
+                                            )
+                                        }}
+                                    </p>
+                                </div>
+                            @endif
+                        </div>
+                    </div>
+
+                    {{-- Level --}}
+                    @if ($user->character)
+                        <div
+                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
+                        >
+                            <div class="flex items-center gap-3">
+                                <div
+                                    class="flex size-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-600/20"
+                                >
+                                    <x-filament::icon
+                                        icon="heroicon-s-star"
+                                        class="size-5 text-purple-500 dark:text-purple-400"
+                                    />
+                                </div>
+                                <div>
+                                    <p class="text-text-medium text-xs">Nível da Comunidade</p>
+                                    <p class="text-text-high text-lg font-bold">{{ $user->character->level }}</p>
+                                </div>
+                            </div>
+                            <div class="mt-3">
+                                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-white/5">
+                                    <div
+                                        class="h-full rounded-full bg-purple-500"
+                                        style="width: {{ $user->character->percentage_experience }}%"
+                                    ></div>
+                                </div>
+                                <p class="text-text-medium mt-1 text-xs">{{ number_format($user->character->experience) }} XP · {{ number_format($user->character->experience_progress) }} para o próximo nível</p>
+                            </div>
+                        </div>
+                    @endif
+                </div>
+            </div>
+        </div>
+    </div>
+</x-portal::layouts.app>

--- a/app-modules/profile/resources/views/public-profile.blade.php
+++ b/app-modules/profile/resources/views/public-profile.blade.php
@@ -1,186 +1,484 @@
 <x-portal::layouts.app title="{{ $profile->nickname ?? $user->name }} — He4rt Devs">
-    <div class="min-h-screen bg-gray-50 dark:bg-[#0d1117]">
-        <div class="mx-auto max-w-5xl px-4 pt-8 pb-6">
-            <div class="flex flex-col items-center gap-4 sm:flex-row sm:items-center sm:gap-6">
-                <div class="shrink-0">
-                    <div
-                        class="flex size-24 items-center justify-center rounded-full bg-purple-600 text-3xl font-bold text-white ring-4 ring-gray-50 sm:size-28 dark:ring-[#0d1117]"
-                    >
-                        {{ strtoupper(substr($user->name, 0, 1)) }}{{
-                            strtoupper(
-                                substr(explode(' ', $user->name)[1] ?? '', 0, 1),
-                            )
-                        }}
-                    </div>
-                </div>
+    @push ('styles')
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" />
+        @vite (['app-modules/profile/resources/css/profile.css'])
+    @endpush
 
-                <div class="flex-1 text-center sm:text-left">
-                    @if ($profile->available_for_proposals)
-                        <h1 class="text-text-high text-2xl font-bold">{{ $profile->nickname ?? $user->name }}</h1>
-                        <p class="text-text-medium mt-1 text-sm">
-                            @if ($profile->headline)
-                                {{ $profile->headline }}
-                            @elseif ($profile->seniority_level)
-                                {{
-                                    __(
-                                        'profile::enums.seniority_level.' . $profile->seniority_level->value,
-                                    )
-                                }}
-                                @if ($profile->years_experience) ·{{ $profile->years_experience }}anos de experiência @endif
+    <div class="profile-page">
+        <div class="mx-auto max-w-6xl px-4 py-10">
+            <div class="grid grid-cols-1 gap-8 lg:grid-cols-[300px_1fr]">
+                <!-- Sidebar -->
+                <aside class="flex flex-col gap-5 lg:sticky lg:top-10 lg:self-start">
+                    <div class="flex justify-center lg:justify-start">
+                        <div class="avatar-wrap">
+                            <div class="avatar-ring-glow"></div>
+                            <div class="avatar-core">
+                                @if ($user->getFirstMediaUrl('avatar'))
+                                    <img
+                                        src="{{ $user->getFirstMediaUrl('avatar') }}"
+                                        alt="{{ $user->name }}"
+                                        class="size-full rounded-full object-cover"
+                                    />
+                                @else
+                                    <img
+                                        src="https://i.pravatar.cc/300?u={{ $user->username }}"
+                                        alt="{{ $user->name }}"
+                                        class="size-full rounded-full object-cover"
+                                    />
+                                @endif
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="text-center lg:text-left">
+                        <h1 class="font-display inline-flex items-center gap-2 text-2xl font-bold">
+                            {{ $user->name }}
+                            @if ($user->character && $user->character->badges->contains('redeem_code', 'H4_VERIFIED'))
+                                <span
+                                    class="bg-e2 border-ol inline-flex items-center gap-1 rounded-full border px-2 py-0.5"
+                                    title="Verificado He4rt"
+                                >
+                                    <span class="text-primary text-[9px] leading-none font-bold">H4</span>
+                                    <svg viewBox="0 0 600 513" xmlns="http://www.w3.org/2000/svg" class="size-[9px] shrink-0" fill="#782bf1">
+                                        <path d="M445.237 0.00033551C424.91 -0.0347431 404.777 3.89304 385.996 11.5576C367.216 19.2221 350.159 30.4719 335.808 44.6594L153.391 224.398L116.915 188.45C111.983 183.761 108.048 178.15 105.341 171.946C102.633 165.741 101.207 159.067 101.145 152.314C101.084 145.56 102.388 138.862 104.983 132.611C107.577 126.359 111.409 120.68 116.255 115.904C121.101 111.128 126.864 107.352 133.207 104.795C139.55 102.239 146.347 100.953 153.2 101.014C160.052 101.074 166.825 102.48 173.12 105.148C179.416 107.816 185.109 111.694 189.867 116.555L262.856 44.6594C233.71 16.6424 194.537 1.07109 153.824 1.31914C113.11 1.56719 74.1349 17.6146 45.3431 45.9846C16.5513 74.3546 0.261527 112.762 0.0031216 152.886C-0.255283 193.01 15.5385 231.618 43.9626 260.346L153.391 368.189L511.948 14.8274C491.12 5.01981 468.32 -0.0474973 445.237 0.00033551Z" />
+                                        <path d="M584.9 86.7579L445.237 224.433L408.76 188.45L335.808 260.345L372.284 296.293L226.379 440.084L299.332 512.015L554.665 260.381C577.296 238.07 592.355 209.395 597.769 178.303C603.183 147.21 598.687 115.228 584.9 86.7579Z" />
+                                    </svg>
+                                </span>
                             @endif
-                        </p>
-                        <span
-                            class="mt-2 -ml-1 inline-flex items-center gap-1.5 rounded-full border border-green-500/30 bg-green-500/10 px-3 py-1 text-xs font-medium text-green-600 dark:text-green-400"
-                        >
-                            Disponível para propostas
-                            <x-filament::icon icon="heroicon-s-check-circle" class="size-3.5" />
-                        </span>
-                    @else
-                        <h1 class="text-text-high mt-8 text-2xl font-bold">{{ $profile->nickname ?? $user->name }}</h1>
-                        <p class="text-text-medium mt-2 text-sm">
-                            @if ($profile->headline)
-                                {{ $profile->headline }}
-                            @elseif ($profile->seniority_level)
-                                {{
-                                    __(
-                                        'profile::enums.seniority_level.' . $profile->seniority_level->value,
-                                    )
-                                }}
-                                @if ($profile->years_experience) ·{{ $profile->years_experience }}anos de experiência @endif
+                        </h1>
+                        <div class="glow-rule mx-auto mt-2 lg:mx-0"></div>
+                    </div>
+
+                    @if ($profile->headline || $profile->seniority_level)
+                        <div class="flex items-center justify-center gap-2 lg:justify-start">
+                            <p class="text-tm text-sm">{{
+                                $profile->headline ??
+                                    __('profile::enums.seniority_level.' . $profile->seniority_level->value, [], 'pt_BR')
+                            }}</p>
+                            @if ($profile->seniority_level)
+                                <span
+                                    class="bg-primary/10 text-primary border-primary/20 inline-flex items-center rounded-full border px-2.5 py-0.5 text-[11px] font-medium"
+                                >
+                                    {{
+                                        __(
+                                            'profile::enums.seniority_level.' . $profile->seniority_level->value,
+                                            [],
+                                            'pt_BR',
+                                        )
+                                    }}
+                                </span>
                             @endif
-                        </p>
+                        </div>
                     @endif
 
-                    <div class="mt-3 flex items-center justify-center gap-2 sm:justify-start">
-                        @if ($profile->social_links)
-                            @foreach (['github', 'linkedin'] as $platform)
-                                @if ($url = $profile->social_links[$platform] ?? null)
+                    @if ($user->address)
+                        <div class="text-tm flex items-center justify-center gap-1.5 text-sm lg:justify-start">
+                            <i class="fa-solid fa-location-dot text-tl text-xs"></i>
+                            {{ $user->address->city }}{{
+                                $user->address->state
+                                    ? ', ' . $user->address->state
+                                    : ''
+                            }}
+                        </div>
+                    @endif
+
+                    @if ($profile->work_types && count($profile->work_types) > 0)
+                        <div class="flex flex-wrap items-center justify-center gap-1.5 lg:justify-start">
+                            @foreach ($profile->work_types as $workType)
+                                <span
+                                    class="inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-[11px] font-medium"
+                                    style="
+                                        background: var(--status-green-bg);
+                                        border: 1px solid var(--status-green-border);
+                                        color: var(--status-green-text);
+                                    "
+                                >
+                                    <i class="fa-solid fa-check text-[10px]"></i>
+                                    {{
+                                        __(
+                                            'profile::enums.work_type.' . $workType,
+                                            [],
+                                            'pt_BR',
+                                        )
+                                    }}
+                                </span>
+                            @endforeach
+                        </div>
+                    @endif
+
+                    @if ($profile->social_links && count($profile->social_links) > 0)
+                        <div class="flex items-center justify-center gap-2 lg:justify-start">
+                            @foreach ($profile->social_links as $platform => $url)
+                                @if ($url)
                                     <a
                                         href="{{ $url }}"
                                         target="_blank"
-                                        rel="noopener noreferrer"
-                                        class="text-text-medium hover:text-text-high flex size-8 items-center justify-center rounded-full bg-gray-100 transition-colors dark:bg-white/5"
+                                        class="card text-tm hover:bg-primary/20 flex size-9 items-center justify-center rounded-lg transition-colors hover:text-white"
                                     >
-                                        @switch ($platform)
-                                            @case ('github')
-                                                <x-filament::icon icon="fab-github" class="size-4" />
-                                                @break
-                                            @case ('linkedin')
-                                                <x-filament::icon icon="fab-linkedin" class="size-4" />
-                                                @break
-                                        @endswitch
+                                        <i class="{{ $socialIcons[$platform] ?? 'fas fa-link' }} text-base"></i>
                                     </a>
                                 @endif
                             @endforeach
-                        @endif
-                    </div>
-                </div>
-            </div>
-        </div>
-
-        <div class="mx-auto max-w-5xl px-4 pb-16">
-            <div class="flex flex-col gap-6 lg:grid lg:grid-cols-3">
-                <div class="flex flex-col gap-6 lg:col-span-2">
-                    @if ($profile->about || $profile->seniority_level || $profile->years_experience)
-                        <div
-                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
-                        >
-                            <h2 class="text-text-high mb-3 text-base font-semibold">Sobre</h2>
-                            @if ($profile->about)
-                                <p class="text-text-medium text-sm leading-relaxed">{{ $profile->about }}</p>
-                            @endif
                         </div>
                     @endif
 
-                    <div class="rounded-xl border border-purple-500/20 bg-white p-5 lg:hidden dark:bg-[#161b22]">
-                        <h2 class="text-text-high mb-4 flex items-center gap-2 text-sm font-semibold">
-                            Resumo para Recrutadores
-                            <x-filament::icon icon="heroicon-s-document-text" class="size-4 text-purple-400" />
-                        </h2>
-                        <div class="grid grid-cols-2 gap-4">
-                            @if ($profile->seniority_level)
-                                <div>
-                                    <p class="text-text-medium text-xs">Senioridade</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{
-                                        __(
-                                            'profile::enums.seniority_level.' . $profile->seniority_level->value,
-                                        )
-                                    }}</p>
-                                </div>
-                            @endif
-                            @if ($profile->years_experience)
-                                <div>
-                                    <p class="text-text-medium text-xs">Experiência</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $profile->years_experience }} anos</p>
-                                </div>
-                            @endif
-                            @if ($user->address)
-                                <div>
-                                    <p class="text-text-medium text-xs">Localização</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $user->address->city }}{{
-                                        $user->address->state
-                                            ? ', ' . $user->address->state
-                                            : ''
-                                    }}</p>
-                                </div>
-                            @endif
-                            @if ($profile->start_availability)
-                                <div>
-                                    <p class="text-text-medium text-xs">Início</p>
-                                    <p class="mt-0.5 rounded-md bg-gradient-to-r from-purple-600 to-indigo-600 px-2 py-0.5 text-sm font-semibold text-white">
-                                        {{
-                                            __(
-                                                'profile::enums.start_availability.' . $profile->start_availability->value,
-                                            )
-                                        }}
-                                    </p>
-                                </div>
-                            @endif
-                        </div>
-                    </div>
+                    @if ($resumeUrl)
+                        <a
+                            href="{{ $resumeUrl }}"
+                            target="_blank"
+                            class="card text-tm hover:bg-primary/20 flex items-center justify-center gap-2 rounded-lg px-4 py-2.5 text-sm font-medium transition-colors hover:text-white"
+                        >
+                            <i class="fa-solid fa-download text-sm"></i>
+                            Download do currículo
+                        </a>
+                    @endif
 
                     @if ($user->character)
-                        <div
-                            class="rounded-xl border border-gray-200 bg-white p-5 lg:hidden dark:border-white/5 dark:bg-[#161b22]"
-                        >
+                        <div class="card p-5">
                             <div class="flex items-center gap-3">
-                                <div
-                                    class="flex size-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-600/20"
-                                >
-                                    <x-filament::icon
-                                        icon="heroicon-s-star"
-                                        class="size-5 text-purple-500 dark:text-purple-400"
-                                    />
+                                <div class="bg-primary/10 flex size-10 items-center justify-center rounded-full">
+                                    <svg class="text-primary size-5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
                                 </div>
                                 <div>
-                                    <p class="text-text-medium text-xs">Nível da Comunidade</p>
-                                    <p class="text-text-high text-lg font-bold">{{ $user->character->level }}</p>
+                                    <p class="text-tl text-xs">Nível da Comunidade</p>
+                                    <p class="font-display text-lg font-bold">{{ $user->character->level }}</p>
                                 </div>
                             </div>
-                            <div class="mt-3">
-                                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-white/5">
+                            <div class="mt-4">
+                                @php
+                                    $xpBarLevel = $user->character->level;
+                                    $xpBarNext = \He4rt\Gamification\Character\Models\Character::LEVEL_THRESHOLDS[$xpBarLevel + 1] ?? 1;
+                                    $xpBarPercent = $xpBarNext > 0 ? round(($user->character->experience / $xpBarNext) * 100, 1) : 100;
+                                @endphp
+                                <div class="xp-track h-2 w-full overflow-hidden rounded-full">
                                     <div
-                                        class="h-full rounded-full bg-purple-500"
-                                        style="width: {{ $user->character->percentage_experience }}%"
+                                        class="xp-bar h-full rounded-full"
+                                        style="width: {{ max($xpBarPercent, 1) }}%;"
                                     ></div>
                                 </div>
-                                <p class="text-text-medium mt-1 text-xs">{{ number_format($user->character->experience) }} XP · {{ number_format($user->character->experience_progress) }} para o próximo nível</p>
+                                <p class="text-tm mt-2 text-xs">{{ number_format($user->character->experience) }} XP · {{ number_format($user->character->experience_progress) }} para o próximo nível</p>
+                            </div>
+                        </div>
+                    @endif
+                </aside>
+
+                <!-- Main -->
+                <main class="flex flex-col gap-6">
+                    @if ($profile->about)
+                        <div class="card p-6">
+                            <h2 class="font-display mb-4 text-lg font-semibold">Sobre</h2>
+                            <p class="text-tm text-base leading-relaxed">{{ $profile->about }}</p>
+                        </div>
+                    @endif
+
+                    @php
+                        $allSkills = collect($profile->skillsByCategory());
+                        $hasLanguages = $profile->languages && count($profile->languages) > 0;
+                    @endphp
+                    @if ($allSkills->isNotEmpty() || $hasLanguages)
+                        <div class="card p-6">
+                            <h2 class="font-display mb-4 text-base font-semibold">Stack & Skills</h2>
+                            <div class="flex flex-col gap-4">
+                                @php
+                                    $chipPurple = 'skill-chip inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium';
+                                    $chipPurpleStyle =
+                                        'background:var(--chip-purple-bg);border:1px solid var(--chip-purple-border);color:var(--chip-purple-text)';
+                                    $chipCyan = 'skill-chip inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium';
+                                    $chipCyanStyle = 'background:var(--chip-cyan-bg);border:1px solid var(--chip-cyan-border);color:var(--chip-cyan-text)';
+                                    $chipGray = 'skill-chip inline-flex items-center gap-1.5 rounded-lg px-2.5 py-1 text-xs font-medium';
+                                    $chipGrayStyle = 'background:var(--chip-gray-bg);border:1px solid var(--chip-gray-border);color:var(--chip-gray-text)';
+                                @endphp
+
+                                @php
+                                    $langFw = $allSkills->where('category', 'languages_frameworks');
+                                @endphp
+                                @if ($langFw->isNotEmpty())
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach ($langFw as $skill)
+                                            <span class="{{ $chipPurple }}" style="{{ $chipPurpleStyle }}">
+                                                @if ($skill['icon'])
+                                                    <i class="{{ $skill['icon'] }} text-[11px]"></i>
+                                                @endif
+                                                {{ $skill['name'] }}
+                                            </span>
+                                        @endforeach
+                                    </div>
+                                @endif
+
+                                @php
+                                    $infraDb = $allSkills->where('category', 'infra_databases');
+                                @endphp
+                                @if ($infraDb->isNotEmpty())
+                                    <div class="skill-divider"></div>
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach ($infraDb as $skill)
+                                            <span class="{{ $chipCyan }}" style="{{ $chipCyanStyle }}">
+                                                @if ($skill['icon'])
+                                                    <i class="{{ $skill['icon'] }} text-[11px]"></i>
+                                                @endif
+                                                {{ $skill['name'] }}
+                                            </span>
+                                        @endforeach
+                                    </div>
+                                @endif
+
+                                @php
+                                    $softTools = $allSkills->where('category', 'softskills_tools');
+                                @endphp
+                                @if ($softTools->isNotEmpty())
+                                    <div class="skill-divider"></div>
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach ($softTools as $skill)
+                                            <span class="{{ $chipGray }}" style="{{ $chipGrayStyle }}">
+                                                @if ($skill['icon'])
+                                                    <i class="{{ $skill['icon'] }} text-[11px]"></i>
+                                                @endif
+                                                {{ $skill['name'] }}
+                                            </span>
+                                        @endforeach
+                                    </div>
+                                @endif
+
+                                @if ($profile->languages && count($profile->languages) > 0)
+                                    <div class="skill-divider"></div>
+                                    <div class="flex flex-wrap gap-2">
+                                        @foreach ($profile->languages as $lang)
+                                            <span class="{{ $chipGray }}" style="{{ $chipGrayStyle }}">
+                                                <i class="fa-solid fa-globe text-[11px]"></i>
+                                                {{ $lang['name'] }} · {{ $lang['level'] }}
+                                            </span>
+                                        @endforeach
+                                    </div>
+                                @endif
                             </div>
                         </div>
                     @endif
 
-                    @if ($user->character && $user->character->badges->isNotEmpty())
-                        <div
-                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
-                        >
-                            <h2 class="text-text-high mb-3 text-base font-semibold">Badges He4rt</h2>
-                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                                @foreach ($user->character->badges as $badge)
-                                    <div
-                                        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 dark:border-white/5 dark:bg-[#1c2128]"
-                                    >
+                    <!-- Projetos -->
+                    @if ($projects->isNotEmpty())
+                        <div class="card p-6" x-data="{ expanded: false }">
+                            <h2 class="font-display mb-4 text-base font-semibold">Projetos</h2>
+                            @foreach ($projects->take(3) as $project)
+                                <div class="rounded-lg border border-ol bg-e2 p-5 {{ !$loop->first ? 'mt-3' : '' }}">
+                                    <div class="flex items-start justify-between gap-3">
+                                        <div class="min-w-0 flex-1">
+                                            <h3 class="text-sm font-semibold">{{ $project->name }}</h3>
+                                            <p class="text-tm mt-1 text-xs leading-relaxed">{{ $project->description }}</p>
+                                        </div>
+                                        @if ($project->url)
+                                            <a
+                                                href="{{ $project->url }}"
+                                                target="_blank"
+                                                class="text-tm hover:text-primary shrink-0 transition-colors"
+                                            >
+                                                <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
+                                            </a>
+                                        @endif
+                                    </div>
+                                    @if ($project->tags)
+                                        <div class="mt-3 flex flex-wrap gap-1.5">
+                                            @foreach ($project->tags as $tag)
+                                                <span
+                                                    class="bg-e2 border-ol text-tm rounded-md border px-1.5 py-0.5 text-[10px] font-medium"
+                                                    >{{ $tag }}</span
+                                                >
+                                            @endforeach
+                                        </div>
+                                    @endif
+                                    @if ($project->stars || $project->forks)
                                         <div
-                                            class="flex size-10 shrink-0 items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-600/20"
+                                            class="border-ol text-tl mt-3 flex items-center gap-4 border-t pt-3 text-[11px]"
+                                        >
+                                            @if ($project->stars)
+                                                <span class="inline-flex items-center gap-1"
+                                                    ><i class="fa-solid fa-star text-[10px]"></i>
+                                                    {{ $project->stars }}</span
+                                                >
+                                            @endif
+                                            @if ($project->forks)
+                                                <span class="inline-flex items-center gap-1"
+                                                    ><i class="fa-solid fa-code-fork text-[10px]"></i>
+                                                    {{ $project->forks }}</span
+                                                >
+                                            @endif
+                                        </div>
+                                    @endif
+                                </div>
+                            @endforeach
+                            @if ($projects->count() > 3)
+                                <div x-show="expanded" x-transition>
+                                    @foreach ($projects->skip(3) as $project)
+                                        <div class="border-ol bg-e2 mt-3 rounded-lg border p-5">
+                                            <div class="flex items-start justify-between gap-3">
+                                                <div class="min-w-0 flex-1">
+                                                    <h3 class="text-sm font-semibold">{{ $project->name }}</h3>
+                                                    <p class="text-tm mt-1 text-xs leading-relaxed">{{ $project->description }}</p>
+                                                </div>
+                                                @if ($project->url)
+                                                    <a
+                                                        href="{{ $project->url }}"
+                                                        target="_blank"
+                                                        class="text-tm hover:text-primary shrink-0 transition-colors"
+                                                    >
+                                                        <i class="fa-solid fa-arrow-up-right-from-square text-xs"></i>
+                                                    </a>
+                                                @endif
+                                            </div>
+                                            @if ($project->tags)
+                                                <div class="mt-3 flex flex-wrap gap-1.5">
+                                                    @foreach ($project->tags as $tag)
+                                                        <span
+                                                            class="bg-e2 border-ol text-tm rounded-md border px-1.5 py-0.5 text-[10px] font-medium"
+                                                            >{{ $tag }}</span
+                                                        >
+                                                    @endforeach
+                                                </div>
+                                            @endif
+                                            @if ($project->stars || $project->forks)
+                                                <div
+                                                    class="border-ol text-tl mt-3 flex items-center gap-4 border-t pt-3 text-[11px]"
+                                                >
+                                                    @if ($project->stars)
+                                                        <span class="inline-flex items-center gap-1"
+                                                            ><i class="fa-solid fa-star text-[10px]"></i>
+                                                            {{ $project->stars }}</span
+                                                        >
+                                                    @endif
+                                                    @if ($project->forks)
+                                                        <span class="inline-flex items-center gap-1"
+                                                            ><i class="fa-solid fa-code-fork text-[10px]"></i>
+                                                            {{ $project->forks }}</span
+                                                        >
+                                                    @endif
+                                                </div>
+                                            @endif
+                                        </div>
+                                    @endforeach
+                                </div>
+                                <div class="mt-4 text-center">
+                                    <button
+                                        @click="expanded = !expanded"
+                                        class="text-primary hover:text-primary/80 cursor-pointer text-xs font-medium transition-colors"
+                                    >
+                                        <span x-text="expanded ? 'Ver menos ↑' : 'Ver todos os projetos →'"></span>
+                                    </button>
+                                </div>
+                            @endif
+                        </div>
+                    @endif
+
+                    <!-- PRs -->
+                    @if ($pullRequests->isNotEmpty())
+                        <div class="card p-6" x-data="{ expanded: false }">
+                            <h2 class="font-display mb-4 text-base font-semibold">PRs na Comunidade</h2>
+                            <div class="flex flex-col gap-3">
+                                @foreach ($pullRequests->take(3) as $pr)
+                                    <div class="border-ol bg-e2 rounded-lg border p-4">
+                                        <div class="flex items-start justify-between gap-3">
+                                            <div class="min-w-0 flex-1">
+                                                <p class="text-sm font-medium">{{ $pr->title }}</p>
+                                                <p class="text-tm mt-0.5 text-xs">{{ $pr->repo }}</p>
+                                            </div>
+                                            <span
+                                                class="shrink-0 rounded-full {{ $pr->status_class }} px-2 py-0.5 text-[10px] font-medium"
+                                            >
+                                                {{ $pr->status_label }}
+                                            </span>
+                                        </div>
+                                        <div class="text-tl mt-2 flex items-center gap-3 text-[11px]">
+                                            <span class="inline-flex items-center gap-1">
+                                                @if ($pr->status === 'merged')
+                                                    <i class="fa-solid fa-code-merge text-[10px]"></i>
+                                                @else
+                                                    <i class="fa-solid fa-code-pull-request text-[10px]"></i>
+                                                @endif
+                                                #{{ $pr->number }}
+                                            </span>
+                                            @if ($pr->pr_created_at)
+                                                <span>{{ $pr->pr_created_at->diffForHumans() }}</span>
+                                            @endif
+                                        </div>
+                                    </div>
+                                @endforeach
+                                @if ($pullRequests->count() > 3)
+                                    <div x-show="expanded" x-transition>
+                                        @foreach ($pullRequests->skip(3) as $pr)
+                                            <div
+                                                class="border-ol bg-e2 rounded-lg border p-4 {{ !$loop->first ? 'mt-3' : '' }}"
+                                            >
+                                                <div class="flex items-start justify-between gap-3">
+                                                    <div class="min-w-0 flex-1">
+                                                        <p class="text-sm font-medium">{{ $pr->title }}</p>
+                                                        <p class="text-tm mt-0.5 text-xs">{{ $pr->repo }}</p>
+                                                    </div>
+                                                    <span
+                                                        class="shrink-0 rounded-full {{ $pr->status_class }} px-2 py-0.5 text-[10px] font-medium"
+                                                    >
+                                                        {{ $pr->status_label }}
+                                                    </span>
+                                                </div>
+                                                <div class="text-tl mt-2 flex items-center gap-3 text-[11px]">
+                                                    <span class="inline-flex items-center gap-1">
+                                                        @if ($pr->status === 'merged')
+                                                            <i class="fa-solid fa-code-merge text-[10px]"></i>
+                                                        @else
+                                                            <i class="fa-solid fa-code-pull-request text-[10px]"></i>
+                                                        @endif
+                                                        #{{ $pr->number }}
+                                                    </span>
+                                                    @if ($pr->pr_created_at)
+                                                        <span>{{ $pr->pr_created_at->diffForHumans() }}</span>
+                                                    @endif
+                                                </div>
+                                            </div>
+                                        @endforeach
+                                    </div>
+                                @endif
+                            </div>
+                            @if ($pullRequests->count() > 3)
+                                <div class="mt-4 text-center">
+                                    <button
+                                        @click="expanded = !expanded"
+                                        class="text-primary hover:text-primary/80 cursor-pointer text-xs font-medium transition-colors"
+                                    >
+                                        <span x-text="expanded ? 'Ver menos ↑' : 'Ver todos os PRs →'"></span>
+                                    </button>
+                                </div>
+                            @endif
+                        </div>
+                    @endif
+
+                    <!-- Badges -->
+                    @php
+                        $allBadges = $user->character?->badges ?? collect();
+                        $h4Badge = $allBadges->firstWhere('redeem_code', 'H4_VERIFIED');
+                        $otherBadges = $allBadges->reject(fn($b) => $b->redeem_code === 'H4_VERIFIED');
+                    @endphp
+                    @if ($h4Badge || $otherBadges->isNotEmpty())
+                        <div class="card p-6" x-data="{ expanded: false }">
+                            <h2 class="font-display mb-3 text-base font-semibold">Badges He4rt</h2>
+                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
+                                @if ($h4Badge)
+                                    <div class="border-ol bg-e2 flex items-center gap-3 rounded-lg border p-4">
+                                        <div
+                                            class="bg-primary/10 flex size-10 shrink-0 items-center justify-center gap-0.5 rounded-lg"
+                                        >
+                                            <span class="text-primary text-[9px] leading-none font-bold">H4</span>
+                                            <svg viewBox="0 0 600 513" xmlns="http://www.w3.org/2000/svg" class="size-[9px] shrink-0" fill="#782bf1">
+                                                <path d="M445.237 0.00033551C424.91 -0.0347431 404.777 3.89304 385.996 11.5576C367.216 19.2221 350.159 30.4719 335.808 44.6594L153.391 224.398L116.915 188.45C111.983 183.761 108.048 178.15 105.341 171.946C102.633 165.741 101.207 159.067 101.145 152.314C101.084 145.56 102.388 138.862 104.983 132.611C107.577 126.359 111.409 120.68 116.255 115.904C121.101 111.128 126.864 107.352 133.207 104.795C139.55 102.239 146.347 100.953 153.2 101.014C160.052 101.074 166.825 102.48 173.12 105.148C179.416 107.816 185.109 111.694 189.867 116.555L262.856 44.6594C233.71 16.6424 194.537 1.07109 153.824 1.31914C113.11 1.56719 74.1349 17.6146 45.3431 45.9846C16.5513 74.3546 0.261527 112.762 0.0031216 152.886C-0.255283 193.01 15.5385 231.618 43.9626 260.346L153.391 368.189L511.948 14.8274C491.12 5.01981 468.32 -0.0474973 445.237 0.00033551Z" />
+                                                <path d="M584.9 86.7579L445.237 224.433L408.76 188.45L335.808 260.345L372.284 296.293L226.379 440.084L299.332 512.015L554.665 260.381C577.296 238.07 592.355 209.395 597.769 178.303C603.183 147.21 598.687 115.228 584.9 86.7579Z" />
+                                            </svg>
+                                        </div>
+                                        <div class="min-w-0 flex-1">
+                                            <h4 class="text-sm font-medium">Perfil Certificado pela Comunidade</h4>
+                                            <p class="text-tm mt-0.5 text-xs">Certificação oficial da He4rt Devs</p>
+                                        </div>
+                                    </div>
+                                @endif
+                                @foreach ($otherBadges->take(4) as $badge)
+                                    <div class="border-ol bg-e2 flex items-center gap-3 rounded-lg border p-4">
+                                        <div
+                                            class="bg-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg"
                                         >
                                             @if ($badge->getFirstMediaUrl('badge'))
                                                 <img
@@ -189,154 +487,60 @@
                                                     class="size-5 object-contain"
                                                 />
                                             @else
-                                                <x-filament::icon
-                                                    icon="heroicon-s-star"
-                                                    class="size-5 text-purple-500 dark:text-purple-400"
-                                                />
+                                                <svg class="text-primary size-5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
                                             @endif
                                         </div>
                                         <div class="min-w-0 flex-1">
-                                            <h4 class="text-text-high text-sm font-medium">{{ $badge->name }}</h4>
+                                            <h4 class="text-sm font-medium">{{ $badge->name }}</h4>
                                             @if ($badge->description)
-                                                <p class="text-text-medium mt-0.5 line-clamp-2 text-xs">{{ $badge->description }}</p>
+                                                <p class="text-tm mt-0.5 text-xs">{{ $badge->description }}</p>
                                             @endif
                                         </div>
                                     </div>
                                 @endforeach
-                            </div>
-                        </div>
-                    @endif
-
-                    @if ($connectedAccounts->isNotEmpty())
-                        <div
-                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
-                        >
-                            <h2 class="text-text-high mb-3 text-base font-semibold">Contas Conectadas</h2>
-                            <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
-                                @foreach ($connectedAccounts as $account)
-                                    <a
-                                        href="{{ $account['url'] }}"
-                                        target="_blank"
-                                        rel="noopener noreferrer"
-                                        class="flex items-center gap-3 rounded-lg border border-gray-200 bg-gray-50 p-4 transition-colors hover:bg-gray-100 dark:border-white/5 dark:bg-[#1c2128] dark:hover:bg-[#21262d]"
-                                    >
-                                        <div class="text-text-medium flex size-8 shrink-0 items-center justify-center">
-                                            @switch ($account['provider'])
-                                                @case ('github')
-                                                    <x-filament::icon icon="fab-github" class="size-5" />
-                                                    @break
-                                                @case ('discord')
-                                                    <x-filament::icon icon="fab-discord" class="size-5" />
-                                                    @break
-                                                @case ('linkedin')
-                                                    <x-filament::icon icon="fab-linkedin" class="size-5" />
-                                                    @break
-                                                @case ('twitter')
-                                                    <x-filament::icon icon="fab-x-twitter" class="size-5" />
-                                                    @break
-                                                @case ('devto')
-                                                    <x-filament::icon icon="fab-dev" class="size-5" />
-                                                    @break
-                                                @case ('youtube')
-                                                    <x-filament::icon icon="fab-youtube" class="size-5" />
-                                                    @break
-                                                @case ('instagram')
-                                                    <x-filament::icon icon="fab-instagram" class="size-5" />
-                                                    @break
-                                                @default
-                                                    <x-filament::icon icon="heroicon-o-link" class="size-5" />
-                                            @endswitch
+                                @if ($otherBadges->count() > 4)
+                                    @foreach ($otherBadges->skip(4) as $badge)
+                                        <div
+                                            x-show="expanded"
+                                            x-transition
+                                            class="border-ol bg-e2 flex items-center gap-3 rounded-lg border p-4"
+                                        >
+                                            <div
+                                                class="bg-primary/10 flex size-10 shrink-0 items-center justify-center rounded-lg"
+                                            >
+                                                @if ($badge->getFirstMediaUrl('badge'))
+                                                    <img
+                                                        src="{{ $badge->getFirstMediaUrl('badge') }}"
+                                                        alt="{{ $badge->name }}"
+                                                        class="size-5 object-contain"
+                                                    />
+                                                @else
+                                                    <svg class="text-primary size-5" fill="currentColor" viewBox="0 0 20 20"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z" /></svg>
+                                                @endif
+                                            </div>
+                                            <div class="min-w-0 flex-1">
+                                                <h4 class="text-sm font-medium">{{ $badge->name }}</h4>
+                                                @if ($badge->description)
+                                                    <p class="text-tm mt-0.5 text-xs">{{ $badge->description }}</p>
+                                                @endif
+                                            </div>
                                         </div>
-                                        <div class="min-w-0 flex-1">
-                                            <p class="text-text-high text-sm font-medium">{{ ucfirst($account['label']) }}</p>
-                                            <p class="text-text-medium truncate text-xs">{{ parse_url($account['url'], PHP_URL_HOST) }}</p>
-                                        </div>
-                                    </a>
-                                @endforeach
+                                    @endforeach
+                                @endif
+                                @if ($otherBadges->count() > 4)
+                                    <div class="col-span-full text-center">
+                                        <button
+                                            @click="expanded = !expanded"
+                                            class="text-primary hover:text-primary/80 cursor-pointer text-xs font-medium transition-colors"
+                                        >
+                                            <span x-text="expanded ? 'Ver menos ↑' : 'Ver todas as badges →'"></span>
+                                        </button>
+                                    </div>
+                                @endif
                             </div>
                         </div>
                     @endif
-                </div>
-
-                <div class="hidden flex-col gap-6 lg:flex">
-                    <div class="rounded-xl border border-purple-500/20 bg-white p-5 dark:bg-[#161b22]">
-                        <h2 class="text-text-high mb-4 flex items-center gap-2 text-sm font-semibold">
-                            Resumo para Recrutadores
-                            <x-filament::icon icon="heroicon-s-document-text" class="size-4 text-purple-400" />
-                        </h2>
-                        <div class="grid grid-cols-2 gap-4">
-                            @if ($profile->seniority_level)
-                                <div>
-                                    <p class="text-text-medium text-xs">Senioridade</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{
-                                        __(
-                                            'profile::enums.seniority_level.' . $profile->seniority_level->value,
-                                        )
-                                    }}</p>
-                                </div>
-                            @endif
-                            @if ($profile->years_experience)
-                                <div>
-                                    <p class="text-text-medium text-xs">Experiência</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $profile->years_experience }} anos</p>
-                                </div>
-                            @endif
-                            @if ($user->address)
-                                <div>
-                                    <p class="text-text-medium text-xs">Localização</p>
-                                    <p class="text-text-high mt-0.5 text-sm font-medium">{{ $user->address->city }}{{
-                                        $user->address->state
-                                            ? ', ' . $user->address->state
-                                            : ''
-                                    }}</p>
-                                </div>
-                            @endif
-                            @if ($profile->start_availability)
-                                <div>
-                                    <p class="text-text-medium text-xs">Início</p>
-                                    <p class="mt-0.5 rounded-md bg-gradient-to-r from-purple-600 to-indigo-600 px-2 py-0.5 text-sm font-semibold text-white">
-                                        {{
-                                            __(
-                                                'profile::enums.start_availability.' . $profile->start_availability->value,
-                                            )
-                                        }}
-                                    </p>
-                                </div>
-                            @endif
-                        </div>
-                    </div>
-
-                    {{-- Level --}}
-                    @if ($user->character)
-                        <div
-                            class="rounded-xl border border-gray-200 bg-white p-5 dark:border-white/5 dark:bg-[#161b22]"
-                        >
-                            <div class="flex items-center gap-3">
-                                <div
-                                    class="flex size-10 items-center justify-center rounded-full bg-purple-100 dark:bg-purple-600/20"
-                                >
-                                    <x-filament::icon
-                                        icon="heroicon-s-star"
-                                        class="size-5 text-purple-500 dark:text-purple-400"
-                                    />
-                                </div>
-                                <div>
-                                    <p class="text-text-medium text-xs">Nível da Comunidade</p>
-                                    <p class="text-text-high text-lg font-bold">{{ $user->character->level }}</p>
-                                </div>
-                            </div>
-                            <div class="mt-3">
-                                <div class="h-2 w-full overflow-hidden rounded-full bg-gray-200 dark:bg-white/5">
-                                    <div
-                                        class="h-full rounded-full bg-purple-500"
-                                        style="width: {{ $user->character->percentage_experience }}%"
-                                    ></div>
-                                </div>
-                                <p class="text-text-medium mt-1 text-xs">{{ number_format($user->character->experience) }} XP · {{ number_format($user->character->experience_progress) }} para o próximo nível</p>
-                            </div>
-                        </div>
-                    @endif
-                </div>
+                </main>
             </div>
         </div>
     </div>

--- a/app-modules/profile/src/Actions/UpsertProfile.php
+++ b/app-modules/profile/src/Actions/UpsertProfile.php
@@ -47,6 +47,18 @@ final class UpsertProfile
             $attributes['social_links'] = $dto->socialLinks;
         }
 
+        if ($dto->workTypes !== null) {
+            $attributes['work_types'] = $dto->workTypes;
+        }
+
+        if ($dto->languages !== null) {
+            $attributes['languages'] = $dto->languages;
+        }
+
+        if ($dto->skills !== null) {
+            $attributes['skills'] = $dto->skills;
+        }
+
         if ($attributes !== []) {
             $profile->update($attributes);
         }

--- a/app-modules/profile/src/DTOs/UpsertProfileDTO.php
+++ b/app-modules/profile/src/DTOs/UpsertProfileDTO.php
@@ -19,6 +19,12 @@ final readonly class UpsertProfileDTO
         public ?int $yearsExperience = null,
         /** @var array<string, string>|null */
         public ?array $socialLinks = null,
+        /** @var array<int, string>|null */
+        public ?array $workTypes = null,
+        /** @var array<int, array{name: string, level: string}>|null */
+        public ?array $languages = null,
+        /** @var array<int, array{name: string, category: string}>|null */
+        public ?array $skills = null,
     ) {}
 
     /**
@@ -36,6 +42,9 @@ final readonly class UpsertProfileDTO
                 : null,
             yearsExperience: isset($data['years_experience']) ? (int) $data['years_experience'] : null,
             socialLinks: $data['social_links'] ?? null,
+            workTypes: $data['work_types'] ?? null,
+            languages: $data['languages'] ?? null,
+            skills: $data['skills'] ?? null,
         );
     }
 }

--- a/app-modules/profile/src/Enums/SeniorityLevel.php
+++ b/app-modules/profile/src/Enums/SeniorityLevel.php
@@ -13,10 +13,8 @@ use Filament\Support\Icons\Heroicon;
 enum SeniorityLevel: string implements HasColor, HasIcon, HasLabel
 {
     case Junior = 'junior';
-    case Mid = 'mid';
+    case Pleno = 'pleno';
     case Senior = 'senior';
-    case Specialist = 'specialist';
-    case Lead = 'lead';
 
     public function getLabel(): string
     {
@@ -27,10 +25,8 @@ enum SeniorityLevel: string implements HasColor, HasIcon, HasLabel
     {
         return match ($this) {
             self::Junior => Color::Green,
-            self::Mid => Color::Blue,
+            self::Pleno => Color::Blue,
             self::Senior => Color::Purple,
-            self::Specialist => Color::Amber,
-            self::Lead => Color::Red,
         };
     }
 
@@ -38,10 +34,8 @@ enum SeniorityLevel: string implements HasColor, HasIcon, HasLabel
     {
         return match ($this) {
             self::Junior => Heroicon::AcademicCap,
-            self::Mid => Heroicon::CodeBracket,
+            self::Pleno => Heroicon::CodeBracket,
             self::Senior => Heroicon::Star,
-            self::Specialist => Heroicon::Beaker,
-            self::Lead => Heroicon::Flag,
         };
     }
 }

--- a/app-modules/profile/src/Enums/SkillCategory.php
+++ b/app-modules/profile/src/Enums/SkillCategory.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Enums;
+
+enum SkillCategory: string
+{
+    case LanguagesFrameworks = 'languages_frameworks';
+    case InfraDatabases = 'infra_databases';
+    case SoftSkillsTools = 'softskills_tools';
+    case Idiomas = 'idiomas';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::LanguagesFrameworks => 'Linguagens & Frameworks',
+            self::InfraDatabases => 'Infraestrutura & Databases',
+            self::SoftSkillsTools => 'Soft Skills & Ferramentas',
+            self::Idiomas => 'Idiomas',
+        };
+    }
+
+    public function limit(): int
+    {
+        return match ($this) {
+            self::LanguagesFrameworks => 6,
+            self::InfraDatabases => 6,
+            self::SoftSkillsTools => 15,
+            self::Idiomas => PHP_INT_MAX,
+        };
+    }
+}

--- a/app-modules/profile/src/Enums/Skills.php
+++ b/app-modules/profile/src/Enums/Skills.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Enums;
+
+/**
+ * Catálogo de skills para resolvedor de ícones.
+ * Ícones fab-* do Font Awesome quando existe marca.
+ * O nome exibido é o que o usuário digita, não o catálogo.
+ */
+final class Skills
+{
+    /** @var array<string, array{icon: string, keywords: array<int, string>}> */
+    public const array ICON_MAP = [
+        // Languages & Frameworks
+        'php' => ['icon' => 'fab fa-php', 'keywords' => ['php']],
+        'javascript' => ['icon' => 'fab fa-js', 'keywords' => ['javascript', 'js']],
+        'typescript' => ['icon' => 'fab fa-js', 'keywords' => ['typescript', 'ts']],
+        'python' => ['icon' => 'fab fa-python', 'keywords' => ['python']],
+        'java' => ['icon' => 'fab fa-java', 'keywords' => ['java']],
+        'csharp' => ['icon' => 'fas fa-hashtag', 'keywords' => ['c#', 'csharp', 'c sharp', '.net']],
+        'go' => ['icon' => 'fas fa-code', 'keywords' => ['go', 'golang']],
+        'rust' => ['icon' => 'fas fa-cog', 'keywords' => ['rust']],
+        'ruby' => ['icon' => 'fas fa-gem', 'keywords' => ['ruby', 'rails', 'ruby on rails']],
+        'swift' => ['icon' => 'fas fa-bolt', 'keywords' => ['swift']],
+        'kotlin' => ['icon' => 'fas fa-code', 'keywords' => ['kotlin']],
+        'dart' => ['icon' => 'fas fa-feather', 'keywords' => ['dart', 'flutter']],
+        'laravel' => ['icon' => 'fab fa-laravel', 'keywords' => ['laravel']],
+        'react' => ['icon' => 'fab fa-react', 'keywords' => ['react', 'reactjs', 'react.js']],
+        'vuejs' => ['icon' => 'fab fa-vuejs', 'keywords' => ['vue', 'vuejs', 'vue.js']],
+        'angular' => ['icon' => 'fab fa-angular', 'keywords' => ['angular']],
+        'nodejs' => ['icon' => 'fab fa-node-js', 'keywords' => ['node', 'nodejs', 'node.js']],
+        'spring' => ['icon' => 'fas fa-leaf', 'keywords' => ['spring', 'spring boot']],
+        'flutter' => ['icon' => 'fas fa-mobile', 'keywords' => ['flutter']],
+        'tailwind' => ['icon' => 'fab fa-css3-alt', 'keywords' => ['tailwind', 'tailwindcss', 'tailwind css']],
+        'nextjs' => ['icon' => 'fas fa-angle-right', 'keywords' => ['next', 'nextjs', 'next.js']],
+        'nuxtjs' => ['icon' => 'fas fa-angle-right', 'keywords' => ['nuxt', 'nuxtjs', 'nuxt.js']],
+        'django' => ['icon' => 'fas fa-leaf', 'keywords' => ['django']],
+        'rails' => ['icon' => 'fas fa-gem', 'keywords' => ['rails']],
+        'express' => ['icon' => 'fas fa-server', 'keywords' => ['express', 'expressjs']],
+        'fastapi' => ['icon' => 'fas fa-bolt', 'keywords' => ['fastapi', 'fast api']],
+        'livewire' => ['icon' => 'fas fa-bolt', 'keywords' => ['livewire']],
+
+        // Infra & Databases
+        'postgresql' => ['icon' => 'fas fa-database', 'keywords' => ['postgresql', 'postgres']],
+        'mysql' => ['icon' => 'fas fa-database', 'keywords' => ['mysql']],
+        'mongodb' => ['icon' => 'fas fa-database', 'keywords' => ['mongodb', 'mongo']],
+        'redis' => ['icon' => 'fas fa-database', 'keywords' => ['redis']],
+        'sqlite' => ['icon' => 'fas fa-database', 'keywords' => ['sqlite']],
+        'elasticsearch' => ['icon' => 'fas fa-search', 'keywords' => ['elasticsearch', 'elastic']],
+        'docker' => ['icon' => 'fab fa-docker', 'keywords' => ['docker']],
+        'kubernetes' => ['icon' => 'fas fa-dharmachakra', 'keywords' => ['kubernetes', 'k8s']],
+        'aws' => ['icon' => 'fab fa-aws', 'keywords' => ['aws', 'amazon web services']],
+        'gcp' => ['icon' => 'fab fa-google', 'keywords' => ['gcp', 'google cloud']],
+        'azure' => ['icon' => 'fab fa-microsoft', 'keywords' => ['azure']],
+        'linux' => ['icon' => 'fab fa-linux', 'keywords' => ['linux']],
+        'git' => ['icon' => 'fab fa-git-alt', 'keywords' => ['git']],
+        'cicd' => ['icon' => 'fas fa-arrows-rotate', 'keywords' => ['ci/cd', 'cicd', 'ci cd', 'pipeline']],
+        'github-actions' => ['icon' => 'fab fa-github', 'keywords' => ['github actions', 'gh actions']],
+
+        // Soft Skills & Tools
+        'figma' => ['icon' => 'fab fa-figma', 'keywords' => ['figma']],
+        'photoshop' => ['icon' => 'fas fa-image', 'keywords' => ['photoshop']],
+        'scrum' => ['icon' => 'fas fa-users', 'keywords' => ['scrum']],
+        'kanban' => ['icon' => 'fas fa-columns', 'keywords' => ['kanban']],
+        'design-thinking' => ['icon' => 'fas fa-lightbulb', 'keywords' => ['design thinking']],
+        'notion' => ['icon' => 'fas fa-book', 'keywords' => ['notion']],
+        'framer' => ['icon' => 'fas fa-shapes', 'keywords' => ['framer']],
+        'miro' => ['icon' => 'fas fa-chalkboard', 'keywords' => ['miro']],
+        'xd' => ['icon' => 'fas fa-pen-nib', 'keywords' => ['adobe xd', 'xd']],
+        'sass' => ['icon' => 'fab fa-sass', 'keywords' => ['sass', 'scss']],
+        'webpack' => ['icon' => 'fas fa-box', 'keywords' => ['webpack']],
+        'vite' => ['icon' => 'fas fa-bolt', 'keywords' => ['vite']],
+        'leadership' => ['icon' => 'fas fa-users', 'keywords' => ['liderança', 'lideranca', 'leadership', 'líder']],
+        'mentoria' => ['icon' => 'fas fa-chalkboard-user', 'keywords' => ['mentoria', 'mentoring', 'mentor']],
+        'comunicacao' => ['icon' => 'fas fa-comments', 'keywords' => ['comunicação', 'comunicacao', 'communication']],
+        'trabalho-em-equipe' => ['icon' => 'fas fa-people-group', 'keywords' => ['trabalho em equipe', 'team work', 'teamwork']],
+        'resolucao-de-problemas' => ['icon' => 'fas fa-puzzle-piece', 'keywords' => ['resolução de problemas', 'problem solving']],
+    ];
+
+    /**
+     * Tenta casar o nome da skill com o catálogo para retornar um ícone.
+     *
+     * @return array{icon: string}|null
+     */
+    public static function matchIcon(string $skillName): ?array
+    {
+        $normalized = mb_strtolower(mb_trim($skillName));
+
+        foreach (self::ICON_MAP as $entry) {
+            foreach ($entry['keywords'] as $keyword) {
+                if ($normalized === $keyword || str_contains($normalized, $keyword) || str_contains($keyword, $normalized)) {
+                    return ['icon' => $entry['icon']];
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Valida e limita skills por categoria.
+     *
+     * @param  array<int, array{name: string, category: string}>  $skills
+     * @return array<int, array{name: string, category: string, icon: string|null}>
+     */
+    public static function validateAndLimit(array $skills): array
+    {
+        $counts = [];
+        $result = [];
+
+        foreach ($skills as $skill) {
+            $category = $skill['category'] ?? '';
+            $categoryEnum = SkillCategory::tryFrom($category);
+
+            if ($categoryEnum === null) {
+                continue;
+            }
+
+            $counts[$category] = ($counts[$category] ?? 0) + 1;
+
+            if ($counts[$category] <= $categoryEnum->limit()) {
+                $matched = self::matchIcon($skill['name']);
+                $result[] = [
+                    'name' => $skill['name'],
+                    'category' => $category,
+                    'icon' => $matched['icon'] ?? null,
+                ];
+            }
+        }
+
+        return $result;
+    }
+}

--- a/app-modules/profile/src/Enums/SocialPlatform.php
+++ b/app-modules/profile/src/Enums/SocialPlatform.php
@@ -15,6 +15,10 @@ enum SocialPlatform: string implements HasIcon, HasLabel
     case Website = 'website';
     case YouTube = 'youtube';
     case Bluesky = 'bluesky';
+    case WhatsApp = 'whatsapp';
+    case LinkedIn = 'linkedin';
+    case GitHub = 'github';
+    case DevTo = 'devto';
 
     /**
      * @return array<int, string>
@@ -40,6 +44,10 @@ enum SocialPlatform: string implements HasIcon, HasLabel
             self::Website => Heroicon::GlobeAlt,
             self::YouTube => Heroicon::PlayCircle,
             self::Bluesky => Heroicon::Cloud,
+            self::WhatsApp => Heroicon::ChatBubbleLeftEllipsis,
+            self::LinkedIn => Heroicon::Briefcase,
+            self::GitHub => Heroicon::CodeBracket,
+            self::DevTo => Heroicon::CommandLine,
         };
     }
 }

--- a/app-modules/profile/src/Http/ProfileController.php
+++ b/app-modules/profile/src/Http/ProfileController.php
@@ -22,10 +22,23 @@ final class ProfileController
         'devto' => 'https://dev.to/%s',
     ];
 
+    private const array SOCIAL_ICONS = [
+        'whatsapp' => 'fa-brands fa-whatsapp',
+        'linkedin' => 'fa-brands fa-linkedin-in',
+        'github' => 'fa-brands fa-github',
+        'devto' => 'fa-brands fa-dev',
+        'instagram' => 'fa-brands fa-instagram',
+        'twitter' => 'fa-brands fa-twitter',
+        'youtube' => 'fa-brands fa-youtube',
+        'website' => 'fas fa-globe',
+        'bluesky' => 'fa-brands fa-bluesky',
+    ];
+
     public function show(Request $request, string $username): Factory|View
     {
         $tenant = Tenant::query()
             ->where('domain', $request->getHost())
+            ->where('active', true)
             ->firstOrFail();
 
         $user = User::query()
@@ -41,21 +54,36 @@ final class ProfileController
 
         abort_if($profile === null, 404);
 
-        $user->load(['character.badges', 'providers', 'address']);
+        $user->load([
+            'character.badges',
+            'providers' => fn ($query) => $query->where('tenant_id', $tenant->id),
+            'address',
+        ]);
 
         $connectedAccounts = $this->buildConnectedAccounts($profile, $user);
+
+        $resumeUrl = $profile->getFirstMediaUrl('resume') ?: null;
+
+        $projects = $profile->projects()->orderBy('sort_order')->get();
+
+        $pullRequests = $profile->pullRequests()->latest()->get();
 
         return view('profile::public-profile', [
             'user' => $user,
             'profile' => $profile,
             'tenant' => $tenant,
             'connectedAccounts' => $connectedAccounts,
+            'socialIcons' => self::SOCIAL_ICONS,
+            'projects' => $projects,
+            'pullRequests' => $pullRequests,
+            'resumeUrl' => $resumeUrl,
         ]);
     }
 
     private function buildConnectedAccounts(Profile $profile, User $user): Collection
     {
         $accounts = collect();
+        $seen = [];
 
         if ($profile->social_links) {
             foreach ($profile->social_links as $platform => $url) {
@@ -64,6 +92,7 @@ final class ProfileController
                     'label' => $platform,
                     'url' => $url,
                 ]);
+                $seen[] = $platform;
             }
         }
 
@@ -72,14 +101,19 @@ final class ProfileController
                 ? $provider->provider->value
                 : $provider->provider;
 
+            if (in_array($name, $seen, true)) {
+                continue;
+            }
+
             $template = self::PROVIDER_URLS[$name] ?? null;
 
-            if ($template) {
+            if ($template && $provider->external_account_id) {
                 $accounts->push([
                     'provider' => $name,
                     'label' => $name,
                     'url' => sprintf($template, $provider->external_account_id),
                 ]);
+                $seen[] = $name;
             }
         }
 

--- a/app-modules/profile/src/Http/ProfileController.php
+++ b/app-modules/profile/src/Http/ProfileController.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Http;
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Models\Profile;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Contracts\View\View;
+use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+
+final class ProfileController
+{
+    private const array PROVIDER_URLS = [
+        'github' => 'https://github.com/%s',
+        'discord' => 'https://discord.com/users/%s',
+        'twitch' => 'https://twitch.tv/%s',
+        'devto' => 'https://dev.to/%s',
+    ];
+
+    public function show(Request $request, string $username): Factory|View
+    {
+        $tenant = Tenant::query()
+            ->where('domain', $request->getHost())
+            ->firstOrFail();
+
+        $user = User::query()
+            ->where('username', $username)
+            ->first();
+
+        abort_if($user === null, 404);
+
+        $profile = Profile::query()
+            ->where('user_id', $user->id)
+            ->where('tenant_id', $tenant->id)
+            ->first();
+
+        abort_if($profile === null, 404);
+
+        $user->load(['character.badges', 'providers', 'address']);
+
+        $connectedAccounts = $this->buildConnectedAccounts($profile, $user);
+
+        return view('profile::public-profile', [
+            'user' => $user,
+            'profile' => $profile,
+            'tenant' => $tenant,
+            'connectedAccounts' => $connectedAccounts,
+        ]);
+    }
+
+    private function buildConnectedAccounts(Profile $profile, User $user): Collection
+    {
+        $accounts = collect();
+
+        if ($profile->social_links) {
+            foreach ($profile->social_links as $platform => $url) {
+                $accounts->push([
+                    'provider' => $platform,
+                    'label' => $platform,
+                    'url' => $url,
+                ]);
+            }
+        }
+
+        foreach ($user->providers as $provider) {
+            $name = $provider->provider instanceof IdentityProvider
+                ? $provider->provider->value
+                : $provider->provider;
+
+            $template = self::PROVIDER_URLS[$name] ?? null;
+
+            if ($template) {
+                $accounts->push([
+                    'provider' => $name,
+                    'label' => $name,
+                    'url' => sprintf($template, $provider->external_account_id),
+                ]);
+            }
+        }
+
+        return $accounts;
+    }
+}

--- a/app-modules/profile/src/Models/Profile.php
+++ b/app-modules/profile/src/Models/Profile.php
@@ -9,6 +9,7 @@ use He4rt\Identity\Tenant\Models\Tenant;
 use He4rt\Identity\User\Models\User;
 use He4rt\Profile\Database\Factories\ProfileFactory;
 use He4rt\Profile\Enums\SeniorityLevel;
+use He4rt\Profile\Enums\Skills;
 use He4rt\Profile\Enums\SocialPlatform;
 use He4rt\Profile\Enums\StartAvailability;
 use Illuminate\Database\Eloquent\Attributes\Table;
@@ -17,7 +18,10 @@ use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use InvalidArgumentException;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
 
 /**
  * @property string $id
@@ -32,15 +36,19 @@ use InvalidArgumentException;
  * @property array<string, string>|null $social_links
  * @property bool $available_for_proposals
  * @property StartAvailability|null $start_availability
+ * @property array<int, array{name: string, category: string, icon: string|null}>|null $skills
+ * @property array<int, string>|null $work_types
+ * @property array<int, array{name: string, level: string}>|null $languages
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
 #[Table(name: 'user_profiles')]
-final class Profile extends Model
+final class Profile extends Model implements HasMedia
 {
     /** @use HasFactory<ProfileFactory> */
     use HasFactory;
     use HasUuids;
+    use InteractsWithMedia;
 
     protected $fillable = [
         'user_id',
@@ -54,6 +62,9 @@ final class Profile extends Model
         'social_links',
         'available_for_proposals',
         'start_availability',
+        'skills',
+        'work_types',
+        'languages',
     ];
 
     /**
@@ -70,6 +81,44 @@ final class Profile extends Model
     public function tenant(): BelongsTo
     {
         return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * @return HasMany<Project, $this>
+     */
+    public function projects(): HasMany
+    {
+        return $this->hasMany(Project::class, 'user_id', 'user_id')
+            ->where('tenant_id', $this->tenant_id)
+            ->orderBy('sort_order');
+    }
+
+    /**
+     * @return HasMany<PullRequest, $this>
+     */
+    public function pullRequests(): HasMany
+    {
+        return $this->hasMany(PullRequest::class, 'user_id', 'user_id')
+            ->where('tenant_id', $this->tenant_id)->latest();
+    }
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('resume')->singleFile();
+    }
+
+    /**
+     * Retorna skills validadas com ícones resolvidos.
+     *
+     * @return array<int, array{name: string, category: string, icon: string|null}>
+     */
+    public function skillsByCategory(): array
+    {
+        if ($this->skills === null) {
+            return [];
+        }
+
+        return Skills::validateAndLimit($this->skills);
     }
 
     protected static function newFactory(): ProfileFactory
@@ -101,11 +150,30 @@ final class Profile extends Model
         });
     }
 
+    /**
+     * @return Attribute<array<int, array{name: string, category: string, icon: string|null}>|null, array<int, array{name: string, category: string, icon: string|null}>|null>
+     */
+    protected function skills(): Attribute
+    {
+        return Attribute::set(function (?array $value): ?string {
+            if ($value === null) {
+                return null;
+            }
+
+            $validated = Skills::validateAndLimit($value);
+
+            return $validated !== [] ? json_encode($validated, JSON_THROW_ON_ERROR) : null;
+        });
+    }
+
     protected function casts(): array
     {
         return [
             'birthdate' => 'date',
             'social_links' => 'array',
+            'skills' => 'array',
+            'work_types' => 'array',
+            'languages' => 'array',
             'available_for_proposals' => 'boolean',
             'seniority_level' => SeniorityLevel::class,
             'start_availability' => StartAvailability::class,

--- a/app-modules/profile/src/Models/Project.php
+++ b/app-modules/profile/src/Models/Project.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Models;
+
+use Carbon\Carbon;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $tenant_id
+ * @property string $name
+ * @property string|null $description
+ * @property string|null $url
+ * @property array<int, string>|null $tags
+ * @property int|null $stars
+ * @property int|null $forks
+ * @property int $sort_order
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+#[Table(name: 'user_projects')]
+final class Project extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'tenant_id',
+        'name',
+        'description',
+        'url',
+        'tags',
+        'stars',
+        'forks',
+        'sort_order',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Tenant, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'tags' => 'array',
+            'stars' => 'integer',
+            'forks' => 'integer',
+            'sort_order' => 'integer',
+        ];
+    }
+}

--- a/app-modules/profile/src/Models/PullRequest.php
+++ b/app-modules/profile/src/Models/PullRequest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Profile\Models;
+
+use Carbon\Carbon;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $user_id
+ * @property string $tenant_id
+ * @property string $title
+ * @property string $repo
+ * @property string $status
+ * @property int $number
+ * @property string|null $url
+ * @property Carbon|null $pr_created_at
+ * @property int $sort_order
+ * @property Carbon $created_at
+ * @property Carbon $updated_at
+ */
+#[Table(name: 'user_pull_requests')]
+final class PullRequest extends Model
+{
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'user_id',
+        'tenant_id',
+        'title',
+        'repo',
+        'status',
+        'number',
+        'url',
+        'pr_created_at',
+        'sort_order',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Tenant, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * @return BelongsTo<Profile, $this>
+     */
+    public function profile(): BelongsTo
+    {
+        return $this->belongsTo(Profile::class);
+    }
+
+    protected function getStatusClassAttribute(): string
+    {
+        return match ($this->status) {
+            'merged' => 'bg-green-500/20 text-green-400',
+            'open' => 'bg-[#782bf1]/20 text-purple-400',
+            'closed' => 'bg-red-500/20 text-red-400',
+            default => 'bg-gray-500/20 text-gray-400',
+        };
+    }
+
+    protected function getStatusLabelAttribute(): string
+    {
+        return match ($this->status) {
+            'merged' => 'Merged',
+            'open' => 'Open',
+            'closed' => 'Closed',
+            default => $this->status,
+        };
+    }
+
+    protected function casts(): array
+    {
+        return [
+            'number' => 'integer',
+            'pr_created_at' => 'datetime',
+            'sort_order' => 'integer',
+        ];
+    }
+}

--- a/app-modules/profile/src/ProfileServiceProvider.php
+++ b/app-modules/profile/src/ProfileServiceProvider.php
@@ -22,7 +22,8 @@ final class ProfileServiceProvider extends ServiceProvider
             'profile' => Profile::class,
         ]);
 
-        Route::get('/@{username}', [ProfileController::class, 'show'])
+        Route::middleware('web')
+            ->get('/@{username}', [ProfileController::class, 'show'])
             ->name('profile.public');
     }
 }

--- a/app-modules/profile/src/ProfileServiceProvider.php
+++ b/app-modules/profile/src/ProfileServiceProvider.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace He4rt\Profile;
 
+use He4rt\Profile\Http\ProfileController;
 use He4rt\Profile\Models\Profile;
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Support\Facades\Route;
 use Illuminate\Support\ServiceProvider;
 
 final class ProfileServiceProvider extends ServiceProvider
@@ -14,9 +16,13 @@ final class ProfileServiceProvider extends ServiceProvider
     {
         $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'profile');
+        $this->loadViewsFrom(__DIR__.'/../resources/views', 'profile');
 
         Relation::morphMap([
             'profile' => Profile::class,
         ]);
+
+        Route::get('/@{username}', [ProfileController::class, 'show'])
+            ->name('profile.public');
     }
 }

--- a/app-modules/profile/tests/Feature/PublicProfileTest.php
+++ b/app-modules/profile/tests/Feature/PublicProfileTest.php
@@ -7,8 +7,7 @@ use He4rt\Identity\User\Models\User;
 use He4rt\Profile\Models\Profile;
 
 it('returns 200 for existing user with complete profile', function (): void {
-    $tenant = Tenant::factory()->create();
-    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
 
     $user = User::factory()->create(['username' => 'janedoe']);
     Profile::factory()->create([
@@ -24,13 +23,18 @@ it('returns 200 for existing user with complete profile', function (): void {
 });
 
 it('renders minimal profile without crashing', function (): void {
-    $tenant = Tenant::factory()->create();
-    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
 
     $user = User::factory()->create(['username' => 'novato']);
     Profile::factory()->create([
         'user_id' => $user->id,
         'tenant_id' => $tenant->id,
+        'headline' => null,
+        'about' => null,
+        'skills' => null,
+        'work_types' => null,
+        'languages' => null,
+        'social_links' => null,
     ]);
 
     $response = $this->get('http://test.he4rtdevs.com/@novato');
@@ -42,8 +46,7 @@ it('renders minimal profile without crashing', function (): void {
 });
 
 it('returns 404 for non-existent user', function (): void {
-    $tenant = Tenant::factory()->create();
-    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+    Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
 
     $response = $this->get('http://test.he4rtdevs.com/@fantasma');
 
@@ -51,8 +54,7 @@ it('returns 404 for non-existent user', function (): void {
 });
 
 it('returns 404 for user without profile in tenant', function (): void {
-    $tenant = Tenant::factory()->create();
-    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+    Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
     User::factory()->create(['username' => 'semprofile']);
 
     $response = $this->get('http://test.he4rtdevs.com/@semprofile');
@@ -60,20 +62,95 @@ it('returns 404 for user without profile in tenant', function (): void {
     $response->assertNotFound();
 });
 
-it('does not show available badge when available_for_proposals is false', function (): void {
-    $tenant = Tenant::factory()->create();
-    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+it('does not show work type tags when work_types is empty', function (): void {
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
 
     $user = User::factory()->create(['username' => 'indisponivel']);
     Profile::factory()->create([
         'user_id' => $user->id,
         'tenant_id' => $tenant->id,
-        'available_for_proposals' => false,
+        'work_types' => null,
     ]);
 
     $response = $this->get('http://test.he4rtdevs.com/@indisponivel');
 
     $response->assertOk();
-    $response->assertDontSee('Disponível');
-    $response->assertDontSee('Indisponível');
+    $response->assertDontSee('Início imediato');
+});
+
+it('renders work type tags when work_types are present', function (): void {
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'disponivel']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'work_types' => ['immediate', 'remote'],
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@disponivel');
+
+    $response->assertOk();
+    $response->assertSee('Início imediato');
+    $response->assertSee('Remoto');
+});
+
+it('renders skills section when skills are present', function (): void {
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'devskill']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'skills' => [
+            ['name' => 'PHP', 'category' => 'languages_frameworks'],
+            ['name' => 'Laravel', 'category' => 'languages_frameworks'],
+            ['name' => 'PostgreSQL', 'category' => 'infra_databases'],
+        ],
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@devskill');
+
+    $response->assertOk();
+    $response->assertSee('Stack & Skills', false);
+    $response->assertSee('PHP');
+    $response->assertSee('Laravel');
+    $response->assertSee('PostgreSQL');
+});
+
+it('does not render skills section when skills are null', function (): void {
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'noskills']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'skills' => null,
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@noskills');
+
+    $response->assertOk();
+    $response->assertDontSee('Stack');
+});
+
+it('renders languages when present', function (): void {
+    $tenant = Tenant::factory()->create(['active' => true, 'domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'polyglot']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'languages' => [
+            ['name' => 'Português', 'level' => 'Nativo'],
+            ['name' => 'Inglês', 'level' => 'Intermediário'],
+        ],
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@polyglot');
+
+    $response->assertOk();
+    $response->assertSee('Português');
+    $response->assertSee('Nativo');
+    $response->assertSee('Inglês');
 });

--- a/app-modules/profile/tests/Feature/PublicProfileTest.php
+++ b/app-modules/profile/tests/Feature/PublicProfileTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Profile\Models\Profile;
+
+it('returns 200 for existing user with complete profile', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'janedoe']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'headline' => 'Backend Dev',
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@janedoe');
+
+    $response->assertOk();
+    $response->assertSee('Backend Dev');
+});
+
+it('renders minimal profile without crashing', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'novato']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@novato');
+
+    $response->assertOk();
+    $response->assertSee($user->name);
+    $response->assertDontSee('null');
+    $response->assertDontSee('undefined');
+});
+
+it('returns 404 for non-existent user', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+
+    $response = $this->get('http://test.he4rtdevs.com/@fantasma');
+
+    $response->assertNotFound();
+});
+
+it('returns 404 for user without profile in tenant', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+    User::factory()->create(['username' => 'semprofile']);
+
+    $response = $this->get('http://test.he4rtdevs.com/@semprofile');
+
+    $response->assertNotFound();
+});
+
+it('does not show available badge when available_for_proposals is false', function (): void {
+    $tenant = Tenant::factory()->create();
+    $tenant->update(['domain' => 'test.he4rtdevs.com']);
+
+    $user = User::factory()->create(['username' => 'indisponivel']);
+    Profile::factory()->create([
+        'user_id' => $user->id,
+        'tenant_id' => $tenant->id,
+        'available_for_proposals' => false,
+    ]);
+
+    $response = $this->get('http://test.he4rtdevs.com/@indisponivel');
+
+    $response->assertOk();
+    $response->assertDontSee('Disponível');
+    $response->assertDontSee('Indisponível');
+});

--- a/app-modules/profile/tests/Feature/UpsertProfileTest.php
+++ b/app-modules/profile/tests/Feature/UpsertProfileTest.php
@@ -15,7 +15,7 @@ test('upsert profile updates all fields', function (): void {
         'birthdate' => '1995-03-15',
         'about' => 'Dev PHP apaixonado por Laravel',
         'headline' => 'Backend Developer',
-        'seniority_level' => 'mid',
+        'seniority_level' => 'pleno',
         'years_experience' => 5,
         'social_links' => [
             'instagram' => '@danielhe4rt',
@@ -29,7 +29,7 @@ test('upsert profile updates all fields', function (): void {
         ->and($result->birthdate->format('Y-m-d'))->toBe('1995-03-15')
         ->and($result->about)->toBe('Dev PHP apaixonado por Laravel')
         ->and($result->headline)->toBe('Backend Developer')
-        ->and($result->seniority_level)->toBe(SeniorityLevel::Mid)
+        ->and($result->seniority_level)->toBe(SeniorityLevel::Pleno)
         ->and($result->years_experience)->toBe(5)
         ->and($result->social_links)->toMatchArray([
             'instagram' => '@danielhe4rt',

--- a/app-modules/profile/tests/Unit/ProfileEnumTest.php
+++ b/app-modules/profile/tests/Unit/ProfileEnumTest.php
@@ -16,10 +16,8 @@ test('seniority level implements filament enum interfaces', function (): void {
         ->toBeInstanceOf(HasIcon::class);
 
     expect(SeniorityLevel::Junior->getLabel())->toBeString()->not->toBeEmpty()
-        ->and(SeniorityLevel::Mid->getLabel())->toBeString()->not->toBeEmpty()
-        ->and(SeniorityLevel::Senior->getLabel())->toBeString()->not->toBeEmpty()
-        ->and(SeniorityLevel::Specialist->getLabel())->toBeString()->not->toBeEmpty()
-        ->and(SeniorityLevel::Lead->getLabel())->toBeString()->not->toBeEmpty();
+        ->and(SeniorityLevel::Pleno->getLabel())->toBeString()->not->toBeEmpty()
+        ->and(SeniorityLevel::Senior->getLabel())->toBeString()->not->toBeEmpty();
 });
 
 test('social platform implements filament enum interfaces', function (): void {
@@ -49,6 +47,6 @@ test('all seniority level cases have distinct colors and icons', function (): vo
     $colors = array_map(fn (SeniorityLevel $level) => $level->getColor(), SeniorityLevel::cases());
     $icons = array_map(fn (SeniorityLevel $level) => $level->getIcon(), SeniorityLevel::cases());
 
-    expect($colors)->toHaveCount(5)
-        ->and($icons)->toHaveCount(5);
+    expect($colors)->toHaveCount(3)
+        ->and($icons)->toHaveCount(3);
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -13,6 +13,7 @@ export default defineConfig({
                 'app-modules/he4rt/resources/css/theme.css',
                 'app-modules/he4rt/resources/css/themes/3pontos/theme.css',
                 'app-modules/docs/resources/css/theme.css',
+                'app-modules/profile/resources/css/profile.css',
             ],
             refresh: true,
         }),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
Adds a public profile page accessible at /@{username}. Implements ProfileController to load tenant-scoped user/profile data, builds connected accounts, registers a public route, and introduces a responsive Blade view rendering avatar, headline, social links, badges and recruiter summary. Feature tests cover successful displays and error cases.

## References
- PR: https://github.com/he4rt/heartdevs.com/pull/282
- PR: https://github.com/he4rt/heartdevs.com/pull/280
- PR: https://github.com/he4rt/heartdevs.com/pull/274
- PR: https://github.com/he4rt/heartdevs.com/pull/303
- This PR: https://github.com/he4rt/heartdevs.com/pull/305

## Dependencies & Requirements
- No new composer/npm dependencies added.
- No environment variables or configuration changes required.
- Compatible with existing tenant-scoped profile structures and provider enum mappings.

## Contributor Summary

| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| GustavoSimao | 529 | 1 | 5 |

## Changes Summary

| File Path | Change Description |
|---|---|
| app-modules/portal/resources/views/components/layouts/app.blade.php | Removed default `class="dark"` from `<html>` root. |
| app-modules/profile/resources/views/public-profile.blade.php | New public profile Blade view: avatar, headline, about, social links, badges, connected accounts, responsive layout. |
| app-modules/profile/src/Http/ProfileController.php | New controller: tenant/user/profile lookup, buildConnectedAccounts logic, renders public profile. |
| app-modules/profile/src/ProfileServiceProvider.php | Registered profile views namespace and public route `GET /@{username}`. |
| app-modules/profile/tests/Feature/PublicProfileTest.php | New feature tests for public profile display, minimal profiles, and 404 scenarios. |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->