### PR TITLE
feat(infra): bump phpstan to level 7

### DIFF
--- a/.ai/guidelines/tooling/01-phpstan.blade.php
+++ b/.ai/guidelines/tooling/01-phpstan.blade.php
@@ -34,6 +34,25 @@ parameters:
     - The error comes from a third-party or generated code.
     - The false positive is a known PHPStan/Larastan limitation (e.g. Livewire `$form`).
 
+## Third-party stubs
+
+Some vendor libraries ship imprecise stubs that report types wider than the
+runtime guarantees. The canonical example is the Discord library
+(`team-reflex/discord-php`), which types repository collections as
+`array<T>|(Discord\Helpers\ExCollectionInterface&iterable<T>)` even though the
+runtime value is always the collection. Calling `->find()` / `->get()` on it is
+valid at runtime but PHPStan flags `method.nonObject` because the `array<T>`
+branch has no such method.
+
+Policy for these:
+
+- Do **not** rewrite working runtime code to satisfy a wrong stub.
+- Suppress the error in the **module-scoped** `phpstan.ignore.neon`
+  (e.g. `app-modules/bot-discord/phpstan.ignore.neon`), never in the root config,
+  so the suppression stays close to the affected module.
+- Use the indented block style, scope to the `path`, pin the `count`, and include
+  the `identifier` — exactly as for any other entry above.
+
 ## Baseline
 
 Prefer running `{{ $assist->binCommand('phpstan analyse --generate-baseline') }}` for bulk

--- a/app-modules/bot-discord/phpstan.ignore.neon
+++ b/app-modules/bot-discord/phpstan.ignore.neon
@@ -75,3 +75,23 @@ parameters:
             identifier: nullsafe.neverNull
             count: 1
             path: src/Tasks/VoiceExperienceTask.php
+        -
+            message: '#^Cannot call method find\(\) on array<Discord\\Parts\\Guild\\Role>\|\(Discord\\Helpers\\ExCollectionInterface&iterable<Discord\\Parts\\Guild\\Role>\)\.$#'
+            identifier: method.nonObject
+            count: 3
+            path: src/SlashCommands/CargoDelasCommand.php
+        -
+            message: '#^Cannot call method find\(\) on array<Discord\\Parts\\Guild\\Role>\|\(Discord\\Helpers\\ExCollectionInterface&iterable<Discord\\Parts\\Guild\\Role>\)\.$#'
+            identifier: method.nonObject
+            count: 1
+            path: src/SlashCommands/IntroductionCommand.php
+        -
+            message: '#^Cannot call method get\(\) on array<Discord\\Parts\\User\\User>\|\(Discord\\Helpers\\ExCollectionInterface&iterable<Discord\\Parts\\User\\User>\)\.$#'
+            identifier: method.nonObject
+            count: 1
+            path: src/SlashCommands/DontAskCommand.php
+        -
+            message: '#^Cannot call method get\(\) on array<Discord\\Parts\\User\\User>\|\(Discord\\Helpers\\ExCollectionInterface&iterable<Discord\\Parts\\User\\User>\)\.$#'
+            identifier: method.nonObject
+            count: 1
+            path: src/SlashCommands/ProfileCommand.php

--- a/app-modules/bot-discord/src/Actions/VoiceChannel/HandleStateChannelAction.php
+++ b/app-modules/bot-discord/src/Actions/VoiceChannel/HandleStateChannelAction.php
@@ -8,6 +8,7 @@ final class HandleStateChannelAction
 {
     public function execute(int|string $userId, ?string $channelId): void
     {
+        $userId = (string) $userId;
         $activeChannels = cache()->tags(['voice_channels'])->get('active_voice_channels_keys', []);
         $oldChannelId = $this->getUserLastChannel($userId);
 

--- a/app-modules/bot-discord/src/Events/RawGatewayEvent.php
+++ b/app-modules/bot-discord/src/Events/RawGatewayEvent.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\BotDiscord\Events;
 
 use He4rt\IntegrationDiscord\Models\DiscordEventLog;
+use RuntimeException;
 
 final class RawGatewayEvent
 {
@@ -14,12 +15,16 @@ final class RawGatewayEvent
             return;
         }
 
+        $encodedPayload = json_encode($payload->d);
+
+        throw_if($encodedPayload === false, RuntimeException::class, 'Failed to encode Discord gateway payload to JSON.');
+
         DiscordEventLog::query()->create([
             'event_type' => $payload->t,
             'guild_id' => $payload->d->guild_id ?? null,
             'user_id' => $payload->d->user_id ?? $payload->d->author->id ?? null,
             'channel_id' => $payload->d->channel_id ?? null,
-            'payload' => json_decode(json_encode($payload->d), true),
+            'payload' => json_decode($encodedPayload, true),
         ]);
     }
 }

--- a/app-modules/docs/src/Discovery/Strategies/AdrStrategy.php
+++ b/app-modules/docs/src/Discovery/Strategies/AdrStrategy.php
@@ -69,9 +69,12 @@ final readonly class AdrStrategy extends AbstractDocumentStrategy
             $inline = $this->inline($content, 'Deciders');
 
             if ($inline !== null) {
+                $segments = preg_split('/[,;]/', $inline);
+                $segments = is_array($segments) ? $segments : [];
+
                 $deciders = array_values(array_filter(array_map(
                     mb_trim(...),
-                    (array) preg_split('/[,;]/', $inline),
+                    $segments,
                 ), static fn (string $name): bool => $name !== ''));
             }
         }

--- a/app-modules/docs/src/Documentation.php
+++ b/app-modules/docs/src/Documentation.php
@@ -117,7 +117,7 @@ class Documentation
 
                         return [
                             (string) Str::of($path)->afterLast('/')->before('.md') => [
-                                'title' => $page['title'],
+                                'title' => $page['title'] ?? '',
                                 'sections' => collect($section['fragments'])
                                     ->combine($section['titles'])
                                     ->map(fn ($title) => ['title' => $title]),

--- a/app-modules/gamification/src/Character/Models/Character.php
+++ b/app-modules/gamification/src/Character/Models/Character.php
@@ -111,12 +111,14 @@ final class Character extends Model
 
     protected function getRankingAttribute(): int
     {
-        return $this->newQuery()
+        $position = $this->newQuery()
             ->orderByDesc('experience')
             ->pluck('id')
             ->filter(fn ($id) => $id === $this->getKey())
             ->keys()
-            ->first() + 1;
+            ->first();
+
+        return (int) $position + 1;
     }
 
     /**

--- a/app-modules/identity/src/Auth/DTOs/OAuthStateDTO.php
+++ b/app-modules/identity/src/Auth/DTOs/OAuthStateDTO.php
@@ -22,7 +22,7 @@ final readonly class OAuthStateDTO implements JsonSerializable, Stringable
 
     public function __toString(): string
     {
-        return Crypt::encryptString(json_encode($this));
+        return Crypt::encryptString(json_encode($this, JSON_THROW_ON_ERROR));
     }
 
     public static function fromEncryptedString(string $state): self

--- a/app-modules/identity/src/ExternalIdentity/Casts/AsCredentials.php
+++ b/app-modules/identity/src/ExternalIdentity/Casts/AsCredentials.php
@@ -31,6 +31,6 @@ class AsCredentials implements CastsAttributes
             'username' => $value->username,
             'password' => $value->password,
             'api_key' => $value->apiKey,
-        ]);
+        ], JSON_THROW_ON_ERROR);
     }
 }

--- a/app-modules/identity/src/ExternalIdentity/Data/ClientAccessManager.php
+++ b/app-modules/identity/src/ExternalIdentity/Data/ClientAccessManager.php
@@ -82,7 +82,7 @@ final class ClientAccessManager implements Wireable
 
     public function getExpiresIn(): ?int
     {
-        return $this->expiresIn !== null ? (int) Crypt::decrypt($this->expiresIn) : null;
+        return $this->expiresIn !== null ? (int) Crypt::decrypt((string) $this->expiresIn) : null;
     }
 
     public function getClientSecret(): ?string

--- a/app-modules/integration-discord/src/ETL/Console/ImportDiscordMessagesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/ImportDiscordMessagesCommand.php
@@ -21,6 +21,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use RuntimeException;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Terminal;
@@ -123,7 +124,7 @@ class ImportDiscordMessagesCommand extends Command
             }
 
             $channelName = basename($channelDir);
-            $chunks = glob($channelDir.'/chunk_*.json');
+            $chunks = glob($channelDir.'/chunk_*.json') ?: [];
             sort($chunks);
 
             if ($chunksPerChannel !== null) {
@@ -147,7 +148,10 @@ class ImportDiscordMessagesCommand extends Command
                     break;
                 }
 
-                $allMessages = json_decode(file_get_contents($chunkFile), true);
+                $chunkContents = file_get_contents($chunkFile);
+                throw_if($chunkContents === false, RuntimeException::class, 'Falha ao ler chunk: '.$chunkFile);
+
+                $allMessages = json_decode($chunkContents, true);
                 if (!is_array($allMessages)) {
                     $chunkCurrent++;
                     $this->renderBox($chunkSection, $chunkTitle, $chunkCurrent, $totalChunks);
@@ -155,7 +159,9 @@ class ImportDiscordMessagesCommand extends Command
                     continue;
                 }
 
-                $messages = $this->filterNewMessages($allMessages, $tenantId);
+                /** @var list<array<string, mixed>> $rawMessages */
+                $rawMessages = array_values(array_filter($allMessages, is_array(...)));
+                $messages = $this->filterNewMessages($rawMessages, $tenantId);
                 $stats['skipped'] += count($allMessages) - count($messages);
 
                 if ($messages !== []) {
@@ -413,7 +419,10 @@ class ImportDiscordMessagesCommand extends Command
             return [];
         }
 
-        $payload = json_decode(file_get_contents($channelsFile), true);
+        $channelsContents = file_get_contents($channelsFile);
+        throw_if($channelsContents === false, RuntimeException::class, 'Falha ao ler channels.json: '.$channelsFile);
+
+        $payload = json_decode($channelsContents, true);
         $channels = is_array($payload) ? ($payload['channels'] ?? $payload) : [];
         $map = [];
 

--- a/app-modules/integration-discord/src/ETL/Console/ImportDiscordProfilesCommand.php
+++ b/app-modules/integration-discord/src/ETL/Console/ImportDiscordProfilesCommand.php
@@ -13,6 +13,7 @@ use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
+use RuntimeException;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
 use Symfony\Component\Console\Output\ConsoleSectionOutput;
 use Symfony\Component\Console\Terminal;
@@ -98,7 +99,10 @@ class ImportDiscordProfilesCommand extends Command
 
         foreach ($chunks as $chunkFile) {
             $chunkName = basename($chunkFile);
-            $profiles = json_decode(file_get_contents($chunkFile), true);
+            $chunkContents = file_get_contents($chunkFile);
+            throw_if($chunkContents === false, RuntimeException::class, 'Falha ao ler chunk: '.$chunkFile);
+
+            $profiles = json_decode($chunkContents, true);
 
             if (!is_array($profiles) || $profiles === []) {
                 $chunkCurrent++;

--- a/app-modules/integration-github/src/Console/BackfillGithubCommand.php
+++ b/app-modules/integration-github/src/Console/BackfillGithubCommand.php
@@ -12,8 +12,10 @@ use He4rt\IntegrationGithub\Models\GithubRepository;
 use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Str;
+use RuntimeException;
 use Saloon\Exceptions\Request\RequestException;
 use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Output\ConsoleOutputInterface;
@@ -231,6 +233,9 @@ final class BackfillGithubCommand extends Command
             return 'data desconhecida';
         }
 
-        return Date::parse($iso)->locale('pt_BR')->diffForHumans();
+        $localized = Date::parse($iso)->locale('pt_BR');
+        throw_unless($localized instanceof Carbon, RuntimeException::class, 'Falha ao localizar data ISO: '.$iso);
+
+        return $localized->diffForHumans();
     }
 }

--- a/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
+++ b/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
@@ -53,11 +53,12 @@ final readonly class ProjectGithubEvent
      */
     private function tenantsTracking(string $repo): array
     {
-        return GithubRepository::query()
+        return array_values(GithubRepository::query()
             ->enabled()
             ->where('full_name', $repo)
             ->pluck('tenant_id')
-            ->all();
+            ->map(static fn (mixed $tenantId): string => (string) $tenantId)
+            ->all());
     }
 
     /**

--- a/app-modules/moderation/src/Classification/Actions/RouteCaseAction.php
+++ b/app-modules/moderation/src/Classification/Actions/RouteCaseAction.php
@@ -25,7 +25,7 @@ final readonly class RouteCaseAction
     public function execute(ModerationCase $case): void
     {
         $scores = $case->ai_scores ?? [];
-        $maxScore = blank($scores) ? 0 : max($scores);
+        $maxScore = $scores === [] ? 0 : max($scores);
 
         $highPriorityThreshold = config('moderation.thresholds.high_priority', 0.9);
 

--- a/app-modules/moderation/src/Classification/Jobs/RouteDecision.php
+++ b/app-modules/moderation/src/Classification/Jobs/RouteDecision.php
@@ -22,7 +22,7 @@ final class RouteDecision implements ShouldQueue
     public function handle(): void
     {
         $scores = $this->case->ai_scores ?? [];
-        $maxScore = blank($scores) ? 0 : max($scores);
+        $maxScore = $scores === [] ? 0 : max($scores);
 
         $flagThreshold = config('moderation.thresholds.flag', 0.7);
         $highPriorityThreshold = config('moderation.thresholds.high_priority', 0.9);

--- a/app-modules/moderation/src/Classification/Jobs/ScreenContent.php
+++ b/app-modules/moderation/src/Classification/Jobs/ScreenContent.php
@@ -55,7 +55,7 @@ final class ScreenContent implements ShouldQueue
             ->addClassifier(OpenAiClassifier::make())
             ->classify($this->content);
 
-        $maxScore = blank($result->scores) ? 0 : max($result->scores);
+        $maxScore = $result->scores === [] ? 0 : max($result->scores);
         $flagThreshold = config('moderation.thresholds.flag', 0.7);
 
         // Below threshold = content is safe. No case created, no DB noise.

--- a/app-modules/moderation/src/Platform/PlatformRegistry.php
+++ b/app-modules/moderation/src/Platform/PlatformRegistry.php
@@ -20,6 +20,9 @@ final class PlatformRegistry
     /** @var array<string, class-string<ModerationPlatformContract>> */
     private array $adapters = [];
 
+    /**
+     * @param  class-string<ModerationPlatformContract>  $adapterClass
+     */
     public function register(Platform $platform, string $adapterClass): void
     {
         $this->adapters[$platform->value] = $adapterClass;

--- a/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/PeriodStats.php
+++ b/app-modules/panel-admin/src/Marketing/Pages/Discord/Dashboard/Queries/PeriodStats.php
@@ -89,91 +89,101 @@ final readonly class PeriodStats
     }
 
     /**
-     * Fetches message counts and unique users for all subdivisions in a single query
-     * using conditional aggregates (CASE WHEN) instead of N separate queries.
+     * Fetches message counts and unique users for all subdivisions in a single
+     * query. The subdivision windows are expanded into a derived table via
+     * PostgreSQL `unnest(...) WITH ORDINALITY`, keeping the SQL a static literal
+     * while the boundaries travel as array bindings.
      *
      * @param  array<int, array{start: Carbon, end: Carbon, label: string}>  $subdivisions
      * @return array<int, array{msgs: int, users: int}>
      */
     private function queryMessageStats(array $subdivisions): array
     {
-        $query = DB::table('messages')->whereNotNull('sent_at');
+        [$startsLiteral, $endsLiteral] = $this->boundaryArrayLiterals($subdivisions);
 
-        $selects = [];
-        $bindings = [];
+        $rows = DB::select(<<<'SQL'
+            SELECT p.idx,
+                   COUNT(m.sent_at) AS msgs,
+                   COUNT(DISTINCT m.external_identity_id) AS users
+            FROM unnest(?::timestamptz[], ?::timestamptz[]) WITH ORDINALITY AS p(start_at, end_at, idx)
+            LEFT JOIN messages m
+                ON m.sent_at >= p.start_at
+               AND m.sent_at < p.end_at
+            GROUP BY p.idx
+            ORDER BY p.idx
+            SQL, [$startsLiteral, $endsLiteral]);
 
-        foreach ($subdivisions as $i => $sub) {
-            $startUtc = $sub['start']->copy()->utc();
-            $endUtc = $sub['end']->copy()->utc();
-
-            $selects[] = 'COUNT(CASE WHEN sent_at >= ? AND sent_at < ? THEN 1 END) AS msgs_'.$i;
-            $selects[] = 'COUNT(DISTINCT CASE WHEN sent_at >= ? AND sent_at < ? THEN external_identity_id END) AS users_'.$i;
-
-            $bindings[] = $startUtc;
-            $bindings[] = $endUtc;
-            $bindings[] = $startUtc;
-            $bindings[] = $endUtc;
+        $byOrdinal = [];
+        foreach ($rows as $row) {
+            $byOrdinal[(int) $row->idx] = [
+                'msgs' => (int) $row->msgs,
+                'users' => (int) $row->users,
+            ];
         }
-
-        $firstStart = $subdivisions[0]['start']->copy()->utc();
-        $lastEnd = end($subdivisions)['end']->copy()->utc();
-
-        $row = $query
-            ->where('sent_at', '>=', $firstStart)
-            ->where('sent_at', '<', $lastEnd)
-            ->selectRaw(implode(', ', $selects), $bindings)
-            ->first();
 
         $result = [];
         foreach (array_keys($subdivisions) as $i) {
-            $result[$i] = [
-                'msgs' => (int) ($row->{'msgs_'.$i} ?? 0),
-                'users' => (int) ($row->{'users_'.$i} ?? 0),
-            ];
+            // `WITH ORDINALITY` is 1-based; subdivision keys are 0-based.
+            $result[$i] = $byOrdinal[$i + 1] ?? ['msgs' => 0, 'users' => 0];
         }
 
         return $result;
     }
 
     /**
-     * Fetches voice join counts for all subdivisions in a single query.
+     * Fetches voice join counts for all subdivisions in a single query, using the
+     * same `unnest(...) WITH ORDINALITY` window expansion as message stats.
      *
      * @param  array<int, array{start: Carbon, end: Carbon, label: string}>  $subdivisions
      * @return array<int, int>
      */
     private function queryVoiceStats(array $subdivisions): array
     {
-        $query = DB::table('voice_messages')
-            ->whereNotNull('occurred_at')
-            ->where('state', 'joined');
+        [$startsLiteral, $endsLiteral] = $this->boundaryArrayLiterals($subdivisions);
 
-        $selects = [];
-        $bindings = [];
+        $rows = DB::select(<<<'SQL'
+            SELECT p.idx, COUNT(v.occurred_at) AS joins
+            FROM unnest(?::timestamptz[], ?::timestamptz[]) WITH ORDINALITY AS p(start_at, end_at, idx)
+            LEFT JOIN voice_messages v
+                ON v.occurred_at >= p.start_at
+               AND v.occurred_at < p.end_at
+               AND v.state = 'joined'
+            GROUP BY p.idx
+            ORDER BY p.idx
+            SQL, [$startsLiteral, $endsLiteral]);
 
-        foreach ($subdivisions as $i => $sub) {
-            $startUtc = $sub['start']->copy()->utc();
-            $endUtc = $sub['end']->copy()->utc();
-
-            $selects[] = 'COUNT(CASE WHEN occurred_at >= ? AND occurred_at < ? THEN 1 END) AS joins_'.$i;
-            $bindings[] = $startUtc;
-            $bindings[] = $endUtc;
+        $byOrdinal = [];
+        foreach ($rows as $row) {
+            $byOrdinal[(int) $row->idx] = (int) $row->joins;
         }
-
-        $firstStart = $subdivisions[0]['start']->copy()->utc();
-        $lastEnd = end($subdivisions)['end']->copy()->utc();
-
-        $row = $query
-            ->where('occurred_at', '>=', $firstStart)
-            ->where('occurred_at', '<', $lastEnd)
-            ->selectRaw(implode(', ', $selects), $bindings)
-            ->first();
 
         $result = [];
         foreach (array_keys($subdivisions) as $i) {
-            $result[$i] = (int) ($row->{'joins_'.$i} ?? 0);
+            $result[$i] = $byOrdinal[$i + 1] ?? 0;
         }
 
         return $result;
+    }
+
+    /**
+     * Builds PostgreSQL `timestamptz[]` array literals for the subdivision start
+     * and end boundaries (in UTC), bound as static parameters to the `unnest`
+     * queries above.
+     *
+     * @param  array<int, array{start: Carbon, end: Carbon, label: string}>  $subdivisions
+     * @return array{0: string, 1: string}
+     */
+    private function boundaryArrayLiterals(array $subdivisions): array
+    {
+        $starts = [];
+        $ends = [];
+
+        foreach ($subdivisions as $sub) {
+            $starts[] = '"'.$sub['start']->copy()->utc()->format('Y-m-d H:i:sP').'"';
+            $ends[] = '"'.$sub['end']->copy()->utc()->format('Y-m-d H:i:sP').'"';
+        }
+
+        return ['{'.implode(',', $starts).'}', '{'.implode(',', $ends).'}'];
     }
 
     /**

--- a/app-modules/panel-admin/src/Twitch/Resources/TwitchEventLogResource.php
+++ b/app-modules/panel-admin/src/Twitch/Resources/TwitchEventLogResource.php
@@ -120,7 +120,7 @@ class TwitchEventLogResource extends Resource
                     ->schema([
                         CodeEntry::make('payload')
                             ->extraAttributes(['class' => 'overflow-auto max-h-128'])
-                            ->formatStateUsing(fn (array $state): string => json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
+                            ->formatStateUsing(fn (array $state): string => json_encode($state, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES))
                             ->columnSpanFull(),
                     ]),
             ]);

--- a/app-modules/panel-admin/tests/Feature/Marketing/PeriodStatsTest.php
+++ b/app-modules/panel-admin/tests/Feature/Marketing/PeriodStatsTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Activity\Message\Models\Message;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\PanelAdmin\Marketing\Pages\Discord\Dashboard\Queries\PeriodStats;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * With rangeDays = 7, PeriodStats produces 7 daily blocks covering the seven
+ * full days that end at today's start-of-day (in the display timezone). Freezing
+ * "now" to 2026-06-15 noon makes those blocks deterministically 2026-06-08
+ * (block 0) through 2026-06-14 (block 6).
+ */
+beforeEach(function (): void {
+    $this->displayTimezone = config('app.display_timezone');
+
+    Date::setTestNow(Date::create(2026, 6, 15, 12, 0, 0, $this->displayTimezone));
+});
+
+afterEach(function (): void {
+    Date::setTestNow();
+});
+
+test('it buckets messages, distinct users and voice joins into the correct daily blocks', function (): void {
+    $tz = $this->displayTimezone;
+
+    $tenant = Tenant::factory()->create();
+    $identityA = ExternalIdentity::factory()->recycle($tenant)->create();
+    $identityB = ExternalIdentity::factory()->recycle($tenant)->create();
+
+    $firstBlockNoon = Date::create(2026, 6, 8, 12, 0, 0, $tz);   // block 0 (oldest day)
+    $lastBlockNoon = Date::create(2026, 6, 14, 12, 0, 0, $tz);   // block 6 (most recent full day)
+    $todayNoon = Date::create(2026, 6, 15, 12, 0, 0, $tz);       // outside every block
+
+    // Block 0: three messages from two distinct identities.
+    Message::factory()->count(2)->recycle($tenant)->create([
+        'external_identity_id' => $identityA->id,
+        'sent_at' => $firstBlockNoon,
+    ]);
+    Message::factory()->recycle($tenant)->create([
+        'external_identity_id' => $identityB->id,
+        'sent_at' => $firstBlockNoon,
+    ]);
+
+    // Block 6: two messages from a single identity.
+    Message::factory()->count(2)->recycle($tenant)->create([
+        'external_identity_id' => $identityA->id,
+        'sent_at' => $lastBlockNoon,
+    ]);
+
+    // Today's message falls outside all seven blocks and must not be counted.
+    Message::factory()->recycle($tenant)->create([
+        'external_identity_id' => $identityA->id,
+        'sent_at' => $todayNoon,
+    ]);
+
+    $insertVoice = function (string $state, Carbon $occurredAt) use ($identityA, $tenant): void {
+        DB::table('voice_messages')->insert([
+            'external_identity_id' => $identityA->id,
+            'tenant_id' => $tenant->id,
+            'channel_name' => 'general',
+            'state' => $state,
+            'obtained_experience' => 0,
+            'occurred_at' => $occurredAt,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    };
+
+    // Block 6: one "joined" event (counted) and one "left" event (ignored by the query).
+    $insertVoice('joined', $lastBlockNoon);
+    $insertVoice('left', $lastBlockNoon);
+
+    $blocks = new PeriodStats(7)->get()['blocks'];
+
+    expect($blocks)->toHaveCount(7);
+
+    // Oldest block: 3 messages, 2 distinct users, no voice.
+    expect($blocks[0]['msgs'])->toBe(3)
+        ->and($blocks[0]['users'])->toBe(2)
+        ->and($blocks[0]['voice'])->toBe(0.0);
+
+    // Most recent full day: 2 messages, 1 user, voice = round(1 * 0.75, 1).
+    expect($blocks[6]['msgs'])->toBe(2)
+        ->and($blocks[6]['users'])->toBe(1)
+        ->and($blocks[6]['voice'])->toBe(0.8);
+
+    // The idle middle blocks are empty.
+    foreach ([1, 2, 3, 4, 5] as $idleBlock) {
+        expect($blocks[$idleBlock]['msgs'])->toBe(0)
+            ->and($blocks[$idleBlock]['users'])->toBe(0);
+    }
+
+    // Today's message is excluded from every block (5 in-range messages total).
+    expect(array_sum(array_column($blocks, 'msgs')))->toBe(5);
+});

--- a/app-modules/panel-app/src/Livewire/Timeline/Composer.php
+++ b/app-modules/panel-app/src/Livewire/Timeline/Composer.php
@@ -12,6 +12,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use He4rt\Activity\Timeline\Actions\CreatePost;
 use He4rt\Activity\Timeline\DTOs\CreatePostDTO;
+use He4rt\Identity\User\Models\User;
 use Illuminate\View\View;
 use Livewire\Component;
 
@@ -60,8 +61,11 @@ final class Composer extends Component implements HasSchemas
 
         $tenant = Filament::getTenant();
 
+        /** @var User $user */
+        $user = auth()->user();
+
         resolve(CreatePost::class)->handle(new CreatePostDTO(
-            userId: auth()->id(),
+            userId: $user->id,
             tenantId: $tenant->id,
             content: $state['content'],
             images: $state['images'] ?? [],

--- a/app-modules/panel-app/src/Livewire/Timeline/ReplyComposer.php
+++ b/app-modules/panel-app/src/Livewire/Timeline/ReplyComposer.php
@@ -11,6 +11,7 @@ use Filament\Schemas\Contracts\HasSchemas;
 use Filament\Schemas\Schema;
 use He4rt\Activity\Timeline\Actions\CreateReply;
 use He4rt\Activity\Timeline\DTOs\CreateReplyDTO;
+use He4rt\Identity\User\Models\User;
 use Illuminate\View\View;
 use Livewire\Attributes\Locked;
 use Livewire\Component;
@@ -62,8 +63,11 @@ final class ReplyComposer extends Component implements HasSchemas
     {
         $state = $this->form->getState();
 
+        /** @var User $user */
+        $user = auth()->user();
+
         resolve(CreateReply::class)->handle(new CreateReplyDTO(
-            userId: auth()->id(),
+            userId: $user->id,
             tenantId: filament()->getTenant()->getKey(),
             parentTimelineId: $this->timelineId,
             content: $state['content'],

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -142,7 +142,7 @@ final readonly class CommunityRetrospective
      */
     private function prRefs(Collection $items): array
     {
-        return $items
+        return array_values($items
             ->filter(fn (GithubContribution $contribution): bool => $contribution->type === ContributionType::Pr)
             ->sortByDesc(fn (GithubContribution $contribution): mixed => $contribution->occurred_at)
             ->map(function (GithubContribution $contribution): array {
@@ -158,7 +158,7 @@ final readonly class CommunityRetrospective
                 ];
             })
             ->values()
-            ->all();
+            ->all());
     }
 
     /**
@@ -167,7 +167,7 @@ final readonly class CommunityRetrospective
      */
     private function issueRefs(Collection $items): array
     {
-        return $items
+        return array_values($items
             ->filter(fn (GithubContribution $contribution): bool => $contribution->type === ContributionType::Issue)
             ->sortByDesc(fn (GithubContribution $contribution): mixed => $contribution->occurred_at)
             ->map(function (GithubContribution $contribution): array {
@@ -181,7 +181,7 @@ final readonly class CommunityRetrospective
                 ];
             })
             ->values()
-            ->all();
+            ->all());
     }
 
     private function refNumber(string $externalRef): int
@@ -242,7 +242,7 @@ final readonly class CommunityRetrospective
      */
     private function repos(Collection $contributions): array
     {
-        return $contributions
+        return array_values($contributions
             ->groupBy('repo')
             ->map(function (Collection $items, string $repo): array {
                 $prs = $items->filter(fn (GithubContribution $contribution): bool => $contribution->type === ContributionType::Pr);
@@ -272,7 +272,7 @@ final readonly class CommunityRetrospective
                 ];
             })
             ->values()
-            ->all();
+            ->all());
     }
 
     /**
@@ -281,13 +281,13 @@ final readonly class CommunityRetrospective
      */
     private function highlights(Collection $contributions): array
     {
-        return $contributions
+        return array_values($contributions
             ->filter(fn (GithubContribution $contribution): bool => $contribution->type === ContributionType::Pr)
             ->map(fn (GithubContribution $contribution): array => [...$this->prRow($contribution), 'repo' => $contribution->repo])
             ->sortByDesc(fn (array $pr): int => $pr['additions'] + $pr['deletions'])
             ->take(4)
             ->values()
-            ->all();
+            ->all());
     }
 
     private function isBot(GithubContribution $contribution): bool

--- a/app/Console/Commands/AnalyzeDiscordProfiles.php
+++ b/app/Console/Commands/AnalyzeDiscordProfiles.php
@@ -143,7 +143,7 @@ class AnalyzeDiscordProfiles extends Command
                 'total_profiles' => $totalProfiles,
                 'total_with_github' => count($githubUsers),
                 'connections' => $githubUsers,
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
         );
 
         info('GitHub connections saved to storage/app/private/discord/github_connections.json');
@@ -157,7 +157,7 @@ class AnalyzeDiscordProfiles extends Command
                 'with_connections' => $withConnections,
                 'platforms' => $socialCounts,
                 'github_users' => count($githubUsers),
-            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
         );
 
         outro(sprintf('Report complete — %d profiles analyzed', $totalProfiles));

--- a/app/Console/Commands/CommunityReport.php
+++ b/app/Console/Commands/CommunityReport.php
@@ -220,31 +220,37 @@ class CommunityReport extends Command
 
         $zeroXp = DB::table('characters')->where('experience', 0)->count();
 
-        // Build CASE expression from Character::LEVEL_THRESHOLDS
-        $thresholds = Character::LEVEL_THRESHOLDS;
-        $caseParts = [];
+        // Bucket characters into level ranges in PHP instead of building dynamic
+        // SQL. Each range maps to a half-open [lowerXp, upperXp) experience window
+        // derived from the level => XP threshold table, so the queries stay static.
+        $levelRanges = [
+            '1-5' => [1, 5],
+            '6-10' => [6, 10],
+            '11-20' => [11, 20],
+            '21-30' => [21, 30],
+            '31-40' => [31, 40],
+            '41-50' => [41, 50],
+        ];
 
-        foreach (array_reverse($thresholds, true) as $level => $xp) {
-            $caseParts[] = sprintf('WHEN experience >= %s THEN %s', $xp, $level);
+        /** @var array<string, int> $levelDistribution */
+        $levelDistribution = [];
+
+        foreach ($levelRanges as $label => [$minLevel, $maxLevel]) {
+            $lowerXp = Character::LEVEL_THRESHOLDS[$minLevel];
+            $upperXp = Character::LEVEL_THRESHOLDS[$maxLevel + 1] ?? null;
+
+            $rangeQuery = DB::table('characters')->where('experience', '>=', $lowerXp);
+
+            if ($upperXp !== null) {
+                $rangeQuery->where('experience', '<', $upperXp);
+            }
+
+            $count = $rangeQuery->count();
+
+            if ($count > 0) {
+                $levelDistribution[$label] = $count;
+            }
         }
-
-        $levelCase = 'CASE '.implode(' ', $caseParts).' ELSE 1 END';
-
-        $levelDistribution = DB::table('characters')
-            ->selectRaw("
-                CASE
-                    WHEN ({$levelCase}) BETWEEN 1 AND 5 THEN '1-5'
-                    WHEN ({$levelCase}) BETWEEN 6 AND 10 THEN '6-10'
-                    WHEN ({$levelCase}) BETWEEN 11 AND 20 THEN '11-20'
-                    WHEN ({$levelCase}) BETWEEN 21 AND 30 THEN '21-30'
-                    WHEN ({$levelCase}) BETWEEN 31 AND 40 THEN '31-40'
-                    WHEN ({$levelCase}) BETWEEN 41 AND 50 THEN '41-50'
-                END as level_range,
-                COUNT(*) as cnt
-            ")
-            ->groupBy('level_range')
-            ->orderByRaw(sprintf('MIN(%s)', $levelCase))
-            ->get();
 
         $percentiles = DB::selectOne('
             SELECT
@@ -270,14 +276,19 @@ class CommunityReport extends Command
             ],
         );
 
+        $distributionRows = [];
+        foreach ($levelDistribution as $range => $cnt) {
+            $distributionRows[] = [
+                $range,
+                number_format($cnt),
+                round($cnt / $totalCharacters * 100, 1).'%',
+            ];
+        }
+
         info('Level Distribution');
         table(
             headers: ['Level Range', 'Characters', '% of Total'],
-            rows: $levelDistribution->map(fn ($r) => [
-                $r->level_range,
-                number_format($r->cnt),
-                round($r->cnt / $totalCharacters * 100, 1).'%',
-            ])->all(),
+            rows: $distributionRows,
         );
 
         info('XP Percentiles');
@@ -304,7 +315,7 @@ class CommunityReport extends Command
                 'p90' => (int) $percentiles->p90,
                 'p99' => (int) $percentiles->p99,
             ],
-            'level_distribution' => $levelDistribution->pluck('cnt', 'level_range')->toArray(),
+            'level_distribution' => $levelDistribution,
         ];
     }
 
@@ -950,7 +961,7 @@ class CommunityReport extends Command
 
         Storage::disk('local')->put(
             'discord/community_report.json',
-            json_encode($this->report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE),
+            json_encode($this->report, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR),
         );
 
         info('Full report saved to storage/app/private/discord/community_report.json');

--- a/app/Console/Commands/FetchDiscordMembers.php
+++ b/app/Console/Commands/FetchDiscordMembers.php
@@ -100,7 +100,7 @@ class FetchDiscordMembers extends Command
             'members' => $members,
         ];
 
-        Storage::disk('local')->put('discord/members.json', json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        Storage::disk('local')->put('discord/members.json', json_encode($output, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
 
         $this->info('Done! Saved '.count($members).sprintf(' members to storage/app/private/discord/members.json (skipped %d bots)', $botCount));
     }

--- a/app/Console/Commands/FetchDiscordProfile.php
+++ b/app/Console/Commands/FetchDiscordProfile.php
@@ -70,6 +70,6 @@ class FetchDiscordProfile extends Command
 
         $this->newLine();
         $this->info('Full response:');
-        $this->line(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->line(json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
     }
 }

--- a/app/Console/Commands/FetchDiscordProfiles.php
+++ b/app/Console/Commands/FetchDiscordProfiles.php
@@ -272,7 +272,7 @@ class FetchDiscordProfiles extends Command
 
         Storage::disk('local')->put(
             $chunkFile,
-            json_encode($existing, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE)
+            json_encode($existing, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR)
         );
     }
 

--- a/app/Console/Commands/FixPostSwitchTimestampsCommand.php
+++ b/app/Console/Commands/FixPostSwitchTimestampsCommand.php
@@ -157,6 +157,7 @@ final class FixPostSwitchTimestampsCommand extends Command
 
                     foreach ($columns as $colDef) {
                         $column = $colDef[0];
+                        /** @var 'column'|'row' $fixScope */
                         $fixScope = $colDef[1] ?? 'column';
                         $moduleStats['columns']++;
 

--- a/app/Http/Middleware/GuestTenantIdentifier.php
+++ b/app/Http/Middleware/GuestTenantIdentifier.php
@@ -28,7 +28,13 @@ class GuestTenantIdentifier
             return $next($request);
         }
 
-        $tenant = $panel->getTenant($request->route()->parameter('tenant'));
+        $tenantSlug = $request->route()->parameter('tenant');
+
+        if (!is_string($tenantSlug)) {
+            return $next($request);
+        }
+
+        $tenant = $panel->getTenant($tenantSlug);
         Filament::setTenant($tenant, true);
 
         return $next($request);

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -3,7 +3,7 @@ includes:
     - phpstan.ignore.neon
 
 parameters:
-    level: 6
+    level: 7
 
     paths:
         - app/


### PR DESCRIPTION
Closes #323

## Context

Raises PHPStan from **level 6 → 7** and fixes all **54** resulting errors. Level 7 adds stricter union handling: `string|false`, `int|string`, `array` vs `list`, and method calls on union types.

## Fixes by pattern

| Pattern | Approach |
|--------|----------|
| `string\|false` from file ops / `json_*` | guard `=== false` + throw, or add `JSON_THROW_ON_ERROR` |
| `int\|string` Discord ids → `string` | cast `(string)` once at the origin |
| `array` → `list` return types | `array_values()` |
| `max()` on possibly-empty array | empty-array guard |
| Discord library collection stubs (`method.nonObject`) | suppressed in the **bot-discord module** `phpstan.ignore.neon` — runtime is always the collection, the stub union is a third-party false positive |
| `literal-string` in raw queries | see refactors below |

### Behaviour-changing refactors (pattern F)

- **`PeriodStats`** — replaced the dynamic `selectRaw(implode(...))` conditional-aggregate query with a static `unnest(?::timestamptz[], ?::timestamptz[]) WITH ORDINALITY` template; the window boundaries now travel as Postgres array-literal bindings, so the SQL is a literal and injection-safe.
- **`CommunityReport`** — computes the level distribution in PHP (bucketing characters into level ranges via `Character::LEVEL_THRESHOLDS`) instead of building dynamic `CASE` / `orderByRaw` SQL.

## Tests

- Added `PeriodStatsTest` (panel-admin feature) covering message/voice bucketing, distinct-user counts, the `joined`-state voice filter, the ordinality→block mapping, and out-of-range exclusion.

## Docs

- Documented the third-party-stubs suppression policy in `.ai/guidelines/tooling/01-phpstan.blade.php`.

## Verification

- `vendor/bin/phpstan analyse` → **[OK] No errors** at level 7
- `php artisan test` → **776 passed** (2144 assertions)
- `vendor/bin/pint` clean