### PR TITLE
feat(db): convert timestamp to timestamptz

### DIFF
--- a/.ai/guidelines/domain/05-timezone-aware-dates.blade.php
+++ b/.ai/guidelines/domain/05-timezone-aware-dates.blade.php
@@ -1,0 +1,118 @@
+@php
+/** @var \Laravel\Boost\Install\GuidelineAssist $assist */
+@endphp
+
+# Migrations & Timezone-Aware Dates
+
+**Priority: HIGH** — These rules are non-negotiable. Every migration MUST be created via Artisan with the correct module flag, and every date/time column MUST use timezone-aware types.
+
+## Creating migrations
+
+Always use `{{ $assist->artisanCommand('make:migration') }}` to create migration files. Never create migration files manually.
+
+This is a modular monorepo (`internachi/modular`). Every migration MUST target its module with the `--module` flag:
+
+@verbatim
+<code-snippet name="Creating a migration for a module" lang="bash">
+# Always specify the module:
+php artisan make:migration create_example_table --module=identity
+php artisan make:migration add_expires_at_to_tokens --module=identity --table=tokens
+
+# NEVER create migrations without --module (they end up in the wrong directory):
+# BAD:  php artisan make:migration create_example_table
+# GOOD: php artisan make:migration create_example_table --module=identity
+</code-snippet>
+@endverbatim
+
+The `--module` flag places the migration in `app-modules/{module}/database/migrations/`, which is where the module's ServiceProvider loads migrations from.
+
+## Timezone-aware date columns — mandatory
+
+When creating or altering any database column that stores a date, time, or datetime value, you MUST use the timezone-aware (`Tz`) variant. Never use the non-tz variants.
+
+### Required mappings
+
+| NEVER use | ALWAYS use instead |
+|-----------|-------------------|
+| `$table->timestamp('col')` | `$table->timestampTz('col')` |
+| `$table->timestamps()` | `$table->timestampsTz()` |
+| `$table->softDeletes()` | `$table->softDeletesTz()` |
+| `$table->dateTime('col')` | `$table->dateTimeTz('col')` |
+| `$table->nullableTimestamps()` | `$table->timestampsTz()` with `->nullable()` |
+
+### Context
+
+This project uses PostgreSQL with `APP_TIMEZONE=UTC` and `display_timezone=America/Sao_Paulo`. The `timestamptz` type stores absolute UTC timestamps, allowing PostgreSQL to handle timezone conversion correctly. The non-tz `timestamp` type stores naive datetimes that lose timezone context and cause ±3h display bugs.
+
+### Display timezone
+
+When displaying dates to users, always use `config('app.display_timezone')`:
+
+@verbatim
+<code-snippet name="Display timezone conversion" lang="php">
+// In Blade/Livewire:
+$date->timezone(config('app.display_timezone'))->format('d/m/Y H:i')
+
+// In Filament table columns:
+TextColumn::make('created_at')
+    ->dateTime('d/m/Y H:i')
+    ->timezone(config('app.display_timezone'))
+</code-snippet>
+@endverbatim
+
+### In raw SQL queries
+
+When converting timestamps for display in raw SQL, use `AT TIME ZONE` with the display timezone:
+
+@verbatim
+<code-snippet name="SQL timezone conversion" lang="sql">
+-- Convert timestamptz to display timezone:
+SELECT occurred_at AT TIME ZONE 'America/Sao_Paulo' AS local_time
+FROM events;
+
+-- NEVER use double AT TIME ZONE (causes +3h shift):
+-- BAD:  occurred_at AT TIME ZONE 'UTC' AT TIME ZONE 'America/Sao_Paulo'
+-- GOOD: occurred_at AT TIME ZONE 'America/Sao_Paulo'
+</code-snippet>
+@endverbatim
+
+### Carbon usage
+
+@verbatim
+<code-snippet name="UTC timestamp creation" lang="php">
+// Correct — uses app timezone (UTC):
+now()
+Carbon::now()
+
+// For explicit UTC:
+now()->utc()
+
+// NEVER hardcode timezone in application logic:
+// BAD:  now()->timezone('America/Sao_Paulo')
+// GOOD: now()  (app is UTC, display converts later)
+</code-snippet>
+@endverbatim
+
+### PostgreSQL session timezone
+
+Do NOT set `'timezone' => 'UTC'` in `config/database.php` pgsql connection. This causes double-conversion on `timestamptz` columns. Let PostgreSQL use its server default.
+
+## What triggers this guideline
+
+- `{{ $assist->artisanCommand('make:migration') }}` — always use `--module=<module>`
+- Any migration that adds date/time columns — always use `Tz` variants
+- Any edit to an existing migration that touches date/time columns
+- Creating a model with `{{ $assist->artisanCommand('make:model') }}` — ensure generated migration uses `timestampsTz()`
+- Display code showing dates — use `config('app.display_timezone')`
+- Raw SQL with timestamp conversion — use single `AT TIME ZONE`
+
+## Verification
+
+Before marking any migration task as done, confirm:
+
+1. Migration was created via `{{ $assist->artisanCommand('make:migration') }}` with `--module=<module>`
+2. Migration file lives in `app-modules/{module}/database/migrations/`
+3. All new date/time columns use the `Tz` variant
+4. No `timestamps()`, `timestamp()`, `softDeletes()`, or `dateTime()` without `Tz`
+5. Display code uses `config('app.display_timezone')` for user-facing dates
+6. Raw SQL queries use single `AT TIME ZONE` (never double)

--- a/.ai/guidelines/domain/05-timezone-aware-dates.blade.php
+++ b/.ai/guidelines/domain/05-timezone-aware-dates.blade.php
@@ -38,7 +38,7 @@ When creating or altering any database column that stores a date, time, or datet
 | `$table->timestamps()` | `$table->timestampsTz()` |
 | `$table->softDeletes()` | `$table->softDeletesTz()` |
 | `$table->dateTime('col')` | `$table->dateTimeTz('col')` |
-| `$table->nullableTimestamps()` | `$table->timestampsTz()` with `->nullable()` |
+| `$table->nullableTimestamps()` | `$table->timestampsTz()` |
 
 ### Context
 

--- a/app-modules/activity/database/migrations/2023_01_18_211845_create_messages_table.php
+++ b/app-modules/activity/database/migrations/2023_01_18_211845_create_messages_table.php
@@ -21,8 +21,8 @@ return new class extends Migration
                 $table->string('channel_id')->nullable();
                 $table->text('content');
                 $table->integer('obtained_experience');
-                $table->timestamp('sent_at')->nullable();
-                $table->timestamps();
+                $table->timestampTz('sent_at')->nullable();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/activity/database/migrations/2023_02_10_224951_create_voice_messages_table.php
+++ b/app-modules/activity/database/migrations/2023_02_10_224951_create_voice_messages_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
                 $table->string('channel_name');
                 $table->string('state');
                 $table->integer('obtained_experience');
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/activity/database/migrations/2026_03_18_000000_create_interactions_table.php
+++ b/app-modules/activity/database/migrations/2026_03_18_000000_create_interactions_table.php
@@ -25,9 +25,9 @@ return new class extends Migration
             $table->nullableUuidMorphs('source');
             $table->string('external_ref')->nullable();
             $table->jsonb('metadata')->nullable();
-            $table->timestamp('occurred_at');
-            $table->timestamp('reviewed_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('occurred_at');
+            $table->timestampTz('reviewed_at')->nullable();
+            $table->timestampsTz();
 
             $table->index(['character_id', 'type', 'created_at'], 'idx_interactions_character_type');
             $table->index(['status', 'value_tier'], 'idx_interactions_status_tier');

--- a/app-modules/activity/database/migrations/2026_04_17_000001_add_metadata_to_messages_table.php
+++ b/app-modules/activity/database/migrations/2026_04_17_000001_add_metadata_to_messages_table.php
@@ -33,7 +33,7 @@ return new class extends Migration
             $table->boolean('is_pinned')->default(false)->after('source_kind');
             $table->boolean('mentions_everyone')->default(false)->after('is_pinned');
             $table->smallInteger('mention_role_count')->default(0)->after('mentions_everyone');
-            $table->timestamp('edited_at')->nullable()->after('mention_role_count');
+            $table->timestampTz('edited_at')->nullable()->after('mention_role_count');
             $table->string('reply_to_provider_message_id')->nullable()->after('edited_at');
 
             $table->index(['tenant_id', 'sent_at'], 'messages_tenant_sent_at_idx');

--- a/app-modules/activity/database/migrations/2026_04_17_000002_create_moderation_events_table.php
+++ b/app-modules/activity/database/migrations/2026_04_17_000002_create_moderation_events_table.php
@@ -20,8 +20,8 @@ return new class extends Migration
             $table->foreignUuid('source_identity_id')->nullable()->constrained('external_identities');
             $table->uuid('source_message_id')->nullable();
             $table->jsonb('metadata')->nullable();
-            $table->timestamp('occurred_at');
-            $table->timestamps();
+            $table->timestampTz('occurred_at');
+            $table->timestampsTz();
 
             $table->foreign('source_message_id')->references('id')->on('messages');
             $table->index(['tenant_id', 'type', 'occurred_at']);

--- a/app-modules/activity/database/migrations/2026_04_17_000003_create_activity_reactions_table.php
+++ b/app-modules/activity/database/migrations/2026_04_17_000003_create_activity_reactions_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->unsignedInteger('count')->default(0);
             $table->unsignedInteger('count_burst')->default(0);
             $table->unsignedInteger('count_normal')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->unique(
                 ['reactable_type', 'reactable_id', 'emoji_key'],

--- a/app-modules/activity/database/migrations/2026_04_19_222819_add_provider_message_id_to_voice_messages_table.php
+++ b/app-modules/activity/database/migrations/2026_04_19_222819_add_provider_message_id_to_voice_messages_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::table('voice_messages', function (Blueprint $table): void {
             $table->string('provider_message_id')->nullable()->after('external_identity_id');
-            $table->timestamp('occurred_at')->nullable()->after('state');
+            $table->timestampTz('occurred_at')->nullable()->after('state');
         });
 
         // Partial unique index — only enforced when we have a provider_message_id

--- a/app-modules/activity/database/migrations/2026_04_20_110053_create_message_mentions_and_threads.php
+++ b/app-modules/activity/database/migrations/2026_04_20_110053_create_message_mentions_and_threads.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->string('mentioned_provider_account_id');
             $table->string('mentioned_username')->nullable();
             $table->unsignedSmallInteger('position')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->unique(
                 ['message_id', 'mentioned_provider_account_id'],
@@ -42,7 +42,7 @@ return new class extends Migration
             $table->string('name')->nullable();
             $table->boolean('archived')->nullable();
             $table->unsignedInteger('auto_archive_duration')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->unique(
                 ['tenant_id', 'provider_thread_id'],

--- a/app-modules/activity/database/migrations/2026_04_20_111057_create_fase3_activity_tables.php
+++ b/app-modules/activity/database/migrations/2026_04_20_111057_create_fase3_activity_tables.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->unsignedBigInteger('size')->nullable();
             $table->unsignedInteger('width')->nullable();
             $table->unsignedInteger('height')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('message_id', 'message_attachments_message_idx');
         });
@@ -39,7 +39,7 @@ return new class extends Migration
             $table->text('thumbnail_url')->nullable();
             $table->jsonb('raw')->nullable();
             $table->unsignedSmallInteger('position')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('message_id', 'message_embeds_message_idx');
             $table->index(['tenant_id', 'source_domain'], 'message_embeds_tenant_domain_idx');
@@ -51,10 +51,10 @@ return new class extends Migration
             $table->foreignUuid('tenant_id')->constrained('tenants');
             $table->foreignUuid('external_identity_id')->constrained('external_identities');
             $table->string('kind');
-            $table->timestamp('occurred_at');
+            $table->timestampTz('occurred_at');
             $table->string('provider_message_id')->nullable();
             $table->jsonb('metadata')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index(['tenant_id', 'kind', 'occurred_at'], 'membership_events_tenant_kind_time_idx');
             $table->index(['external_identity_id', 'kind'], 'membership_events_identity_kind_idx');

--- a/app-modules/activity/database/migrations/2026_05_09_154113_create_activity_timeline_table.php
+++ b/app-modules/activity/database/migrations/2026_05_09_154113_create_activity_timeline_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->boolean('is_ignored')->default(false);
             $table->boolean('pinned')->default(false);
             $table->integer('views')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index(['tenant_id', 'created_at'], 'activity_timeline_tenant_feed_index');
             $table->index(['tenant_id', 'parent_id', 'is_ignored', 'created_at'], 'activity_timeline_feed_composite_index');

--- a/app-modules/activity/database/migrations/2026_05_09_155946_create_activity_post_entries_table.php
+++ b/app-modules/activity/database/migrations/2026_05_09_155946_create_activity_post_entries_table.php
@@ -13,8 +13,8 @@ return new class extends Migration
         Schema::create('activity_post_entries', function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->text('content');
-            $table->timestamps();
-            $table->softDeletes();
+            $table->timestampsTz();
+            $table->softDeletesTz();
         });
     }
 

--- a/app-modules/activity/database/migrations/2026_06_06_190902_alter_activity_timestamps_to_timestamptz.php
+++ b/app-modules/activity/database/migrations/2026_06_06_190902_alter_activity_timestamps_to_timestamptz.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // messages (skip sent_at — already timestamptz)
+        $this->alterColumn('messages', 'created_at');
+        $this->alterColumn('messages', 'updated_at');
+        $this->alterColumn('messages', 'edited_at');
+
+        // voice_messages (skip occurred_at — already timestamptz)
+        $this->alterColumn('voice_messages', 'created_at');
+        $this->alterColumn('voice_messages', 'updated_at');
+
+        // interactions
+        $this->alterColumn('interactions', 'created_at');
+        $this->alterColumn('interactions', 'updated_at');
+        $this->alterColumn('interactions', 'occurred_at');
+        $this->alterColumn('interactions', 'reviewed_at');
+
+        // moderation_events
+        $this->alterColumn('moderation_events', 'created_at');
+        $this->alterColumn('moderation_events', 'updated_at');
+        $this->alterColumn('moderation_events', 'occurred_at');
+
+        // activity_reactions
+        $this->alterColumn('activity_reactions', 'created_at');
+        $this->alterColumn('activity_reactions', 'updated_at');
+
+        // message_mentions
+        $this->alterColumn('message_mentions', 'created_at');
+        $this->alterColumn('message_mentions', 'updated_at');
+
+        // message_threads
+        $this->alterColumn('message_threads', 'created_at');
+        $this->alterColumn('message_threads', 'updated_at');
+
+        // message_attachments
+        $this->alterColumn('message_attachments', 'created_at');
+        $this->alterColumn('message_attachments', 'updated_at');
+
+        // message_embeds
+        $this->alterColumn('message_embeds', 'created_at');
+        $this->alterColumn('message_embeds', 'updated_at');
+
+        // membership_events
+        $this->alterColumn('membership_events', 'created_at');
+        $this->alterColumn('membership_events', 'updated_at');
+        $this->alterColumn('membership_events', 'occurred_at');
+
+        // activity_timeline
+        $this->alterColumn('activity_timeline', 'created_at');
+        $this->alterColumn('activity_timeline', 'updated_at');
+
+        // activity_post_entries
+        $this->alterColumn('activity_post_entries', 'created_at');
+        $this->alterColumn('activity_post_entries', 'updated_at');
+        $this->alterColumn('activity_post_entries', 'deleted_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/community/database/migrations/2022_12_07_005119_create_meeting_types_table.php
+++ b/app-modules/community/database/migrations/2022_12_07_005119_create_meeting_types_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
                 $table->string('name');
                 $table->integer('week_day')->comment('Week day of event');
                 $table->time('start_at')->comment('Number of minutes past midnight');
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/community/database/migrations/2022_12_07_005347_create_meetings_table.php
+++ b/app-modules/community/database/migrations/2022_12_07_005347_create_meetings_table.php
@@ -19,9 +19,9 @@ return new class extends Migration
                 $table->foreignUuid('admin_id')->constrained('users')->cascadeOnDelete();
                 $table->text('content')->nullable();
                 $table->foreignId('meeting_type_id')->constrained('meeting_types')->cascadeOnDelete();
-                $table->dateTime('starts_at');
-                $table->dateTime('ends_at')->nullable();
-                $table->timestamps();
+                $table->dateTimeTz('starts_at');
+                $table->dateTimeTz('ends_at')->nullable();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/community/database/migrations/2022_12_07_005627_create_meeting_participants_table.php
+++ b/app-modules/community/database/migrations/2022_12_07_005627_create_meeting_participants_table.php
@@ -17,8 +17,8 @@ return new class extends Migration
             Schema::create('meeting_participants', function (Blueprint $table): void {
                 $table->foreignUuid('meeting_id')->constrained('meetings')->cascadeOnDelete();
                 $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
-                $table->dateTime('attend_at');
-                $table->timestamps();
+                $table->dateTimeTz('attend_at');
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/community/database/migrations/2023_01_28_183013_create_feedbacks_table.php
+++ b/app-modules/community/database/migrations/2023_01_28_183013_create_feedbacks_table.php
@@ -19,7 +19,7 @@ return new class extends Migration
             $table->foreignUuid('target_id')->constrained('users')->cascadeOnDelete();
             $table->string('type');
             $table->text('message');
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/community/database/migrations/2023_01_28_202610_create_feedback_reviews_table.php
+++ b/app-modules/community/database/migrations/2023_01_28_202610_create_feedback_reviews_table.php
@@ -19,8 +19,8 @@ return new class extends Migration
             $table->foreignUuid('staff_id')->constrained('users')->cascadeOnDelete();
             $table->string('status');
             $table->text('reason')->nullable();
-            $table->timestamp('received_at');
-            $table->timestamps();
+            $table->timestampTz('received_at');
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/community/database/migrations/2026_06_06_190906_alter_community_timestamps_to_timestamptz.php
+++ b/app-modules/community/database/migrations/2026_06_06_190906_alter_community_timestamps_to_timestamptz.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // meeting_types
+        $this->alterColumn('meeting_types', 'created_at');
+        $this->alterColumn('meeting_types', 'updated_at');
+
+        // meetings
+        $this->alterColumn('meetings', 'created_at');
+        $this->alterColumn('meetings', 'updated_at');
+        $this->alterColumn('meetings', 'starts_at');
+        $this->alterColumn('meetings', 'ends_at');
+
+        // meeting_participants
+        $this->alterColumn('meeting_participants', 'created_at');
+        $this->alterColumn('meeting_participants', 'updated_at');
+        $this->alterColumn('meeting_participants', 'attend_at');
+
+        // feedbacks
+        $this->alterColumn('feedbacks', 'created_at');
+        $this->alterColumn('feedbacks', 'updated_at');
+
+        // feedback_reviews
+        $this->alterColumn('feedback_reviews', 'created_at');
+        $this->alterColumn('feedback_reviews', 'updated_at');
+        $this->alterColumn('feedback_reviews', 'received_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/community/src/Feedback/Models/Review.php
+++ b/app-modules/community/src/Feedback/Models/Review.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Community\Feedback\Models;
 
-use Carbon\Carbon;
+use Carbon\CarbonInterface;
 use He4rt\Community\Database\Factories\ReviewFactory;
 use He4rt\Community\Feedback\Enums\ReviewTypeEnum;
 use He4rt\Identity\User\Models\User;
@@ -21,9 +21,9 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property string $staff_id
  * @property ReviewTypeEnum $status
  * @property string|null $reason
- * @property int $received_at
- * @property Carbon|null $created_at
- * @property Carbon|null $updated_at
+ * @property CarbonInterface|null $received_at
+ * @property CarbonInterface|null $created_at
+ * @property CarbonInterface|null $updated_at
  */
 #[Table(name: 'feedback_reviews')]
 final class Review extends Model
@@ -57,7 +57,7 @@ final class Review extends Model
     {
         return [
             'status' => ReviewTypeEnum::class,
-            'received_at' => 'timestamp',
+            'received_at' => 'datetime',
         ];
     }
 }

--- a/app-modules/economy/database/migrations/2026_03_16_220000_create_wallets_table.php
+++ b/app-modules/economy/database/migrations/2026_03_16_220000_create_wallets_table.php
@@ -15,7 +15,7 @@ return new class extends Migration
             $table->uuidMorphs('owner');
             $table->string('currency');
             $table->integer('balance')->default(0);
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->unique(['owner_type', 'owner_id', 'currency']);
         });

--- a/app-modules/economy/database/migrations/2026_03_16_220001_create_transactions_table.php
+++ b/app-modules/economy/database/migrations/2026_03_16_220001_create_transactions_table.php
@@ -18,7 +18,7 @@ return new class extends Migration
             $table->integer('balance_after');
             $table->nullableUuidMorphs('reference');
             $table->string('description')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/economy/database/migrations/2026_06_06_190907_alter_economy_timestamps_to_timestamptz.php
+++ b/app-modules/economy/database/migrations/2026_06_06_190907_alter_economy_timestamps_to_timestamptz.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // wallets
+        $this->alterColumn('wallets', 'created_at');
+        $this->alterColumn('wallets', 'updated_at');
+
+        // transactions
+        $this->alterColumn('transactions', 'created_at');
+        $this->alterColumn('transactions', 'updated_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/gamification/database/migrations/2023_01_14_053138_create_characters_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_14_053138_create_characters_table.php
@@ -19,8 +19,8 @@ return new class extends Migration
                 $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
                 $table->integer('experience')->default(0);
                 $table->integer('reputation')->default(0);
-                $table->timestamp('daily_bonus_claimed_at')->nullable();
-                $table->timestamps();
+                $table->timestampTz('daily_bonus_claimed_at')->nullable();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/gamification/database/migrations/2023_01_20_193234_create_badges_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_20_193234_create_badges_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                 $table->text('description');
                 $table->string('redeem_code');
                 $table->boolean('active');
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/gamification/database/migrations/2023_01_22_152940_create_characters_badges_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_22_152940_create_characters_badges_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             Schema::create('characters_badges', function (Blueprint $table): void {
                 $table->foreignUuid('character_id')->constrained('characters')->cascadeOnDelete();
                 $table->foreignId('badge_id')->constrained('badges')->cascadeOnDelete();
-                $table->timestamp('claimed_at');
+                $table->timestampTz('claimed_at');
             });
         }
     }

--- a/app-modules/gamification/database/migrations/2023_01_26_200555_create_seasons_rankings_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_26_200555_create_seasons_rankings_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->integer('messages_count');
             $table->integer('badges_count');
             $table->integer('meetings_count');
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/gamification/database/migrations/2023_01_30_174411_create_seasons_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_30_174411_create_seasons_table.php
@@ -18,13 +18,13 @@ return new class extends Migration
                 $table->uuid('id');
                 $table->string('name');
                 $table->text('description');
-                $table->timestamp('started_at')->nullable();
-                $table->timestamp('ended_at')->nullable();
+                $table->timestampTz('started_at')->nullable();
+                $table->timestampTz('ended_at')->nullable();
                 $table->integer('messages_count')->default(0);
                 $table->integer('participants_count')->default(0);
                 $table->integer('meeting_count')->default(0);
                 $table->integer('badges_count')->default(0);
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/gamification/database/migrations/2023_01_31_220125_create_character_levelup_table.php
+++ b/app-modules/gamification/database/migrations/2023_01_31_220125_create_character_levelup_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('character_id')->constrained('characters');
             $table->integer('level');
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/gamification/database/migrations/2026_06_06_190903_alter_gamification_timestamps_to_timestamptz.php
+++ b/app-modules/gamification/database/migrations/2026_06_06_190903_alter_gamification_timestamps_to_timestamptz.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // characters
+        $this->alterColumn('characters', 'created_at');
+        $this->alterColumn('characters', 'updated_at');
+        $this->alterColumn('characters', 'daily_bonus_claimed_at');
+
+        // badges
+        $this->alterColumn('badges', 'created_at');
+        $this->alterColumn('badges', 'updated_at');
+
+        // characters_badges
+        $this->alterColumn('characters_badges', 'claimed_at');
+
+        // seasons_rankings
+        $this->alterColumn('seasons_rankings', 'created_at');
+        $this->alterColumn('seasons_rankings', 'updated_at');
+
+        // seasons
+        $this->alterColumn('seasons', 'created_at');
+        $this->alterColumn('seasons', 'updated_at');
+        $this->alterColumn('seasons', 'started_at');
+        $this->alterColumn('seasons', 'ended_at');
+
+        // characters_leveling_logs (skip characters_wallet — already timestamptz)
+        $this->alterColumn('characters_leveling_logs', 'created_at');
+        $this->alterColumn('characters_leveling_logs', 'updated_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/identity/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/app-modules/identity/database/migrations/2014_10_12_000000_create_users_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                 $table->string('email')->nullable();
                 $table->string('password')->nullable();
                 $table->boolean('is_donator')->default(false);
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/identity/database/migrations/2014_10_12_100000_create_password_resets_table.php
+++ b/app-modules/identity/database/migrations/2014_10_12_100000_create_password_resets_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             Schema::create('password_resets', function (Blueprint $table): void {
                 $table->string('email')->primary();
                 $table->string('token');
-                $table->timestamp('created_at')->nullable();
+                $table->timestampTz('created_at')->nullable();
             });
         }
     }

--- a/app-modules/identity/database/migrations/2023_01_18_210724_create_providers_table.php
+++ b/app-modules/identity/database/migrations/2023_01_18_210724_create_providers_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
                 $table->string('email')->nullable();
                 $table->string('avatar')->nullable();
                 $table->string('username')->nullable();
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/identity/database/migrations/2023_01_26_155712_create_user_address_table.php
+++ b/app-modules/identity/database/migrations/2023_01_26_155712_create_user_address_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('state', 4)->nullable();
             $table->string('city')->nullable();
             $table->string('zip_code')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/identity/database/migrations/2023_01_26_193201_create_user_information_table.php
+++ b/app-modules/identity/database/migrations/2023_01_26_193201_create_user_information_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->string('github_url')->nullable();
             $table->date('birthdate')->nullable();
             $table->text('about')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/identity/database/migrations/2025_11_02_172528_create_tenants_table.php
+++ b/app-modules/identity/database/migrations/2025_11_02_172528_create_tenants_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
             $table->string('slug');
             $table->foreignUuid('owner_id')->constrained('users');
             $table->boolean('active');
-            $table->timestamps();
-            $table->softDeletes();
+            $table->timestampsTz();
+            $table->softDeletesTz();
         });
     }
 

--- a/app-modules/identity/database/migrations/2025_11_07_162624_create_providers_tokens_table.php
+++ b/app-modules/identity/database/migrations/2025_11_07_162624_create_providers_tokens_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
                 $table->string('access_token');
                 $table->string('refresh_token');
                 $table->integer('expires_in')->nullable();
-                $table->timestamps();
+                $table->timestampsTz();
             });
         }
     }

--- a/app-modules/identity/database/migrations/2025_11_08_161609_create_tenant_users_table.php
+++ b/app-modules/identity/database/migrations/2025_11_08_161609_create_tenant_users_table.php
@@ -16,7 +16,7 @@ return new class extends Migration
         Schema::create('tenant_users', function (Blueprint $table): void {
             $table->foreignUuid('tenant_id')->constrained('tenants')->cascadeOnDelete();
             $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/identity/database/migrations/2026_03_21_000001_migrate_providers_to_external_identities.php
+++ b/app-modules/identity/database/migrations/2026_03_21_000001_migrate_providers_to_external_identities.php
@@ -35,10 +35,10 @@ return new class extends Migration
             $table->string('credentials_type')->default('oauth2')->after('provider');
             $table->text('credentials')->nullable()->after('credentials_type');
             $table->uuid('connected_by')->nullable()->after('provider_id');
-            $table->timestamp('connected_at')->nullable()->after('connected_by');
-            $table->timestamp('disconnected_at')->nullable()->after('connected_at');
+            $table->timestampTz('connected_at')->nullable()->after('connected_by');
+            $table->timestampTz('disconnected_at')->nullable()->after('connected_at');
             $table->json('metadata')->nullable()->after('disconnected_at');
-            $table->softDeletes();
+            $table->softDeletesTz();
         });
 
         // ──────────────────────────────────────────────

--- a/app-modules/identity/database/migrations/2026_05_26_001934_add_first_login_at_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_05_26_001934_add_first_login_at_to_users_table.php
@@ -11,7 +11,7 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('users', function (Blueprint $table): void {
-            $table->timestamp('first_login_at')->nullable()->after('banned_at');
+            $table->timestampTz('first_login_at')->nullable()->after('banned_at');
         });
     }
 };

--- a/app-modules/identity/database/migrations/2026_06_06_190901_alter_identity_timestamps_to_timestamptz.php
+++ b/app-modules/identity/database/migrations/2026_06_06_190901_alter_identity_timestamps_to_timestamptz.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // users
+        $this->alterColumn('users', 'created_at');
+        $this->alterColumn('users', 'updated_at');
+        $this->alterColumn('users', 'first_login_at');
+
+        // password_resets
+        $this->alterColumn('password_resets', 'created_at');
+
+        // user_address
+        $this->alterColumn('user_address', 'created_at');
+        $this->alterColumn('user_address', 'updated_at');
+
+        // user_information
+        $this->alterColumn('user_information', 'created_at');
+        $this->alterColumn('user_information', 'updated_at');
+
+        // tenants
+        $this->alterColumn('tenants', 'created_at');
+        $this->alterColumn('tenants', 'updated_at');
+        $this->alterColumn('tenants', 'deleted_at');
+
+        // tenant_users
+        $this->alterColumn('tenant_users', 'created_at');
+        $this->alterColumn('tenant_users', 'updated_at');
+
+        // external_identities
+        $this->alterColumn('external_identities', 'created_at');
+        $this->alterColumn('external_identities', 'updated_at');
+        $this->alterColumn('external_identities', 'deleted_at');
+        $this->alterColumn('external_identities', 'connected_at');
+        $this->alterColumn('external_identities', 'disconnected_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_155732_create_discord_event_logs_table.php
@@ -20,7 +20,7 @@ return new class extends Migration
             $table->string('user_id')->nullable();
             $table->string('channel_id')->nullable();
             $table->jsonb('payload');
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200000_create_discord_guilds_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200000_create_discord_guilds_table.php
@@ -23,8 +23,8 @@ return new class extends Migration
             $table->integer('member_count')->nullable();
             $table->smallInteger('premium_tier')->default(0);
             $table->jsonb('features')->default('[]');
-            $table->timestamp('synced_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('synced_at')->nullable();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200001_create_discord_channels_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200001_create_discord_channels_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->boolean('nsfw')->default(false);
             $table->integer('bitrate')->nullable();
             $table->integer('user_limit')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('discord_guild_id');
         });

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200002_create_discord_roles_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200002_create_discord_roles_table.php
@@ -25,7 +25,7 @@ return new class extends Migration
             $table->boolean('is_mentionable')->default(false);
             $table->boolean('is_managed')->default(false);
             $table->string('icon')->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('discord_guild_id');
         });

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200003_create_discord_members_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200003_create_discord_members_table.php
@@ -24,11 +24,11 @@ return new class extends Migration
             $table->string('nickname')->nullable();
             $table->boolean('is_bot')->default(false);
             $table->boolean('is_pending')->default(false);
-            $table->timestamp('joined_at')->nullable();
-            $table->timestamp('premium_since')->nullable();
-            $table->timestamp('communication_disabled_until')->nullable();
-            $table->timestamp('left_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('joined_at')->nullable();
+            $table->timestampTz('premium_since')->nullable();
+            $table->timestampTz('communication_disabled_until')->nullable();
+            $table->timestampTz('left_at')->nullable();
+            $table->timestampsTz();
 
             $table->unique(['discord_guild_id', 'discord_user_id']);
             $table->index('discord_user_id');

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200004_create_discord_member_roles_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200004_create_discord_member_roles_table.php
@@ -16,8 +16,8 @@ return new class extends Migration
         Schema::create('discord_member_roles', function (Blueprint $table): void {
             $table->foreignId('discord_member_id')->constrained('discord_members')->cascadeOnDelete();
             $table->foreignId('discord_role_id')->constrained('discord_roles')->cascadeOnDelete();
-            $table->timestamp('assigned_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('assigned_at')->nullable();
+            $table->timestampsTz();
 
             $table->primary(['discord_member_id', 'discord_role_id']);
         });

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
@@ -15,9 +15,9 @@ return new class extends Migration
             $table->foreignId('discord_member_id')->constrained('discord_members')->cascadeOnDelete();
             $table->foreignId('discord_role_id')->constrained('discord_roles')->cascadeOnDelete();
             $table->string('action');
-            $table->timestamp('occurred_at');
+            $table->timestampTz('occurred_at');
             $table->foreignId('source_event_log_id')->nullable()->constrained('discord_event_logs')->nullOnDelete();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('discord_member_id');
             $table->index('discord_role_id');

--- a/app-modules/integration-discord/database/migrations/2026_06_06_190904_alter_discord_timestamps_to_timestamptz.php
+++ b/app-modules/integration-discord/database/migrations/2026_06_06_190904_alter_discord_timestamps_to_timestamptz.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // discord_event_logs
+        $this->alterColumn('discord_event_logs', 'created_at');
+        $this->alterColumn('discord_event_logs', 'updated_at');
+
+        // discord_guilds
+        $this->alterColumn('discord_guilds', 'created_at');
+        $this->alterColumn('discord_guilds', 'updated_at');
+        $this->alterColumn('discord_guilds', 'synced_at');
+
+        // discord_channels
+        $this->alterColumn('discord_channels', 'created_at');
+        $this->alterColumn('discord_channels', 'updated_at');
+
+        // discord_roles
+        $this->alterColumn('discord_roles', 'created_at');
+        $this->alterColumn('discord_roles', 'updated_at');
+
+        // discord_members
+        $this->alterColumn('discord_members', 'created_at');
+        $this->alterColumn('discord_members', 'updated_at');
+        $this->alterColumn('discord_members', 'left_at');
+        // Discord API — always UTC
+        $this->alterColumn('discord_members', 'joined_at', 'UTC');
+        $this->alterColumn('discord_members', 'premium_since', 'UTC');
+        $this->alterColumn('discord_members', 'communication_disabled_until', 'UTC');
+
+        // discord_member_roles
+        $this->alterColumn('discord_member_roles', 'created_at');
+        $this->alterColumn('discord_member_roles', 'updated_at');
+        $this->alterColumn('discord_member_roles', 'assigned_at');
+
+        // discord_member_role_history
+        $this->alterColumn('discord_member_role_history', 'created_at');
+        $this->alterColumn('discord_member_role_history', 'updated_at');
+        $this->alterColumn('discord_member_role_history', 'occurred_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/integration-twitch/database/migrations/2026_05_20_000001_create_twitch_event_logs_table.php
+++ b/app-modules/integration-twitch/database/migrations/2026_05_20_000001_create_twitch_event_logs_table.php
@@ -17,7 +17,7 @@ return new class extends Migration
             $table->string('user_id')->nullable();
             $table->string('twitch_message_id')->unique();
             $table->jsonb('payload');
-            $table->timestamps();
+            $table->timestampsTz();
         });
     }
 

--- a/app-modules/integration-twitch/database/migrations/2026_05_22_000001_create_twitch_subscriptions_table.php
+++ b/app-modules/integration-twitch/database/migrations/2026_05_22_000001_create_twitch_subscriptions_table.php
@@ -22,7 +22,7 @@ return new class extends Migration
             $table->integer('cost')->default(0);
             $table->string('version')->default('1');
             $table->foreignUuid('tenant_id')->constrained()->cascadeOnDelete();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->index('type');
             $table->index('broadcaster_user_id');

--- a/app-modules/integration-twitch/database/migrations/2026_06_06_190905_alter_twitch_timestamps_to_timestamptz.php
+++ b/app-modules/integration-twitch/database/migrations/2026_06_06_190905_alter_twitch_timestamps_to_timestamptz.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // Post-switch tables — data always UTC
+
+        // twitch_event_logs
+        $this->alterColumn('twitch_event_logs', 'created_at', 'UTC');
+        $this->alterColumn('twitch_event_logs', 'updated_at', 'UTC');
+
+        // twitch_subscriptions
+        $this->alterColumn('twitch_subscriptions', 'created_at', 'UTC');
+        $this->alterColumn('twitch_subscriptions', 'updated_at', 'UTC');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app-modules/profile/database/migrations/2026_05_21_000000_create_user_profiles_table.php
+++ b/app-modules/profile/database/migrations/2026_05_21_000000_create_user_profiles_table.php
@@ -24,7 +24,7 @@ return new class extends Migration
             $table->jsonb('social_links')->nullable();
             $table->boolean('available_for_proposals')->default(false);
             $table->string('start_availability', 30)->nullable();
-            $table->timestamps();
+            $table->timestampsTz();
 
             $table->unique(['user_id', 'tenant_id']);
         });

--- a/app-modules/profile/database/migrations/2026_06_06_190908_alter_profile_timestamps_to_timestamptz.php
+++ b/app-modules/profile/database/migrations/2026_06_06_190908_alter_profile_timestamps_to_timestamptz.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // user_profiles — Post-switch table — data always UTC
+        $this->alterColumn('user_profiles', 'created_at', 'UTC');
+        $this->alterColumn('user_profiles', 'updated_at', 'UTC');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/app/Console/Commands/FixPostSwitchTimestampsCommand.php
+++ b/app/Console/Commands/FixPostSwitchTimestampsCommand.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Attributes\Description;
+use Illuminate\Console\Attributes\Signature;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\intro;
+use function Laravel\Prompts\outro;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\task;
+use function Laravel\Prompts\warning;
+
+#[Description('Fix post-switch timestamp data after ALTER migrations (Option D Step 2)')]
+#[Signature('maintenance:fix-post-switch-timestamps
+        {--dry-run : Show what would be done without altering data}
+        {--module= : Process only a specific module}
+        {--table= : Process only a specific table}')]
+final class FixPostSwitchTimestampsCommand extends Command
+{
+    private const string CUTOFF = '2026-05-20 20:04:16+00';
+
+    public function handle(): int
+    {
+        $totalStart = microtime(true);
+
+        intro('Fix post-switch timestamps (Option D — Step 2)');
+
+        if (!$this->validateSchemaReady()) {
+            return self::FAILURE;
+        }
+
+        $this->showConfig();
+
+        if (!$this->option('dry-run') && !confirm('Proceed with data fix?', default: false)) {
+            warning('Aborted.');
+
+            return self::FAILURE;
+        }
+
+        $allStats = [];
+        $modulesToProcess = $this->getModulesToProcess();
+
+        foreach ($modulesToProcess as $name => $tables) {
+            $allStats[$name] = $this->processModule($name, $tables);
+        }
+
+        $this->showSummary($allStats);
+
+        $this->runVerification();
+
+        $total = microtime(true) - $totalStart;
+        outro(sprintf('Done in %.1fs', $total));
+
+        return self::SUCCESS;
+    }
+
+    private function validateSchemaReady(): bool
+    {
+        $remaining = DB::select(
+            "SELECT table_name, column_name
+             FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND data_type = 'timestamp without time zone'
+             ORDER BY table_name, column_name",
+        );
+
+        if ($remaining === []) {
+            return true;
+        }
+
+        warning(sprintf(
+            'Found %d column(s) still using "timestamp without time zone". ALTER migrations must run first.',
+            count($remaining),
+        ));
+
+        table(
+            headers: ['Table', 'Column'],
+            rows: array_map(fn ($row) => [$row->table_name, $row->column_name], $remaining),
+        );
+
+        return false;
+    }
+
+    private function showConfig(): void
+    {
+        $moduleFilter = $this->option('module') ?? 'all';
+        $tableFilter = $this->option('table') ?? 'all';
+
+        table(
+            headers: ['Setting', 'Value'],
+            rows: [
+                ['Cutoff', self::CUTOFF],
+                ['Fix', "SET col = col - interval '3 hours' WHERE col >= CUTOFF"],
+                ['Dry run', $this->option('dry-run') ? 'Yes' : 'No'],
+                ['Database', DB::getDatabaseName()],
+                ['Module filter', $moduleFilter],
+                ['Table filter', $tableFilter],
+            ],
+        );
+    }
+
+    /**
+     * @return array<string, array<string, list<list<string>>>>
+     */
+    private function getModulesToProcess(): array
+    {
+        $modules = $this->modules();
+        $moduleFilter = $this->option('module');
+        $tableFilter = $this->option('table');
+
+        if ($moduleFilter !== null) {
+            $modules = array_filter(
+                $modules,
+                fn (string $key) => $key === $moduleFilter,
+                ARRAY_FILTER_USE_KEY,
+            );
+        }
+
+        if ($tableFilter !== null) {
+            foreach ($modules as $name => $tables) {
+                $modules[$name] = array_filter(
+                    $tables,
+                    fn (string $key) => $key === $tableFilter,
+                    ARRAY_FILTER_USE_KEY,
+                );
+
+                if ($modules[$name] === []) {
+                    unset($modules[$name]);
+                }
+            }
+        }
+
+        return $modules;
+    }
+
+    /**
+     * @param  array<string, list<list<string>>>  $tables
+     * @return array{tables: int, columns: int, rows: int, elapsed: float}
+     */
+    private function processModule(string $name, array $tables): array
+    {
+        $moduleStats = ['tables' => 0, 'columns' => 0, 'rows' => 0, 'elapsed' => 0.0];
+
+        task(
+            label: $name.': processing...',
+            callback: function ($logger) use ($name, $tables, &$moduleStats): void {
+                $moduleStart = microtime(true);
+
+                foreach ($tables as $tableName => $columns) {
+                    $moduleStats['tables']++;
+
+                    foreach ($columns as $colDef) {
+                        $column = $colDef[0];
+                        $fixScope = $colDef[1] ?? 'column';
+                        $moduleStats['columns']++;
+
+                        $result = $this->fixColumn($tableName, $column, $fixScope);
+                        $moduleStats['rows'] += $result['rows'];
+
+                        $action = $this->option('dry-run') ? 'would fix' : 'UPDATE';
+                        $logger->line(sprintf(
+                            '  %s.%-35s %s %s rows  %sms',
+                            $tableName,
+                            $column,
+                            $action,
+                            number_format($result['rows']),
+                            number_format($result['elapsed'], 0),
+                        ));
+                    }
+                }
+
+                $moduleStats['elapsed'] = (microtime(true) - $moduleStart) * 1000;
+                $logger->label(sprintf(
+                    '%s: %d tables, %d cols, %s rows — %.1fs',
+                    $name,
+                    $moduleStats['tables'],
+                    $moduleStats['columns'],
+                    number_format($moduleStats['rows']),
+                    $moduleStats['elapsed'] / 1000,
+                ));
+            },
+        );
+
+        return $moduleStats;
+    }
+
+    /**
+     * @param  'column'|'row'  $fixScope
+     * @return array{rows: int, elapsed: float}
+     */
+    private function fixColumn(string $table, string $column, string $fixScope = 'column'): array
+    {
+        $start = microtime(true);
+        $whereCol = $fixScope === 'row' ? 'created_at' : sprintf('"%s"', $column);
+
+        if ($this->option('dry-run')) {
+            $count = (int) DB::scalar(
+                sprintf('SELECT count(*) FROM %s WHERE %s >= ?', $table, $whereCol),
+                [self::CUTOFF],
+            );
+
+            return ['rows' => $count, 'elapsed' => (microtime(true) - $start) * 1000];
+        }
+
+        $rowsFixed = DB::affectingStatement(
+            sprintf("UPDATE %s SET \"%s\" = \"%s\" - interval '3 hours' WHERE %s >= ?", $table, $column, $column, $whereCol),
+            [self::CUTOFF],
+        );
+
+        return ['rows' => $rowsFixed, 'elapsed' => (microtime(true) - $start) * 1000];
+    }
+
+    /**
+     * @param  array<string, array{tables: int, columns: int, rows: int, elapsed: float}>  $allStats
+     */
+    private function showSummary(array $allStats): void
+    {
+        $rows = [];
+        $totalTables = 0;
+        $totalColumns = 0;
+        $totalRows = 0;
+        $totalElapsed = 0.0;
+
+        foreach ($allStats as $module => $stats) {
+            $rows[] = [
+                $module,
+                (string) $stats['tables'],
+                (string) $stats['columns'],
+                number_format($stats['rows']),
+                sprintf('%.1fs', $stats['elapsed'] / 1000),
+            ];
+            $totalTables += $stats['tables'];
+            $totalColumns += $stats['columns'];
+            $totalRows += $stats['rows'];
+            $totalElapsed += $stats['elapsed'];
+        }
+
+        $rows[] = [
+            'TOTAL',
+            (string) $totalTables,
+            (string) $totalColumns,
+            number_format($totalRows),
+            sprintf('%.1fs', $totalElapsed / 1000),
+        ];
+
+        table(
+            headers: ['Module', 'Tables', 'Columns', 'Rows', 'Time'],
+            rows: $rows,
+        );
+    }
+
+    private function runVerification(): void
+    {
+        $remaining = DB::select(
+            "SELECT table_name, column_name
+             FROM information_schema.columns
+             WHERE table_schema = 'public'
+               AND data_type = 'timestamp without time zone'
+             ORDER BY table_name, column_name",
+        );
+
+        if ($remaining === []) {
+            table(
+                headers: ['Verification'],
+                rows: [['0 columns with "timestamp without time zone" — schema is clean']],
+            );
+
+            return;
+        }
+
+        warning(sprintf('%d column(s) still using "timestamp without time zone":', count($remaining)));
+
+        table(
+            headers: ['Table', 'Column'],
+            rows: array_map(fn ($row) => [$row->table_name, $row->column_name], $remaining),
+        );
+    }
+
+    /**
+     * @return array<string, array<string, list<list<string>>>>
+     */
+    private function modules(): array
+    {
+        return [
+            'identity' => [
+                'users' => [['created_at'], ['updated_at'], ['first_login_at']],
+                'password_resets' => [['created_at']],
+                'user_address' => [['created_at'], ['updated_at']],
+                'user_information' => [['created_at'], ['updated_at']],
+                'tenants' => [['created_at'], ['updated_at'], ['deleted_at']],
+                'tenant_users' => [['created_at'], ['updated_at']],
+                'external_identities' => [['created_at'], ['updated_at'], ['deleted_at'], ['connected_at'], ['disconnected_at']],
+            ],
+            'activity' => [
+                'messages' => [['created_at'], ['updated_at'], ['edited_at']],
+                'voice_messages' => [['created_at'], ['updated_at']],
+                'interactions' => [['created_at'], ['updated_at'], ['occurred_at'], ['reviewed_at']],
+                'moderation_events' => [['created_at'], ['updated_at'], ['occurred_at']],
+                'activity_reactions' => [['created_at'], ['updated_at']],
+                'message_mentions' => [['created_at'], ['updated_at']],
+                'message_threads' => [['created_at'], ['updated_at']],
+                'message_attachments' => [['created_at'], ['updated_at']],
+                'message_embeds' => [['created_at'], ['updated_at']],
+                'membership_events' => [['created_at'], ['updated_at'], ['occurred_at']],
+                'activity_timeline' => [['created_at'], ['updated_at']],
+                'activity_post_entries' => [['created_at'], ['updated_at'], ['deleted_at']],
+            ],
+            'gamification' => [
+                'characters' => [['created_at'], ['updated_at'], ['daily_bonus_claimed_at']],
+                'badges' => [['created_at'], ['updated_at']],
+                'characters_badges' => [['claimed_at']],
+                'seasons_rankings' => [['created_at'], ['updated_at']],
+                'seasons' => [['created_at'], ['updated_at'], ['started_at', 'row'], ['ended_at', 'row']],
+                'characters_leveling_logs' => [['created_at'], ['updated_at']],
+            ],
+            'integration-discord' => [
+                'discord_event_logs' => [['created_at'], ['updated_at']],
+                'discord_guilds' => [['created_at'], ['updated_at'], ['synced_at']],
+                'discord_channels' => [['created_at'], ['updated_at']],
+                'discord_roles' => [['created_at'], ['updated_at']],
+                'discord_members' => [['created_at'], ['updated_at'], ['left_at']],
+                'discord_member_roles' => [['created_at'], ['updated_at'], ['assigned_at']],
+                'discord_member_role_history' => [['created_at'], ['updated_at'], ['occurred_at']],
+            ],
+            'community' => [
+                'meeting_types' => [['created_at'], ['updated_at']],
+                'meetings' => [['created_at'], ['updated_at'], ['starts_at', 'row'], ['ends_at', 'row']],
+                'meeting_participants' => [['created_at'], ['updated_at'], ['attend_at']],
+                'feedbacks' => [['created_at'], ['updated_at']],
+                'feedback_reviews' => [['created_at'], ['updated_at'], ['received_at']],
+            ],
+            'economy' => [
+                'wallets' => [['created_at'], ['updated_at']],
+                'transactions' => [['created_at'], ['updated_at']],
+            ],
+            'main' => [
+                'personal_access_tokens' => [['created_at'], ['updated_at'], ['last_used_at'], ['expires_at', 'row']],
+                'notifications' => [['created_at'], ['updated_at'], ['read_at']],
+                'media' => [['created_at'], ['updated_at']],
+                'failed_jobs' => [['failed_at']],
+                'telescope_entries' => [['created_at']],
+            ],
+        ];
+    }
+}

--- a/app/Console/Commands/FixPostSwitchTimestampsCommand.php
+++ b/app/Console/Commands/FixPostSwitchTimestampsCommand.php
@@ -198,10 +198,11 @@ final class FixPostSwitchTimestampsCommand extends Command
     {
         $start = microtime(true);
         $whereCol = $fixScope === 'row' ? 'created_at' : sprintf('"%s"', $column);
+        $nullGuard = $fixScope === 'row' ? sprintf(' AND "%s" IS NOT NULL', $column) : '';
 
         if ($this->option('dry-run')) {
             $count = (int) DB::scalar(
-                sprintf('SELECT count(*) FROM %s WHERE %s >= ?', $table, $whereCol),
+                sprintf('SELECT count(*) FROM %s WHERE %s >= ?%s', $table, $whereCol, $nullGuard),
                 [self::CUTOFF],
             );
 
@@ -209,7 +210,7 @@ final class FixPostSwitchTimestampsCommand extends Command
         }
 
         $rowsFixed = DB::affectingStatement(
-            sprintf("UPDATE %s SET \"%s\" = \"%s\" - interval '3 hours' WHERE %s >= ?", $table, $column, $column, $whereCol),
+            sprintf("UPDATE %s SET \"%s\" = \"%s\" - interval '3 hours' WHERE %s >= ?%s", $table, $column, $column, $whereCol, $nullGuard),
             [self::CUTOFF],
         );
 

--- a/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
+++ b/database/migrations/2019_08_19_000000_create_failed_jobs_table.php
@@ -21,7 +21,7 @@ return new class extends Migration
                 $table->text('queue');
                 $table->longText('payload');
                 $table->longText('exception');
-                $table->timestamp('failed_at')->useCurrent();
+                $table->timestampTz('failed_at')->useCurrent();
             });
         }
     }

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -20,9 +20,9 @@ return new class extends Migration
                 $table->string('name');
                 $table->string('token', 64)->unique();
                 $table->text('abilities')->nullable();
-                $table->timestamp('last_used_at')->nullable();
-                $table->timestamp('expires_at')->nullable();
-                $table->timestamps();
+                $table->timestampTz('last_used_at')->nullable();
+                $table->timestampTz('expires_at')->nullable();
+                $table->timestampsTz();
             });
         }
     }

--- a/database/migrations/2025_10_30_072218_create_notifications_table.php
+++ b/database/migrations/2025_10_30_072218_create_notifications_table.php
@@ -18,8 +18,8 @@ return new class extends Migration
             $table->string('type');
             $table->morphs('notifiable');
             $table->text('data');
-            $table->timestamp('read_at')->nullable();
-            $table->timestamps();
+            $table->timestampTz('read_at')->nullable();
+            $table->timestampsTz();
         });
     }
 };

--- a/database/migrations/2025_11_05_135059_create_media_table.php
+++ b/database/migrations/2025_11_05_135059_create_media_table.php
@@ -30,7 +30,7 @@ return new class extends Migration
             $table->unsignedInteger('order_column')->nullable()->index();
 
             $table->index(['model_type', 'model_id'], 'media_model_idx');
-            $table->nullableTimestamps();
+            $table->timestampsTz();
         });
     }
 };

--- a/database/migrations/2025_12_17_151114_create_telescope_entries_table.php
+++ b/database/migrations/2025_12_17_151114_create_telescope_entries_table.php
@@ -31,7 +31,7 @@ return new class extends Migration
             $table->boolean('should_display_on_index')->default(true);
             $table->string('type', 20);
             $table->longText('content');
-            $table->dateTime('created_at')->nullable();
+            $table->dateTimeTz('created_at')->nullable();
 
             $table->unique('uuid');
             $table->index('batch_id');

--- a/database/migrations/2026_06_06_190909_alter_main_timestamps_to_timestamptz.php
+++ b/database/migrations/2026_06_06_190909_alter_main_timestamps_to_timestamptz.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // personal_access_tokens
+        $this->alterColumn('personal_access_tokens', 'created_at');
+        $this->alterColumn('personal_access_tokens', 'updated_at');
+        $this->alterColumn('personal_access_tokens', 'last_used_at');
+        $this->alterColumn('personal_access_tokens', 'expires_at');
+
+        // notifications
+        $this->alterColumn('notifications', 'created_at');
+        $this->alterColumn('notifications', 'updated_at');
+        $this->alterColumn('notifications', 'read_at');
+
+        // media
+        $this->alterColumn('media', 'created_at');
+        $this->alterColumn('media', 'updated_at');
+
+        // failed_jobs
+        $this->alterColumn('failed_jobs', 'failed_at');
+
+        // telescope_entries
+        $this->alterColumn('telescope_entries', 'created_at');
+    }
+
+    /**
+     * @param  'America/Sao_Paulo'|'UTC'  $timezone
+     */
+    private function alterColumn(string $table, string $column, string $timezone = 'America/Sao_Paulo'): void
+    {
+        $isTimestamp = DB::scalar(
+            "SELECT data_type = 'timestamp without time zone'
+             FROM information_schema.columns
+             WHERE table_schema = 'public' AND table_name = ? AND column_name = ?",
+            [$table, $column],
+        );
+
+        if (!$isTimestamp) {
+            return;
+        }
+
+        DB::statement(
+            sprintf("ALTER TABLE %s ALTER COLUMN \"%s\" TYPE timestamptz USING \"%s\" AT TIME ZONE '%s'", $table, $column, $column, $timezone)
+        );
+    }
+};

--- a/database/migrations/2026_06_06_191000_drop_orphaned_tmi_cluster_tables.php
+++ b/database/migrations/2026_06_06_191000_drop_orphaned_tmi_cluster_tables.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::dropIfExists('tmi_cluster_channels');
+        Schema::dropIfExists('tmi_cluster_supervisor_processes');
+        Schema::dropIfExists('tmi_cluster_supervisors');
+    }
+};


### PR DESCRIPTION
## Summary

- Convert 77 `timestamp` columns to `timestamptz` across 9 modules using Option D (AT TIME ZONE 'America/Sao_Paulo' + fix post-switch window)
- Add Artisan command `maintenance:fix-post-switch-timestamps` for data correction (~190k rows) with progress display, dry-run, and module/table filters
- Update 49 original migrations to use `timestampsTz()`/`timestampTz()`/`softDeletesTz()`/`dateTimeTz()` for fresh installs

## Context

After the APP_TIMEZONE switch from `America/Sao_Paulo` to `UTC` (2026-05-20, commit c35082ea), the database has mixed-era data: ~3 years stored in SP time and ~2 weeks in UTC. This causes ±3h display bugs.

**Option D** was chosen: interpret all data as SP time during ALTER (fixes 3 years), then UPDATE only the ~2 week post-switch window to subtract 3h.

## What changed

**9 ALTER migrations** (1 per module, idempotent):
- Category A: pre-switch columns → `AT TIME ZONE 'America/Sao_Paulo'`
- Category B: Discord API columns → `AT TIME ZONE 'UTC'` (always were UTC)
- Category C: post-switch tables → `AT TIME ZONE 'UTC'`
- Category D: already timestamptz → skip

**Artisan command** `maintenance:fix-post-switch-timestamps`:
- Corrects post-switch data: `UPDATE col = col - interval '3 hours'`
- Future-dated columns use `WHERE created_at >= CUTOFF` instead of `WHERE col >= CUTOFF`
- Progress display via Laravel Prompts (task/label/line)

**Extras**:
- Drop orphaned `tmi_cluster_*` tables (removed package)
- Fix `Review.received_at` cast from `'timestamp'` (int) to `'datetime'`
- Add `.ai/guidelines/domain/05-timezone-aware-dates.blade.php`

## Production procedure

```
php artisan down
# stop Discord bot
php artisan migrate                                    # ~65s (ALTER)
php artisan maintenance:fix-post-switch-timestamps     # ~3s (UPDATE)
# run verification checklist
php artisan up
# restart Discord bot
```

## Validation (local prod dump)

- 0 `timestamp without time zone` columns remaining
- Pre-switch spot-check: SP times show 14h-16h ✓
- Post-switch spot-check: no +3h shift ✓
- Discord API: joined_at ↔ created_at ±1s ✓
- Idempotent: re-running is no-op ✓
- 620/620 tests passing, pint + phpstan clean

## Report

https://waifuvault.moe/f/f1f61a41-f995-4043-9c8a-8b544106c995/2026-06-06-timestamp-to-timestamptz-report.html

## Test plan

- [x] Run `php artisan migrate` on local prod dump
- [x] Run `php artisan maintenance:fix-post-switch-timestamps --dry-run`
- [x] Run `php artisan maintenance:fix-post-switch-timestamps`
- [x] Verify 0 timestamp columns remaining
- [x] Spot-check pre/post-switch data
- [x] Run `php artisan migrate:fresh` (fresh install creates timestamptz)
- [x] Run full test suite