### PR TITLE
fix(integration-github): store contribution timestamps in utc

### DIFF
--- a/app-modules/integration-github/src/Models/GithubContribution.php
+++ b/app-modules/integration-github/src/Models/GithubContribution.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use He4rt\Identity\Tenant\Models\Tenant;
 use He4rt\IntegrationGithub\Database\Factories\GithubContributionFactory;
 use He4rt\IntegrationGithub\Enums\ContributionType;
+use Illuminate\Database\Eloquent\Attributes\DateFormat;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -28,6 +29,11 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
+// Persist datetimes with their timezone offset (the trailing P) so PostgreSQL
+// stores the absolute instant on `timestamptz` columns regardless of the
+// database server's session timezone. Without the offset, an offset-less
+// literal is interpreted in the session timezone and shifts the stored instant.
+#[DateFormat('Y-m-d H:i:sP')]
 #[Table(name: 'github_contributions')]
 final class GithubContribution extends Model
 {

--- a/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
+++ b/app-modules/integration-github/tests/Feature/BackfillRepositoryTest.php
@@ -83,7 +83,7 @@ it('faz backfill de PRs upsertando contributions com tamanho, autor e tenant', f
         ->and($contribution->actor_login)->toBe('maria')
         ->and($contribution->actor_id)->toBe(42)
         ->and($contribution->repo)->toBe('he4rt/heartdevs.com')
-        ->and($contribution->occurred_at->toIso8601String())->toBe('2026-06-01T12:00:00+00:00')
+        ->and($contribution->occurred_at->utc()->toIso8601String())->toBe('2026-06-01T12:00:00+00:00')
         ->and($contribution->metadata['additions'])->toBe(10)
         ->and($contribution->metadata['deletions'])->toBe(2)
         ->and($contribution->metadata['is_bot'])->toBeFalse();
@@ -244,7 +244,7 @@ it('faz backfill das reviews de um PR com target_ref para o PR', function (): vo
     expect($review->external_ref)->toBe('review:555')
         ->and($review->target_ref)->toBe('pr:1')
         ->and($review->actor_login)->toBe('joao')
-        ->and($review->occurred_at->toIso8601String())->toBe('2026-06-02T09:00:00+00:00');
+        ->and($review->occurred_at->utc()->toIso8601String())->toBe('2026-06-02T09:00:00+00:00');
 });
 
 it('faz backfill de issues ignorando os PRs retornados pelo endpoint de issues', function (): void {
@@ -317,7 +317,7 @@ it('faz backfill de commits dedup por sha, com fallback de autor', function (): 
     expect($linked->type)->toBe(ContributionType::Commit)
         ->and($linked->actor_login)->toBe('maria')
         ->and($linked->actor_id)->toBe(42)
-        ->and($linked->occurred_at->toIso8601String())->toBe('2026-06-04T08:00:00+00:00')
+        ->and($linked->occurred_at->utc()->toIso8601String())->toBe('2026-06-04T08:00:00+00:00')
         ->and($unlinked->actor_login)->toBe('Sem Conta')
         ->and($unlinked->actor_id)->toBeNull();
 });


### PR DESCRIPTION
## O que acontecia

Os horários das contribuições do GitHub (pull requests, reviews, comentários e commits) estavam sendo guardados de forma errada quando o banco de dados rodava em um fuso diferente de UTC — por exemplo, no fuso de Brasília (-03:00), o caso comum nas máquinas da equipe.

Na prática, um horário que deveria representar "12h em UTC" acabava sendo gravado como se fosse "15h em UTC", deslocado em 3 horas. O valor parecia correto à primeira vista (o número do relógio batia), mas o momento real registrado ficava errado.

Além disso, alguns testes que conferiam esses horários quebravam ou passavam dependendo do fuso configurado no banco de quem rodava: na integração contínua (que roda em UTC) eles passavam, mas no computador de quem estivesse com o fuso de Brasília eles falhavam. Ou seja, o resultado mudava conforme o ambiente, em vez de ser sempre o mesmo.

## Por que isso importa

Esses horários alimentam relatórios e a retrospectiva da comunidade. Um deslocamento de 3 horas pode jogar uma contribuição para o "dia seguinte" ou agrupá-la no período errado, distorcendo as estatísticas. E testes que dependem do fuso da máquina minam a confiança da equipe: quando um teste falha, queremos saber que algo realmente quebrou, não que apenas o relógio do ambiente é diferente.

## Como foi resolvido

- O registro das contribuições passou a guardar sempre o momento exato em UTC, de forma independente do fuso configurado no banco de dados. Assim, o horário fica igual em qualquer ambiente — desenvolvimento, testes ou produção.
- Os testes passaram a verificar o momento exato (sempre comparando em UTC), em vez de depender de como o fuso local mostra aquele horário. Agora o resultado é o mesmo para todo mundo, rode onde rodar.

## Verificação

- Os 3 testes que falhavam voltaram a passar.
- Toda a bateria de testes da integração com o GitHub continua verde (39 testes).
