### PR TITLE
fix(integration-discord): handle cloudflare 429

### DIFF
--- a/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
+++ b/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
@@ -139,6 +139,12 @@ final readonly class PurgeUnusedInvitesAction
             return (float) $retryAfter;
         }
 
+        $resetAfter = $response->header('X-RateLimit-Reset-After');
+
+        if ($resetAfter !== '' && is_numeric($resetAfter)) {
+            return (float) $resetAfter;
+        }
+
         $header = $response->header('Retry-After');
 
         if ($header !== '' && is_numeric($header)) {

--- a/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
+++ b/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
@@ -9,6 +9,7 @@ use He4rt\IntegrationDiscord\Sync\DTOs\PurgeInvitesResultDTO;
 use He4rt\IntegrationDiscord\Transport\DiscordConnector;
 use He4rt\IntegrationDiscord\Transport\Requests\Invites\DeleteInvite;
 use He4rt\IntegrationDiscord\Transport\Requests\Invites\ListGuildInvites;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Sleep;
 use JsonException;
@@ -16,6 +17,7 @@ use Random\RandomException;
 use RuntimeException;
 use Saloon\Exceptions\Request\FatalRequestException;
 use Saloon\Exceptions\Request\RequestException;
+use Saloon\Http\Response;
 use Throwable;
 
 final readonly class PurgeUnusedInvitesAction
@@ -111,14 +113,38 @@ final readonly class PurgeUnusedInvitesAction
                 return;
             }
 
-            if ($response->status() === 429 && $attempt < self::MAX_RETRIES) {
-                $retryAfter = (float) ($response->json('retry_after') ?? 1.0);
-                $this->jitteredSleep($retryAfter);
+            if ($response->status() === 429) {
+                $retryAfter = $this->parseRetryAfter($response);
 
-                continue;
+                if ($retryAfter > 60.0) {
+                    throw new RuntimeException(sprintf('Cloudflare IP ban: Retry-After %ds', (int) $retryAfter));
+                }
+
+                if ($attempt < self::MAX_RETRIES) {
+                    $this->jitteredSleep($retryAfter);
+
+                    continue;
+                }
             }
 
             throw new RuntimeException(sprintf('HTTP %d: %s', $response->status(), $response->body()));
         }
+    }
+
+    private function parseRetryAfter(Response $response): float
+    {
+        $retryAfter = Arr::get(json_decode($response->body(), true), 'retry_after');
+
+        if ($retryAfter !== null) {
+            return (float) $retryAfter;
+        }
+
+        $header = $response->header('Retry-After');
+
+        if ($header !== '' && is_numeric($header)) {
+            return (float) $header;
+        }
+
+        return 1.0;
     }
 }

--- a/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
+++ b/app-modules/integration-discord/src/Sync/Actions/PurgeUnusedInvitesAction.php
@@ -6,6 +6,7 @@ namespace He4rt\IntegrationDiscord\Sync\Actions;
 
 use He4rt\IntegrationDiscord\Sync\DTOs\MatchedInviteDTO;
 use He4rt\IntegrationDiscord\Sync\DTOs\PurgeInvitesResultDTO;
+use He4rt\IntegrationDiscord\Sync\Exceptions\CloudflareIpBanException;
 use He4rt\IntegrationDiscord\Transport\DiscordConnector;
 use He4rt\IntegrationDiscord\Transport\Requests\Invites\DeleteInvite;
 use He4rt\IntegrationDiscord\Transport\Requests\Invites\ListGuildInvites;
@@ -71,6 +72,14 @@ final readonly class PurgeUnusedInvitesAction
             try {
                 $this->deleteInvite($invite['code']);
                 $deleted++;
+            } catch (CloudflareIpBanException $e) {
+                $failed += count($unused) - $index;
+                Log::warning('Cloudflare IP ban detected, aborting purge', [
+                    'code' => $invite['code'],
+                    'error' => $e->getMessage(),
+                ]);
+
+                break;
             } catch (Throwable $e) {
                 $failed++;
                 Log::warning('Failed to delete Discord invite', [
@@ -99,6 +108,7 @@ final readonly class PurgeUnusedInvitesAction
     }
 
     /**
+     * @throws CloudflareIpBanException
      * @throws RandomException
      * @throws FatalRequestException
      * @throws RequestException
@@ -117,7 +127,7 @@ final readonly class PurgeUnusedInvitesAction
                 $retryAfter = $this->parseRetryAfter($response);
 
                 if ($retryAfter > 60.0) {
-                    throw new RuntimeException(sprintf('Cloudflare IP ban: Retry-After %ds', (int) $retryAfter));
+                    throw new CloudflareIpBanException(sprintf('Retry-After %ds', (int) $retryAfter));
                 }
 
                 if ($attempt < self::MAX_RETRIES) {

--- a/app-modules/integration-discord/src/Sync/Exceptions/CloudflareIpBanException.php
+++ b/app-modules/integration-discord/src/Sync/Exceptions/CloudflareIpBanException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationDiscord\Sync\Exceptions;
+
+use RuntimeException;
+
+final class CloudflareIpBanException extends RuntimeException {}

--- a/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
+++ b/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
@@ -239,15 +239,18 @@ it('retries on cloudflare 429 with non-json body and short retry-after header', 
         ->and($result->failed)->toBe(0);
 });
 
-it('aborts immediately on cloudflare ip ban', function (): void {
+it('aborts entire purge on cloudflare ip ban', function (): void {
     Sleep::fake();
 
     $invites = [
         makeInvite('aaa', maxAge: 0, uses: 0),
+        makeInvite('bbb', maxAge: 0, uses: 0),
+        makeInvite('ccc', maxAge: 0, uses: 0),
     ];
 
     $mockClient = new MockClient([
         MockResponse::make($invites),
+        MockResponse::make([], 204),
         MockResponse::make('error code: 1015', 429, ['Retry-After' => '80974']),
     ]);
 
@@ -257,10 +260,11 @@ it('aborts immediately on cloudflare ip ban', function (): void {
     $action = new PurgeUnusedInvitesAction($connector);
     $result = $action->execute('guild-123', dryRun: false);
 
-    expect($result->deleted)->toBe(0)
-        ->and($result->failed)->toBe(1);
+    expect($result->deleted)->toBe(1)
+        ->and($result->failed)->toBe(2);
 
-    Sleep::assertSleptTimes(0);
+    $mockClient->assertSentCount(3);
+    Sleep::assertSleptTimes(1);
 });
 
 it('fails after exhausting retries on persistent 429', function (): void {

--- a/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
+++ b/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
@@ -193,6 +193,53 @@ it('retries on 429 rate limit and succeeds', function (): void {
     Sleep::assertSleptTimes(1);
 });
 
+it('retries on cloudflare 429 with non-json body and short retry-after header', function (): void {
+    Sleep::fake();
+
+    $invites = [
+        makeInvite('aaa', maxAge: 0, uses: 0),
+    ];
+
+    $mockClient = new MockClient([
+        MockResponse::make($invites),
+        MockResponse::make('error code: 1015', 429, ['Retry-After' => '5']),
+        MockResponse::make([], 204),
+    ]);
+
+    $connector = new DiscordConnector('test-token');
+    $connector->withMockClient($mockClient);
+
+    $action = new PurgeUnusedInvitesAction($connector);
+    $result = $action->execute('guild-123', dryRun: false);
+
+    expect($result->deleted)->toBe(1)
+        ->and($result->failed)->toBe(0);
+});
+
+it('aborts immediately on cloudflare ip ban', function (): void {
+    Sleep::fake();
+
+    $invites = [
+        makeInvite('aaa', maxAge: 0, uses: 0),
+    ];
+
+    $mockClient = new MockClient([
+        MockResponse::make($invites),
+        MockResponse::make('error code: 1015', 429, ['Retry-After' => '80974']),
+    ]);
+
+    $connector = new DiscordConnector('test-token');
+    $connector->withMockClient($mockClient);
+
+    $action = new PurgeUnusedInvitesAction($connector);
+    $result = $action->execute('guild-123', dryRun: false);
+
+    expect($result->deleted)->toBe(0)
+        ->and($result->failed)->toBe(1);
+
+    Sleep::assertSleptTimes(0);
+});
+
 it('fails after exhausting retries on persistent 429', function (): void {
     Sleep::fake();
 

--- a/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
+++ b/app-modules/integration-discord/tests/Unit/Sync/PurgeUnusedInvitesActionTest.php
@@ -193,6 +193,29 @@ it('retries on 429 rate limit and succeeds', function (): void {
     Sleep::assertSleptTimes(1);
 });
 
+it('uses X-RateLimit-Reset-After header when body has no retry_after', function (): void {
+    Sleep::fake();
+
+    $invites = [
+        makeInvite('aaa', maxAge: 0, uses: 0),
+    ];
+
+    $mockClient = new MockClient([
+        MockResponse::make($invites),
+        MockResponse::make(['message' => 'You are being rate limited.'], 429, ['X-RateLimit-Reset-After' => '2.57']),
+        MockResponse::make([], 204),
+    ]);
+
+    $connector = new DiscordConnector('test-token');
+    $connector->withMockClient($mockClient);
+
+    $action = new PurgeUnusedInvitesAction($connector);
+    $result = $action->execute('guild-123', dryRun: false);
+
+    expect($result->deleted)->toBe(1)
+        ->and($result->failed)->toBe(0);
+});
+
 it('retries on cloudflare 429 with non-json body and short retry-after header', function (): void {
     Sleep::fake();
 


### PR DESCRIPTION
## Summary
- Parse `Retry-After` from HTTP header when Cloudflare returns a 429 with non-JSON body (`error code: 1015`), fixing `JsonException: Syntax error`
- Abort immediately on Cloudflare IP bans (`Retry-After > 60s`) instead of wasting retries against a ~22-hour ban
- Use `Arr::get` for safe JSON body parsing

## Test plan
- [x] Cloudflare 429 with short `Retry-After` header: retries and succeeds
- [x] Cloudflare IP ban with large `Retry-After` header: aborts immediately, no sleep
- [x] All 11 tests passing, four checks clean