### PR TITLE
feat(events): bot check-in integration

### DIFF
--- a/app-modules/events/lang/en/check_in.php
+++ b/app-modules/events/lang/en/check_in.php
@@ -17,6 +17,6 @@ return [
     'check_in_code_rate_limited' => 'Too many attempts. Try again in :seconds seconds.',
     'bot_user_not_linked' => 'Your account is not linked to this platform.',
     'bot_no_active_enrollment' => 'No active enrollment found for an event happening today.',
-    'bot_multiple_active_events' => 'You have multiple active events today. Specify which event to check in.',
+    'bot_multiple_active_events' => 'More than one event uses this code today. Please check in through the panel.',
     'bot_check_in_success' => 'Check-in confirmed. See you there!',
 ];

--- a/app-modules/events/lang/en/check_in.php
+++ b/app-modules/events/lang/en/check_in.php
@@ -15,4 +15,8 @@ return [
     'check_in_code_exhausted' => 'Code has reached maximum uses.',
     'check_in_code_wrong_date' => 'Code is not valid for today.',
     'check_in_code_rate_limited' => 'Too many attempts. Try again in :seconds seconds.',
+    'bot_user_not_linked' => 'Your account is not linked to this platform.',
+    'bot_no_active_enrollment' => 'No active enrollment found for an event happening today.',
+    'bot_multiple_active_events' => 'You have multiple active events today. Specify which event to check in.',
+    'bot_check_in_success' => 'Check-in confirmed. See you there!',
 ];

--- a/app-modules/events/lang/pt_BR/check_in.php
+++ b/app-modules/events/lang/pt_BR/check_in.php
@@ -15,4 +15,8 @@ return [
     'check_in_code_exhausted' => 'O código atingiu o limite máximo de usos.',
     'check_in_code_wrong_date' => 'O código não é válido para hoje.',
     'check_in_code_rate_limited' => 'Muitas tentativas. Tente novamente em :seconds segundos.',
+    'bot_user_not_linked' => 'Sua conta não está vinculada a esta plataforma.',
+    'bot_no_active_enrollment' => 'Nenhuma inscrição ativa encontrada para um evento de hoje.',
+    'bot_multiple_active_events' => 'Você tem múltiplos eventos ativos hoje. Especifique em qual fazer check-in.',
+    'bot_check_in_success' => 'Check-in confirmado. Até lá!',
 ];

--- a/app-modules/events/lang/pt_BR/check_in.php
+++ b/app-modules/events/lang/pt_BR/check_in.php
@@ -17,6 +17,6 @@ return [
     'check_in_code_rate_limited' => 'Muitas tentativas. Tente novamente em :seconds segundos.',
     'bot_user_not_linked' => 'Sua conta não está vinculada a esta plataforma.',
     'bot_no_active_enrollment' => 'Nenhuma inscrição ativa encontrada para um evento de hoje.',
-    'bot_multiple_active_events' => 'Você tem múltiplos eventos ativos hoje. Especifique em qual fazer check-in.',
+    'bot_multiple_active_events' => 'Mais de um evento usa esse código hoje. Faça o check-in pelo painel.',
     'bot_check_in_success' => 'Check-in confirmado. Até lá!',
 ];

--- a/app-modules/events/src/CheckIn/Enums/BotCheckInStatus.php
+++ b/app-modules/events/src/CheckIn/Enums/BotCheckInStatus.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Enums;
+
+enum BotCheckInStatus: string
+{
+    case Success = 'success';
+    case Error = 'error';
+}

--- a/app-modules/events/src/CheckIn/Events/CheckInProcessed.php
+++ b/app-modules/events/src/CheckIn/Events/CheckInProcessed.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Events;
+
+use He4rt\Events\CheckIn\Enums\BotCheckInStatus;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class CheckInProcessed
+{
+    use Dispatchable;
+
+    /**
+     * @param  array<string, mixed>  $channelContext  Echoed back from the request for reply routing.
+     */
+    public function __construct(
+        public IdentityProvider $provider,
+        public string $externalUserId,
+        public BotCheckInStatus $status,
+        public string $message,
+        public array $channelContext = [],
+        public ?string $enrollmentId = null,
+    ) {}
+}

--- a/app-modules/events/src/CheckIn/Events/CheckInRequested.php
+++ b/app-modules/events/src/CheckIn/Events/CheckInRequested.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Events;
+
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use Illuminate\Foundation\Events\Dispatchable;
+
+final readonly class CheckInRequested
+{
+    use Dispatchable;
+
+    /**
+     * @param  array<string, mixed>  $channelContext  Opaque routing data the bot uses to reply to the member.
+     */
+    public function __construct(
+        public IdentityProvider $provider,
+        public string $externalUserId,
+        public string $code,
+        public string $tenantId,
+        public ?string $eventId = null,
+        public array $channelContext = [],
+    ) {}
+}

--- a/app-modules/events/src/CheckIn/Exceptions/CheckInException.php
+++ b/app-modules/events/src/CheckIn/Exceptions/CheckInException.php
@@ -104,4 +104,20 @@ final class CheckInException extends Exception
             Response::HTTP_TOO_MANY_REQUESTS,
         );
     }
+
+    public static function botNoActiveEnrollment(): self
+    {
+        return new self(
+            __('events::check_in.bot_no_active_enrollment'),
+            Response::HTTP_NOT_FOUND,
+        );
+    }
+
+    public static function botMultipleActiveEvents(): self
+    {
+        return new self(
+            __('events::check_in.bot_multiple_active_events'),
+            Response::HTTP_UNPROCESSABLE_ENTITY,
+        );
+    }
 }

--- a/app-modules/events/src/CheckIn/Listeners/HandleBotCheckIn.php
+++ b/app-modules/events/src/CheckIn/Listeners/HandleBotCheckIn.php
@@ -10,6 +10,7 @@ use He4rt\Events\CheckIn\Enums\BotCheckInStatus;
 use He4rt\Events\CheckIn\Events\CheckInProcessed;
 use He4rt\Events\CheckIn\Events\CheckInRequested;
 use He4rt\Events\CheckIn\Exceptions\CheckInException;
+use He4rt\Events\CheckIn\Models\CheckInCode;
 use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
 use He4rt\Events\Enrollment\Models\Enrollment;
 use He4rt\Events\Event\Enums\EventStatus;
@@ -71,11 +72,25 @@ final readonly class HandleBotCheckIn
             ->get();
 
         $enrollment = $enrollments->first();
-
         throw_unless($enrollment, CheckInException::botNoActiveEnrollment());
-        throw_if($enrollments->count() > 1, CheckInException::botMultipleActiveEvents());
 
-        return $enrollment;
+        if ($enrollments->count() === 1) {
+            return $enrollment;
+        }
+
+        $matchingEventIds = CheckInCode::query()
+            ->whereIn('event_id', $enrollments->pluck('event_id'))
+            ->where('code', $event->code)
+            ->whereDate('event_date', $today)
+            ->pluck('event_id');
+
+        $matching = $enrollments->whereIn('event_id', $matchingEventIds);
+
+        $matched = $matching->first();
+        throw_unless($matched, CheckInException::invalidCheckInCode());
+        throw_if($matching->count() > 1, CheckInException::botMultipleActiveEvents());
+
+        return $matched;
     }
 
     private function dispatchSuccess(CheckInRequested $event, string $enrollmentId): void

--- a/app-modules/events/src/CheckIn/Listeners/HandleBotCheckIn.php
+++ b/app-modules/events/src/CheckIn/Listeners/HandleBotCheckIn.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Events\CheckIn\Listeners;
+
+use He4rt\Events\CheckIn\Actions\NumericCodeCheckInAction;
+use He4rt\Events\CheckIn\DTOs\NumericCodeCheckInDTO;
+use He4rt\Events\CheckIn\Enums\BotCheckInStatus;
+use He4rt\Events\CheckIn\Events\CheckInProcessed;
+use He4rt\Events\CheckIn\Events\CheckInRequested;
+use He4rt\Events\CheckIn\Exceptions\CheckInException;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Identity\ExternalIdentity\Actions\FindExternalIdentity;
+use He4rt\Identity\ExternalIdentity\Exceptions\ExternalIdentityException;
+use Illuminate\Database\Eloquent\Builder;
+
+final readonly class HandleBotCheckIn
+{
+    public function __construct(
+        private FindExternalIdentity $findExternalIdentity,
+        private NumericCodeCheckInAction $numericCodeCheckIn,
+    ) {}
+
+    public function handle(CheckInRequested $event): void
+    {
+        try {
+            $userId = $this->resolveUserId($event);
+            $enrollment = $this->resolveEnrollment($event, $userId);
+
+            $checkIn = $this->numericCodeCheckIn->handle(
+                new NumericCodeCheckInDTO(
+                    enrollment: $enrollment,
+                    code: $event->code,
+                    eventDate: now(),
+                ),
+            );
+
+            $this->dispatchSuccess($event, $checkIn->enrollment_id);
+        } catch (ExternalIdentityException) {
+            $this->dispatchError($event, __('events::check_in.bot_user_not_linked'));
+        } catch (CheckInException $exception) {
+            $this->dispatchError($event, $exception->getMessage());
+        }
+    }
+
+    private function resolveUserId(CheckInRequested $event): string
+    {
+        return $this->findExternalIdentity->handle(
+            provider: $event->provider->value,
+            providerId: $event->externalUserId,
+            tenantId: $event->tenantId,
+        )->model_id;
+    }
+
+    private function resolveEnrollment(CheckInRequested $event, string $userId): Enrollment
+    {
+        $today = now()->toDateString();
+
+        $enrollments = Enrollment::query()
+            ->where('user_id', $userId)
+            ->whereIn('status', [EnrollmentStatus::Confirmed, EnrollmentStatus::CheckedIn])
+            ->whereHas('event', function (Builder $query) use ($event, $today): void {
+                $query->where('tenant_id', $event->tenantId)
+                    ->where('status', EventStatus::Published)
+                    ->whereDate('starts_at', '<=', $today)
+                    ->whereDate('ends_at', '>=', $today);
+            })
+            ->get();
+
+        $enrollment = $enrollments->first();
+
+        throw_unless($enrollment, CheckInException::botNoActiveEnrollment());
+        throw_if($enrollments->count() > 1, CheckInException::botMultipleActiveEvents());
+
+        return $enrollment;
+    }
+
+    private function dispatchSuccess(CheckInRequested $event, string $enrollmentId): void
+    {
+        event(new CheckInProcessed(
+            provider: $event->provider,
+            externalUserId: $event->externalUserId,
+            status: BotCheckInStatus::Success,
+            message: __('events::check_in.bot_check_in_success'),
+            channelContext: $event->channelContext,
+            enrollmentId: $enrollmentId,
+        ));
+    }
+
+    private function dispatchError(CheckInRequested $event, string $message): void
+    {
+        event(new CheckInProcessed(
+            provider: $event->provider,
+            externalUserId: $event->externalUserId,
+            status: BotCheckInStatus::Error,
+            message: $message,
+            channelContext: $event->channelContext,
+        ));
+    }
+}

--- a/app-modules/events/src/EventsServiceProvider.php
+++ b/app-modules/events/src/EventsServiceProvider.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace He4rt\Events;
 
+use He4rt\Events\CheckIn\Events\CheckInRequested;
 use He4rt\Events\CheckIn\Listeners\GenerateQrTokenOnConfirmed;
+use He4rt\Events\CheckIn\Listeners\HandleBotCheckIn;
 use He4rt\Events\Console\Commands\ClosePendingEventsCommand;
 use He4rt\Events\Enrollment\Events\EnrollmentConfirmed;
 use Illuminate\Console\Scheduling\Schedule;
@@ -24,6 +26,7 @@ class EventsServiceProvider extends ServiceProvider
         $this->loadTranslationsFrom(__DIR__.'/../lang', 'events');
 
         Event::listen(EnrollmentConfirmed::class, GenerateQrTokenOnConfirmed::class);
+        Event::listen(CheckInRequested::class, HandleBotCheckIn::class);
 
         if ($this->app->runningInConsole()) {
             $this->app->make(Schedule::class)

--- a/app-modules/events/tests/Feature/HandleBotCheckInTest.php
+++ b/app-modules/events/tests/Feature/HandleBotCheckInTest.php
@@ -186,11 +186,54 @@ test('bot check-in is rejected when the enrollment event is not happening today'
         && $event->message === __('events::check_in.bot_no_active_enrollment'));
 });
 
-test('bot check-in with multiple active events today asks for an explicit event', function (): void {
+test('bot check-in with multiple events today checks into the one matching the typed code', function (): void {
     EventFacade::fake([CheckInProcessed::class]);
     $scenario = createBotCheckInScenario();
-    $startsAt = now()->setTime(9, 0);
 
+    $afternoonStart = now()->setTime(14, 0);
+    $afternoonEvent = Event::factory()
+        ->for($scenario['tenant'])
+        ->create([
+            'starts_at' => $afternoonStart,
+            'ends_at' => $afternoonStart->clone()->setTime(20, 0),
+            'status' => EventStatus::Published,
+        ]);
+
+    $afternoonEnrollment = Enrollment::factory()->create([
+        'event_id' => $afternoonEvent->id,
+        'user_id' => $scenario['participant']->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    CheckInCode::factory()->create([
+        'event_id' => $afternoonEvent->id,
+        'event_date' => now()->toDateString(),
+        'code' => '654321',
+        'starts_at' => now()->subHour(),
+        'expires_at' => now()->addHours(8),
+    ]);
+
+    // User types the MORNING code — only that event owns it.
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::CheckedIn)
+        ->and($afternoonEnrollment->fresh()->status)->toBe(EnrollmentStatus::Confirmed);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Success
+        && $event->enrollmentId === $scenario['enrollment']->id);
+});
+
+test('bot check-in with multiple events today and a non-matching code errors as invalid', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    $startsAt = now()->setTime(9, 0);
     $secondEvent = Event::factory()
         ->for($scenario['tenant'])
         ->create([
@@ -204,6 +247,55 @@ test('bot check-in with multiple active events today asks for an explicit event'
         'user_id' => $scenario['participant']->id,
         'status' => EnrollmentStatus::Confirmed,
         'confirmed_at' => now(),
+    ]);
+
+    CheckInCode::factory()->create([
+        'event_id' => $secondEvent->id,
+        'event_date' => now()->toDateString(),
+        'code' => '654321',
+        'starts_at' => now()->subHour(),
+        'expires_at' => now()->addHours(2),
+    ]);
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '999999',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::Confirmed);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.invalid_check_in_code'));
+});
+
+test('bot check-in errors when the same code exists on multiple events today', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    $startsAt = now()->setTime(9, 0);
+    $secondEvent = Event::factory()
+        ->for($scenario['tenant'])
+        ->create([
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->setTime(18, 0),
+            'status' => EventStatus::Published,
+        ]);
+
+    Enrollment::factory()->create([
+        'event_id' => $secondEvent->id,
+        'user_id' => $scenario['participant']->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    CheckInCode::factory()->create([
+        'event_id' => $secondEvent->id,
+        'event_date' => now()->toDateString(),
+        'code' => '123456',
+        'starts_at' => now()->subHour(),
+        'expires_at' => now()->addHours(2),
     ]);
 
     resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(

--- a/app-modules/events/tests/Feature/HandleBotCheckInTest.php
+++ b/app-modules/events/tests/Feature/HandleBotCheckInTest.php
@@ -1,0 +1,279 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Events\CheckIn\Enums\BotCheckInStatus;
+use He4rt\Events\CheckIn\Enums\CheckInMethod;
+use He4rt\Events\CheckIn\Events\CheckInProcessed;
+use He4rt\Events\CheckIn\Events\CheckInRequested;
+use He4rt\Events\CheckIn\Listeners\HandleBotCheckIn;
+use He4rt\Events\CheckIn\Models\CheckInCode;
+use He4rt\Events\Enrollment\Enums\EnrollmentStatus;
+use He4rt\Events\Enrollment\Models\Enrollment;
+use He4rt\Events\Event\Enums\EventStatus;
+use He4rt\Events\Event\Models\Event;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\Event as EventFacade;
+
+beforeEach(function (): void {
+    Date::setTestNow(now()->setTime(12, 0));
+});
+
+afterEach(function (): void {
+    Date::setTestNow();
+});
+
+function createBotCheckInScenario(array $codeOverrides = []): array
+{
+    $tenant = Tenant::factory()->create();
+    $participant = User::factory()->create();
+    $externalId = '900900900';
+    $startsAt = now()->setTime(9, 0);
+
+    $event = Event::factory()
+        ->for($tenant)
+        ->create([
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->setTime(18, 0),
+            'status' => EventStatus::Published,
+        ]);
+
+    $enrollment = Enrollment::factory()->create([
+        'event_id' => $event->id,
+        'user_id' => $participant->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    ExternalIdentity::factory()->create([
+        'tenant_id' => $tenant->id,
+        'provider' => IdentityProvider::Discord,
+        'external_account_id' => $externalId,
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $participant->id,
+    ]);
+
+    $code = CheckInCode::factory()->create(array_merge([
+        'event_id' => $event->id,
+        'event_date' => now()->toDateString(),
+        'code' => '123456',
+        'starts_at' => now()->subHour(),
+        'expires_at' => now()->addHours(2),
+        'max_uses' => null,
+        'uses_count' => 0,
+    ], $codeOverrides));
+
+    return ['tenant' => $tenant, 'participant' => $participant, 'externalId' => $externalId, 'event' => $event, 'enrollment' => $enrollment, 'code' => $code];
+}
+
+test('dispatching CheckInRequested is handled by the registered listener', function (): void {
+    $scenario = createBotCheckInScenario();
+
+    event(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::CheckedIn);
+    $this->assertDatabaseHas('events_check_ins', [
+        'enrollment_id' => $scenario['enrollment']->id,
+        'method' => CheckInMethod::NumericCode->value,
+    ]);
+});
+
+test('successful bot check-in records the check-in and dispatches a success response', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+        channelContext: ['channel_id' => 'C1'],
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::CheckedIn)
+        ->and($scenario['code']->fresh()->uses_count)->toBe(1);
+
+    $this->assertDatabaseHas('events_check_ins', [
+        'enrollment_id' => $scenario['enrollment']->id,
+        'method' => CheckInMethod::NumericCode->value,
+    ]);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Success
+        && $event->enrollmentId === $scenario['enrollment']->id
+        && $event->externalUserId === $scenario['externalId']
+        && $event->channelContext === ['channel_id' => 'C1']
+        && $event->message === __('events::check_in.bot_check_in_success'));
+});
+
+test('bot check-in for an unlinked external user dispatches an error and records nothing', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: 'unlinked-user',
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::Confirmed);
+    $this->assertDatabaseCount('events_check_ins', 0);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->enrollmentId === null
+        && $event->message === __('events::check_in.bot_user_not_linked'));
+});
+
+test('bot check-in with an invalid code dispatches an error', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '000000',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::Confirmed);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.invalid_check_in_code'));
+});
+
+test('bot check-in for a user with no enrollment dispatches no active enrollment error', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+    $scenario['enrollment']->delete();
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.bot_no_active_enrollment'));
+});
+
+test('bot check-in is rejected when the enrollment event is not happening today', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+    $futureStart = now()->addDays(5)->setTime(9, 0);
+    $scenario['event']->update([
+        'starts_at' => $futureStart,
+        'ends_at' => $futureStart->clone()->setTime(18, 0),
+    ]);
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.bot_no_active_enrollment'));
+});
+
+test('bot check-in with multiple active events today asks for an explicit event', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+    $startsAt = now()->setTime(9, 0);
+
+    $secondEvent = Event::factory()
+        ->for($scenario['tenant'])
+        ->create([
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->setTime(18, 0),
+            'status' => EventStatus::Published,
+        ]);
+
+    Enrollment::factory()->create([
+        'event_id' => $secondEvent->id,
+        'user_id' => $scenario['participant']->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.bot_multiple_active_events'));
+});
+
+test('bot check-in when already checked in today dispatches an error', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+
+    $request = new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    );
+
+    resolve(HandleBotCheckIn::class)->handle($request);
+    resolve(HandleBotCheckIn::class)->handle($request);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Error
+        && $event->message === __('events::check_in.already_checked_in_for_date'));
+});
+
+test('bot check-in ignores a waitlisted enrollment and checks in the confirmed one', function (): void {
+    EventFacade::fake([CheckInProcessed::class]);
+    $scenario = createBotCheckInScenario();
+    $scenario['enrollment']->update(['status' => EnrollmentStatus::Waitlisted]);
+
+    $startsAt = now()->setTime(9, 0);
+    $confirmedEvent = Event::factory()
+        ->for($scenario['tenant'])
+        ->create([
+            'starts_at' => $startsAt,
+            'ends_at' => $startsAt->clone()->setTime(18, 0),
+            'status' => EventStatus::Published,
+        ]);
+
+    $confirmedEnrollment = Enrollment::factory()->create([
+        'event_id' => $confirmedEvent->id,
+        'user_id' => $scenario['participant']->id,
+        'status' => EnrollmentStatus::Confirmed,
+        'confirmed_at' => now(),
+    ]);
+
+    CheckInCode::factory()->create([
+        'event_id' => $confirmedEvent->id,
+        'event_date' => now()->toDateString(),
+        'code' => '123456',
+        'starts_at' => now()->subHour(),
+        'expires_at' => now()->addHours(2),
+    ]);
+
+    resolve(HandleBotCheckIn::class)->handle(new CheckInRequested(
+        provider: IdentityProvider::Discord,
+        externalUserId: $scenario['externalId'],
+        code: '123456',
+        tenantId: $scenario['tenant']->id,
+    ));
+
+    expect($confirmedEnrollment->fresh()->status)->toBe(EnrollmentStatus::CheckedIn)
+        ->and($scenario['enrollment']->fresh()->status)->toBe(EnrollmentStatus::Waitlisted);
+
+    EventFacade::assertDispatched(fn (CheckInProcessed $event): bool => $event->status === BotCheckInStatus::Success
+        && $event->enrollmentId === $confirmedEnrollment->id);
+});


### PR DESCRIPTION
  ## Summary

  Implements the **Events-module side** of bot-triggered check-in (Discord/Twitch). The bot dispatches a `CheckInRequested` domain event; Events listens (`HandleBotCheckIn`), resolves the user and enrollment, processes the check-in by reusing the numeric-code validation, and dispatches a `CheckInProcessed` response so the bot can reply to the member in chat. The bot is pure transport; Events owns the rules (ADR-0005).

  **Flow:** `CheckInRequested` → `HandleBotCheckIn` → `NumericCodeCheckInAction` → `CheckInProcessed`

  Closes #248

  ---
  
  ## What changed — `app-modules/events`

  | File | Role |
  |---|---|
  | `src/CheckIn/Events/CheckInRequested.php` | Inbound domain event dispatched by the bot. Payload: `provider`, `externalUserId`, `code`, `tenantId`, `eventId?` (reserved, see below), `channelContext`. |
  | `src/CheckIn/Events/CheckInProcessed.php` | Outbound response event for the bot to reply in chat. Payload: `provider`, `externalUserId`, `status`, `message`, `channelContext`, `enrollmentId?`. |
  | `src/CheckIn/Enums/BotCheckInStatus.php` | `Success` / `Error` status for the response event. |
  | `src/CheckIn/Listeners/HandleBotCheckIn.php` | Resolves the user via Identity (`FindExternalIdentity`), resolves the enrollment, delegates to `NumericCodeCheckInAction`, dispatches `CheckInProcessed`. Catches `ExternalIdentityException` / `CheckInException` → error response. |
  | `src/CheckIn/Exceptions/CheckInException.php` | Adds `botNoActiveEnrollment()` and `botMultipleActiveEvents()` factories. |
  | `lang/en/check_in.php`, `lang/pt_BR/check_in.php` | Bot-facing messages (user not linked, no active enrollment, success) + reworded multiple-events message. |
  | `src/EventsServiceProvider.php` | Registers `CheckInRequested → HandleBotCheckIn`. |

  ### Event resolution (the important bit)

  The listener finds the user's check-in-able enrollments (`confirmed`/`checked_in`) for a published event happening today, scoped to the tenant. When the user has **more than one** active event the same day (e.g. a morning and an evening online event), the **typed code identifies which event** — each `CheckInCode` belongs to a single event.

  This replaces an earlier **date-only** resolution that errored on *any* 2-same-day case, which would have wrongly blocked the legitimate morning+evening scenario. The single-event flow is unchanged; only a genuine collision (same code value on two same-day events the user is enrolled in) returns an ambiguity error pointing to the panel.

  ---

  ## Acceptance criteria

  - [x] `CheckInRequested` defined with proper payload
  - [x] Events listener resolves the user and processes the check-in
  - [x] `CheckInProcessed` response dispatched with success/error status
  - [x] Numeric code validation applies the same rules as the web flow (delegates to `NumericCodeCheckInAction`)
  - [x] Error cases handled: user not linked, not enrolled, invalid code, already checked in, ambiguous code
  - [x] Listener registered via `EventsServiceProvider` — **manual registration** (Laravel event auto-discovery is disabled app-wide; matches the existing `GenerateQrTokenOnConfirmed` pattern)
  - [x] Feature tests (see Test plan)
  - [x] Pint passes

  ---

  ## Test plan

  ```bash
  # Bot check-in tests
  vendor/bin/pest app-modules/events/tests/Feature/HandleBotCheckInTest.php

  # Full events module (must stay green)
  vendor/bin/pest app-modules/events/tests
  
  # Style + static analysis
  make pint && make phpstan
  ```

  Results:
  - `HandleBotCheckInTest`: **11/11**
  - Events module: **133/133** (0 regressions)
  - Pint: clean · PHPStan: **0 errors** · Rector (dry-run): clean

  Scenarios covered: success + success response · unlinked user · invalid code · no active enrollment · event not today · multiple events → typed code selects the right one · multiple events + non-matching code → invalid · same code on two events → ambiguity error · already checked in today · waitlisted enrollment ignored.

  ---

  ## Out of scope (separate issues)

  - The **bot-side command** that dispatches `CheckInRequested` (`app-modules/bot-discord/`) — separate concern, per the issue.
  - **Rate limiting** on the bot path — deferred to the bot command (the web flow already throttles 5/60s).
  - **Explicit event selection** (`eventId` / "path A") — the field stays reserved in the payload but is not honored; the typed code already resolves the event.
