### PR TITLE
fix(identity): add remember_token to users

### DIFF
--- a/app-modules/identity/database/migrations/2026_06_14_155139_add_remember_token_to_users_table.php
+++ b/app-modules/identity/database/migrations/2026_06_14_155139_add_remember_token_to_users_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table): void {
+            $table->rememberToken();
+        });
+    }
+};

--- a/app-modules/identity/src/User/Models/User.php
+++ b/app-modules/identity/src/User/Models/User.php
@@ -14,6 +14,7 @@ use He4rt\Identity\Database\Factories\UserFactory;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
 use He4rt\Identity\Tenant\Concerns\InteractsWithTenants;
 use He4rt\Identity\User\Observers\UserObserver;
+use Illuminate\Database\Eloquent\Attributes\Hidden;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Casts\Attribute;
@@ -36,11 +37,13 @@ use Spatie\MediaLibrary\InteractsWithMedia;
  * @property Carbon|null $suspended_until
  * @property Carbon|null $banned_at
  * @property Carbon|null $first_login_at
+ * @property string|null $remember_token
  * @property Carbon|null $created_at
  * @property Carbon|null $updated_at
  */
 #[ObservedBy(UserObserver::class)]
 #[Table(name: 'users')]
+#[Hidden('password', 'remember_token', 'email_verified_at')]
 final class User extends Authenticatable implements FilamentUser, HasMedia, HasName, HasTenants
 {
     use HasAddress;


### PR DESCRIPTION
## Summary
- Add `remember_token` column to `users` table via migration
- Update User model PHPDoc with `@property string|null $remember_token`
- Add `#[Hidden]` attribute to hide `password`, `remember_token`, and `email_verified_at` from serialization

Fixes login crash (`SQLSTATE[42703]`) caused by `SessionGuard` attempting to store the remember token on a column that didn't exist.