### PR TITLE
fix(identity): reassign connected_by FK on merge

### DIFF
--- a/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
+++ b/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
@@ -20,6 +20,7 @@ final class MergeAccountsAction
                 ->update(['model_id' => $oldUser->id]);
 
             ExternalIdentity::query()
+                ->withTrashed()
                 ->where('connected_by', $currentUser->id)
                 ->update(['connected_by' => $oldUser->id]);
 

--- a/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
+++ b/app-modules/identity/src/Auth/Actions/MergeAccountsAction.php
@@ -19,6 +19,10 @@ final class MergeAccountsAction
                 ->where('model_id', $currentUser->id)
                 ->update(['model_id' => $oldUser->id]);
 
+            ExternalIdentity::query()
+                ->where('connected_by', $currentUser->id)
+                ->update(['connected_by' => $oldUser->id]);
+
             $oldUser->tenants()->syncWithoutDetaching(
                 $currentUser->tenants()->pluck('tenants.id')
             );

--- a/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
+++ b/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
@@ -76,6 +76,28 @@ test('reassigns connected_by from current to old user', function (): void {
     expect($identity->connected_by)->toBe($oldUser->id);
 });
 
+test('reassigns connected_by on soft-deleted identities', function (): void {
+    $tenant = Tenant::factory()->create();
+    $oldUser = User::factory()->create(['first_login_at' => now()]);
+    $currentUser = User::factory()->create();
+
+    $identity = ExternalIdentity::factory()->create([
+        'tenant_id' => $tenant->id,
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $oldUser->id,
+        'provider' => IdentityProvider::GitHub,
+        'external_account_id' => 'github-789',
+        'connected_by' => $currentUser->id,
+        'deleted_at' => now(),
+    ]);
+
+    $action = new MergeAccountsAction();
+    $action->execute($currentUser, $oldUser);
+
+    $identity->refresh();
+    expect($identity->connected_by)->toBe($oldUser->id);
+});
+
 test('enriches old user when first_login_at is null', function (): void {
     $oldUser = User::factory()->create([
         'username' => 'old-etl-user',

--- a/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
+++ b/app-modules/identity/tests/Feature/Auth/MergeAccountsActionTest.php
@@ -55,6 +55,27 @@ test('deletes current user after merge', function (): void {
     expect(User::query()->find($currentUserId))->toBeNull();
 });
 
+test('reassigns connected_by from current to old user', function (): void {
+    $tenant = Tenant::factory()->create();
+    $oldUser = User::factory()->create(['first_login_at' => now()]);
+    $currentUser = User::factory()->create();
+
+    $identity = ExternalIdentity::factory()->create([
+        'tenant_id' => $tenant->id,
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $oldUser->id,
+        'provider' => IdentityProvider::GitHub,
+        'external_account_id' => 'github-456',
+        'connected_by' => $currentUser->id,
+    ]);
+
+    $action = new MergeAccountsAction();
+    $action->execute($currentUser, $oldUser);
+
+    $identity->refresh();
+    expect($identity->connected_by)->toBe($oldUser->id);
+});
+
 test('enriches old user when first_login_at is null', function (): void {
     $oldUser = User::factory()->create([
         'username' => 'old-etl-user',


### PR DESCRIPTION
## Summary
- `MergeAccountsAction` reassigned `external_identities.model_id` before deleting `$currentUser`, but did not update `connected_by` — a separate FK column with no cascade behavior
- PostgreSQL blocked the deletion with `external_identities_connected_by_foreign` constraint violation
- Added query to reassign `connected_by` to `$oldUser->id` before deletion
- Added test covering the `connected_by` reassignment (existing tests used `null` for `connected_by`, masking the issue)