### PR TITLE
fix(gamification): min 1 XP per message and consolidate text XP logic

### DIFF
--- a/app-modules/activity/src/Message/Actions/NewMessage.php
+++ b/app-modules/activity/src/Message/Actions/NewMessage.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace He4rt\Activity\Message\Actions;
 
 use He4rt\Activity\Message\DTOs\NewMessageDTO;
-use He4rt\Gamification\Character\Models\Character;
+use He4rt\Gamification\Character\Actions\IncrementExperience;
 use He4rt\Identity\ExternalIdentity\DTOs\ResolveUserProviderDTO;
 use He4rt\Identity\User\Actions\ResolveUserContext;
 use He4rt\Identity\User\Models\User;
@@ -16,6 +16,7 @@ final readonly class NewMessage
 {
     public function __construct(
         private PersistMessage $persistMessage,
+        private IncrementExperience $incrementExperience,
     ) {}
 
     public function persist(NewMessageDTO $messageDTO): void
@@ -31,15 +32,11 @@ final readonly class NewMessage
 
             $userContext = resolve(ResolveUserContext::class)->handle($userDto);
 
-            $userContext->character->refresh();
-
-            $obtainedExperience = Character::generateTextExperience(
+            $obtainedExperience = $this->incrementExperience->incrementByTextMessage(
+                $userContext->character->id,
                 $messageDTO->content,
-                $userContext->character->level,
                 $userContext->user->is_donator,
             );
-
-            $userContext->character->increment('experience', $obtainedExperience);
 
             $this->persistMessage->handle(
                 $messageDTO,

--- a/app-modules/activity/tests/Unit/Actions/NewMessageTest.php
+++ b/app-modules/activity/tests/Unit/Actions/NewMessageTest.php
@@ -2,90 +2,127 @@
 
 declare(strict_types=1);
 
+use Carbon\CarbonImmutable;
 use He4rt\Activity\Message\Actions\NewMessage;
-use He4rt\Activity\Message\Actions\PersistMessage;
 use He4rt\Activity\Message\DTOs\NewMessageDTO;
-use He4rt\Community\Meeting\Actions\AttendMeeting;
-use He4rt\Identity\ExternalIdentity\Actions\FindExternalIdentity;
-use He4rt\Identity\ExternalIdentity\Actions\LinkExternalIdentity as NewAccountByProvider;
-use Illuminate\Support\Facades\Cache;
+use He4rt\Activity\Message\Models\Message;
+use He4rt\Gamification\Character\Models\Character;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 
-test('new message', function (string $provider, array $payload): void {
-    Cache::shouldReceive('tags->has')
-        ->once()
-        ->with('current-meeting')
-        ->andReturn(true);
+uses(RefreshDatabase::class);
 
-    Cache::shouldReceive('tags->has')
-        ->once()
-        ->with('meeting-id-user-foda-attended')
-        ->andReturn(false);
+test('persist delegates to IncrementExperience and stores message', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = User::factory()->create(['is_donator' => false]);
+    $character = Character::factory()
+        ->recycle($user)
+        ->recycle($tenant)
+        ->create(['experience' => 0]);
 
-    $findProviderStub = Mockery::mock(FindExternalIdentity::class);
-    $findCharacterStub = Mockery::mock(FindCharacterIdByUserId::class);
-    $characterExperienceStub = Mockery::mock(IncrementExperience::class);
-    $persistMessageStub = Mockery::mock(PersistMessage::class);
-    $attendMeetingStub = Mockery::mock(AttendMeeting::class);
-    $newUserStub = Mockery::mock(NewAccountByProvider::class);
+    $provider = ExternalIdentity::factory()
+        ->recycle($tenant)
+        ->create([
+            'model_type' => (new User)->getMorphClass(),
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '123456',
+        ]);
 
-    $obtainedExperience = 1;
-    $providerEntityMock = (object) [
-        'id' => '1',
-        'model_id' => 'id-user-foda',
-        'provider' => 'twitch',
-        'external_account_id' => '12312312',
-    ];
-
-    $findProviderStub
-        ->shouldReceive('handle')
-        ->with($provider, $payload['external_account_id'])
-        ->andReturn($providerEntityMock);
-
-    $findCharacterStub
-        ->shouldReceive('handle')
-        ->once()
-        ->with($providerEntityMock->model_id)
-        ->andReturn('id-character-foda');
-
-    $characterExperienceStub
-        ->shouldReceive('incrementByTextMessage')
-        ->once()
-        ->with('id-character-foda', $payload['content'])
-        ->andReturn($obtainedExperience);
-
-    $persistMessageStub
-        ->shouldReceive('handle')
-        ->once()
-        ->with(Mockery::type(NewMessageDTO::class), $obtainedExperience, $providerEntityMock->id);
-
-    $attendMeetingStub
-        ->shouldReceive('handle')
-        ->once()
-        ->with($providerEntityMock->model_id);
-
-    $action = new NewMessage(
-        $persistMessageStub,
-        $findProviderStub,
-        $findCharacterStub,
-        $characterExperienceStub,
-        $attendMeetingStub,
-        $newUserStub
+    $content = str_repeat('a', 200);
+    $dto = new NewMessageDTO(
+        tenantId: $tenant->id,
+        provider: IdentityProvider::Discord,
+        providerUsername: 'testuser',
+        externalAccountId: '123456',
+        providerMessageId: 'msg-001',
+        channelId: 'ch-001',
+        content: $content,
+        sentAt: CarbonImmutable::parse('2025-01-01 12:00:00'),
     );
 
-    $action->persist($payload);
-})->with('data provider')->skip();
+    resolve(NewMessage::class)->persist($dto);
 
-dataset('data provider', fn () => [
-    'twitch #1' => [
-        'provider' => 'twitch',
-        'payload' => [
-            'provider' => 'twitch',
-            'tenant_id' => 1,
-            'external_account_id' => '1234',
-            'provider_message_id' => '78781237',
-            'channel_id' => '31231267312',
-            'content' => 'deixa o sub',
-            'sent_at' => '2023-01-18 22:36:32',
-        ],
-    ],
-]);
+    // (200 * 0.01) + (1 * 0.1) = 2.1 → (int) 2
+    expect($character->fresh()->experience)->toBe(2);
+
+    $message = Message::query()->where('provider_message_id', 'msg-001')->first();
+    expect($message)->not->toBeNull()
+        ->and($message->obtained_experience)->toBe(2)
+        ->and($message->content)->toBe($content)
+        ->and($message->external_identity_id)->toBe($provider->id);
+});
+
+test('supporter gets double xp on message', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = User::factory()->create(['is_donator' => true]);
+    $character = Character::factory()
+        ->recycle($user)
+        ->recycle($tenant)
+        ->create(['experience' => 0]);
+
+    ExternalIdentity::factory()
+        ->recycle($tenant)
+        ->create([
+            'model_type' => (new User)->getMorphClass(),
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '789',
+        ]);
+
+    $dto = new NewMessageDTO(
+        tenantId: $tenant->id,
+        provider: IdentityProvider::Discord,
+        providerUsername: 'supporter',
+        externalAccountId: '789',
+        providerMessageId: 'msg-002',
+        channelId: 'ch-001',
+        content: str_repeat('a', 200),
+        sentAt: CarbonImmutable::parse('2025-01-01 12:00:00'),
+    );
+
+    resolve(NewMessage::class)->persist($dto);
+
+    // non-supporter: (200 * 0.01) + (1 * 0.1) = 2 → supporter: 2 * 2 = 4
+    expect($character->fresh()->experience)->toBe(4);
+});
+
+test('short message gives minimum 1 xp at level 1', function (): void {
+    $tenant = Tenant::factory()->create();
+    $user = User::factory()->create(['is_donator' => false]);
+    $character = Character::factory()
+        ->recycle($user)
+        ->recycle($tenant)
+        ->create(['experience' => 0]);
+
+    ExternalIdentity::factory()
+        ->recycle($tenant)
+        ->create([
+            'model_type' => (new User)->getMorphClass(),
+            'model_id' => $user->id,
+            'provider' => IdentityProvider::Discord,
+            'external_account_id' => '456',
+        ]);
+
+    $dto = new NewMessageDTO(
+        tenantId: $tenant->id,
+        provider: IdentityProvider::Discord,
+        providerUsername: 'newbie',
+        externalAccountId: '456',
+        providerMessageId: 'msg-003',
+        channelId: 'ch-001',
+        content: 'hello world',
+        sentAt: CarbonImmutable::parse('2025-01-01 12:00:00'),
+    );
+
+    resolve(NewMessage::class)->persist($dto);
+
+    expect($character->fresh()->experience)->toBe(1);
+
+    $message = Message::query()->where('provider_message_id', 'msg-003')->first();
+    expect($message)->not->toBeNull()
+        ->and($message->obtained_experience)->toBe(1);
+});

--- a/app-modules/gamification/src/Character/Actions/IncrementExperience.php
+++ b/app-modules/gamification/src/Character/Actions/IncrementExperience.php
@@ -9,10 +9,10 @@ use He4rt\Gamification\Character\Models\Character;
 
 class IncrementExperience
 {
-    public function incrementByTextMessage(string $characterId, string $message): int
+    public function incrementByTextMessage(string $characterId, string $message, bool $isSupporter): int
     {
         $character = Character::query()->findOrFail($characterId);
-        $experience = Character::generateTextExperience($message, $character->level, false);
+        $experience = Character::generateTextExperience($message, $character->level, $isSupporter);
         $character->increment('experience', $experience);
 
         return $experience;

--- a/app-modules/gamification/src/Character/Models/Character.php
+++ b/app-modules/gamification/src/Character/Models/Character.php
@@ -24,6 +24,7 @@ use Illuminate\Database\Eloquent\Relations\Pivot;
 use Illuminate\Support\Facades\Date;
 
 /**
+ * @property string $id
  * @property int $user_id
  * @property int $reputation
  * @property int $experience
@@ -61,7 +62,7 @@ final class Character extends Model
 
     public static function generateTextExperience(string $message, int $level, bool $isSupporter): int
     {
-        $experience = (int) ((mb_strlen($message) * 0.01) + ($level * 0.1));
+        $experience = max(1, (int) ((mb_strlen($message) * 0.01) + ($level * 0.1)));
 
         return $isSupporter ? $experience * 2 : $experience;
     }

--- a/app-modules/gamification/tests/Unit/Character/GenerateTextExperienceTest.php
+++ b/app-modules/gamification/tests/Unit/Character/GenerateTextExperienceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Gamification\Character\Models\Character;
+
+test('empty message returns minimum 1 xp', function (): void {
+    expect(Character::generateTextExperience('', 1, false))->toBe(1);
+});
+
+test('short messages at level 1 return minimum 1 xp', function (string $message): void {
+    expect(Character::generateTextExperience($message, 1, false))->toBe(1);
+})->with([
+    'hello' => ['hello'],
+    '50 chars' => [str_repeat('a', 50)],
+    '89 chars' => [str_repeat('a', 89)],
+]);
+
+test('90 chars at level 1 still gives 1 xp from formula', function (): void {
+    $message = str_repeat('a', 90);
+
+    // (90 * 0.01) + (1 * 0.1) = 0.9 + 0.1 = 1.0 → max(1, 1) = 1
+    expect(Character::generateTextExperience($message, 1, false))->toBe(1);
+});
+
+test('xp scales with message length', function (int $length, int $level, int $expectedXp): void {
+    $message = str_repeat('a', $length);
+
+    expect(Character::generateTextExperience($message, $level, false))->toBe($expectedXp);
+})->with([
+    '100 chars, level 1' => [100, 1, 1],
+    '200 chars, level 1' => [200, 1, 2],
+    '500 chars, level 1' => [500, 1, 5],
+    '100 chars, level 10' => [100, 10, 2],
+    '100 chars, level 50' => [100, 50, 6],
+    '500 chars, level 50' => [500, 50, 10],
+]);
+
+test('supporter doubles xp', function (): void {
+    $message = str_repeat('a', 200);
+
+    $regularXp = Character::generateTextExperience($message, 10, false);
+    $supporterXp = Character::generateTextExperience($message, 10, true);
+
+    expect($supporterXp)->toBe($regularXp * 2);
+});
+
+test('supporter gets minimum 2 xp for short messages', function (): void {
+    expect(Character::generateTextExperience('hi', 1, true))->toBe(2);
+});
+
+test('multibyte characters count by character not byte', function (): void {
+    $asciiMessage = str_repeat('a', 100);
+    $mbMessage = str_repeat('ã', 100);
+
+    expect(Character::generateTextExperience($mbMessage, 1, false))
+        ->toBe(Character::generateTextExperience($asciiMessage, 1, false));
+});

--- a/app-modules/gamification/tests/Unit/Character/LevelCalculationTest.php
+++ b/app-modules/gamification/tests/Unit/Character/LevelCalculationTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Gamification\Character\Models\Character;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('zero experience is level 1', function (): void {
+    $character = Character::factory()->create(['experience' => 0]);
+
+    expect($character->level)->toBe(1);
+});
+
+test('experience at exact threshold gives that level', function (int $level, int $xp): void {
+    $character = Character::factory()->create(['experience' => $xp]);
+
+    expect($character->level)->toBe($level);
+})->with([
+    'level 2 at 120 xp' => [2, 120],
+    'level 5 at 1000 xp' => [5, 1000],
+    'level 10 at 4500 xp' => [10, 4500],
+    'level 25 at 39000 xp' => [25, 39000],
+    'level 50 at 400000 xp' => [50, 400000],
+]);
+
+test('experience just below threshold stays at previous level', function (int $expectedLevel, int $xp): void {
+    $character = Character::factory()->create(['experience' => $xp]);
+
+    expect($character->level)->toBe($expectedLevel);
+})->with([
+    'level 1 at 119 xp' => [1, 119],
+    'level 4 at 999 xp' => [4, 999],
+    'level 9 at 4499 xp' => [9, 4499],
+]);
+
+test('experience beyond max threshold is still level 50', function (): void {
+    $character = Character::factory()->create(['experience' => 999999]);
+
+    expect($character->level)->toBe(50);
+});
+
+test('percentage experience at midpoint', function (): void {
+    // Level 1: 0, Level 2: 120 → midpoint = 60
+    $character = Character::factory()->create(['experience' => 60]);
+
+    expect($character->level)->toBe(1)
+        ->and($character->percentage_experience)->toBe(50.0);
+});
+
+test('percentage experience at start of level', function (): void {
+    $character = Character::factory()->create(['experience' => 120]);
+
+    expect($character->level)->toBe(2)
+        ->and($character->percentage_experience)->toBe(0.0);
+});
+
+test('percentage experience at max level is 100', function (): void {
+    $character = Character::factory()->create(['experience' => 400000]);
+
+    expect($character->level)->toBe(50)
+        ->and($character->percentage_experience)->toBe(100.0);
+});
+
+test('experience progress shows xp remaining to next level', function (): void {
+    // Level 1: 0, Level 2: 120. At 60 xp → 60 remaining
+    $character = Character::factory()->create(['experience' => 60]);
+
+    expect($character->experience_progress)->toBe(60);
+});

--- a/app-modules/gamification/tests/Unit/Character/VoiceExperienceTest.php
+++ b/app-modules/gamification/tests/Unit/Character/VoiceExperienceTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Gamification\Character\Actions\IncrementExperience;
+use He4rt\Gamification\Character\Enums\VoiceStatesEnum;
+use He4rt\Gamification\Character\Models\Character;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+uses(RefreshDatabase::class);
+
+test('voice state multipliers', function (VoiceStatesEnum $state, int $expected): void {
+    expect($state->getExperienceMultiplier())->toBe($expected);
+})->with([
+    'disabled gives 0' => [VoiceStatesEnum::Disabled, 0],
+    'muted gives 3' => [VoiceStatesEnum::Muted, 3],
+    'unmuted gives 5' => [VoiceStatesEnum::Unmuted, 5],
+]);
+
+test('voice xp increments by multiplier times level', function (): void {
+    $character = Character::factory()->create(['experience' => 4500]);
+    // level 10 at 4500 xp, unmuted = 5 * 10 = 50
+
+    $xp = resolve(IncrementExperience::class)
+        ->incrementByVoiceMessage($character->id, VoiceStatesEnum::Unmuted);
+
+    expect($xp)->toBe(50)
+        ->and($character->fresh()->experience)->toBe(4550);
+});
+
+test('disabled voice state gives zero xp', function (): void {
+    $character = Character::factory()->create(['experience' => 4500]);
+
+    $xp = resolve(IncrementExperience::class)
+        ->incrementByVoiceMessage($character->id, VoiceStatesEnum::Disabled);
+
+    expect($xp)->toBe(0)
+        ->and($character->fresh()->experience)->toBe(4500);
+});
+
+test('text message increment works through action', function (): void {
+    $character = Character::factory()->create(['experience' => 0]);
+    $message = str_repeat('a', 200);
+
+    $xp = resolve(IncrementExperience::class)
+        ->incrementByTextMessage($character->id, $message, false);
+
+    // (200 * 0.01) + (1 * 0.1) = 2.1 → (int) 2
+    expect($xp)->toBe(2)
+        ->and($character->fresh()->experience)->toBe(2);
+});
+
+test('text message increment passes supporter flag', function (): void {
+    $character = Character::factory()->create(['experience' => 0]);
+    $message = str_repeat('a', 200);
+
+    $xp = resolve(IncrementExperience::class)
+        ->incrementByTextMessage($character->id, $message, true);
+
+    // non-supporter would be 2, supporter = 4
+    expect($xp)->toBe(4)
+        ->and($character->fresh()->experience)->toBe(4);
+});

--- a/app-modules/identity/database/factories/TenantFactory.php
+++ b/app-modules/identity/database/factories/TenantFactory.php
@@ -29,6 +29,11 @@ final class TenantFactory extends Factory
         ];
     }
 
+    public function withOwnerAsMember(): self
+    {
+        return $this->afterCreating(fn (Tenant $tenant) => $tenant->members()->attach($tenant->owner_id));
+    }
+
     public function withDiscordProvider(string $providerId = '123'): self
     {
         return $this->withProvider(IdentityProvider::Discord, $providerId);
@@ -44,6 +49,9 @@ final class TenantFactory extends Factory
         return $this->afterCreating(function (Tenant $tenant) use ($provider, $providerId): void {
             ExternalIdentity::factory()->create([
                 'tenant_id' => $tenant->getKey(),
+                'model_type' => (new Tenant)->getMorphClass(),
+                'model_id' => $tenant->getKey(),
+                'connected_by' => $tenant->owner_id,
                 'provider' => $provider,
                 'external_account_id' => $providerId,
             ]);

--- a/app-modules/panel-admin/src/Filament/Resources/ExternalIdentities/Schemas/ExternalIdentityForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/ExternalIdentities/Schemas/ExternalIdentityForm.php
@@ -18,8 +18,7 @@ class ExternalIdentityForm
             ->components([
                 TextInput::make('tenant_id')
                     ->label('Tenant Id')
-                    ->required()
-                    ->integer(),
+                    ->required(),
 
                 TextInput::make('model_type')
                     ->label('Model Type')


### PR DESCRIPTION
## Summary

- Every message now earns at least 1 XP (2 for supporters),
  removing the 90-char threshold that blocked level 1 users
  from earning any XP on short messages.
- `IncrementExperience::incrementByTextMessage` now accepts
  `isSupporter` — previously hardcoded `false`, so supporters
  never got their 2x multiplier through this path.
- `NewMessage` delegates to `IncrementExperience` instead of
  duplicating the calculate + increment logic inline.
- Added `@property string $id` to Character PHPDoc (HasUuids).
- Fix `ExternalIdentityForm` crash: `->integer()` on the
  `tenant_id` field parsed UUIDs as numbers producing `INF`,
  crashing Livewire JSON serialization on the edit page.
- Fix `TenantFactory::withProvider()` to set correct morph
  type/id (Tenant, not User) and `connected_by` to owner.
- Add `withOwnerAsMember()` factory state.
- 38 new tests covering the XP system end-to-end.

## Test plan

- [x] `GenerateTextExperienceTest` — formula, min floor,
  supporter 2x, multibyte chars
- [x] `LevelCalculationTest` — thresholds, boundaries,
  percentage, progress
- [x] `VoiceExperienceTest` — multipliers, action, supporter
  flag passthrough
- [x] `NewMessageTest` — full integration flow, supporter
  double XP, short message min 1 XP
- [x] ExternalIdentity edit page loads without crash
- [x] PHPStan passes
- [x] Pint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Description
- Ensures every text message grants at least 1 XP (2 XP for supporters) by applying a minimum floor before the supporter multiplier and removing the 90-character threshold. Consolidates text XP logic so NewMessage delegates to IncrementExperience. Adds 38 tests covering XP, levels, and voice experience; fixes related factory, form, and PHPDoc issues.

## References
- PR: https://github.com/he4rt/heartdevs.com/pull/308
- Related discussions/issues: `#176`, `#54`, `#11`

## Dependencies & Requirements
- No new dependencies or environment changes. Internal refactor and test additions only.

## Contributor Summary
| Contributor | Lines Added | Lines Removed | Files Changed |
|---|---:|---:|---:|
| gvieira18 | 329 | 95 | 9 |

## Changes Summary
| File Path | Change Description |
|---|---|
| app-modules/gamification/src/Character/Models/Character.php | Enforce minimum 1 XP in generateTextExperience(); add `@property string $id` PHPDoc. |
| app-modules/gamification/src/Character/Actions/IncrementExperience.php | Add `bool $isSupporter` parameter to `incrementByTextMessage()` and forward to calculation. |
| app-modules/activity/src/Message/Actions/NewMessage.php | Inject IncrementExperience and delegate XP calculation; remove duplicated inline XP logic. |
| app-modules/activity/tests/Unit/Actions/NewMessageTest.php | Replace mocks with DB-backed tests verifying experience persistence, supporter 2×, and min 1 XP for short messages. |
| app-modules/gamification/tests/Unit/Character/GenerateTextExperienceTest.php | New tests: formula, min floor, supporter doubling, multibyte handling. |
| app-modules/gamification/tests/Unit/Character/LevelCalculationTest.php | New tests for level thresholds, boundaries, percentage and progress. |
| app-modules/gamification/tests/Unit/Character/VoiceExperienceTest.php | New tests for voice multipliers and IncrementExperience behavior. |
| app-modules/identity/database/factories/TenantFactory.php | Fix withProvider morph fields and `connected_by`; add `withOwnerAsMember()` state. |
| app-modules/panel-admin/src/Filament/Resources/ExternalIdentities/Schemas/ExternalIdentityForm.php | Remove `->integer()` constraint on `tenant_id` TextInput to avoid UUID parsing crash. |
<!-- end of auto-generated comment: release notes by coderabbit.ai -->