### PR TITLE
feat(core): self-document DB-backed enums via StringifyEnum + column comments

### DIFF
--- a/app-modules/activity/database/migrations/2026_03_18_000000_create_interactions_table.php
+++ b/app-modules/activity/database/migrations/2026_03_18_000000_create_interactions_table.php
@@ -2,6 +2,9 @@
 
 declare(strict_types=1);
 
+use He4rt\Activity\Tracking\Enums\ActivityStatus;
+use He4rt\Activity\Tracking\Enums\ActivityType;
+use He4rt\Activity\Tracking\Enums\ValueTier;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,14 +17,14 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('character_id')->constrained('characters');
             $table->foreignUuid('tenant_id')->constrained('tenants');
-            $table->string('type');
+            $table->string('type')->comment(ActivityType::stringifyCases());
             $table->string('provider');
-            $table->string('value_tier');
+            $table->string('value_tier')->comment(ValueTier::stringifyCases());
             $table->integer('coins_min');
             $table->integer('coins_max');
             $table->integer('coins_awarded')->nullable();
             $table->integer('xp_awarded')->nullable();
-            $table->string('status')->default('pending');
+            $table->string('status')->default('pending')->comment(ActivityStatus::stringifyCases());
             $table->nullableUuidMorphs('source');
             $table->string('external_ref')->nullable();
             $table->jsonb('metadata')->nullable();

--- a/app-modules/activity/database/migrations/2026_04_17_000001_add_metadata_to_messages_table.php
+++ b/app-modules/activity/database/migrations/2026_04_17_000001_add_metadata_to_messages_table.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use He4rt\Activity\Message\Enums\MessageKind;
+use He4rt\Activity\Message\Enums\MessageSourceKind;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -27,9 +29,9 @@ return new class extends Migration
             $table->unsignedInteger('reactions_count')->default(0)->after('metadata');
             $table->unsignedInteger('reactions_total')->default(0)->after('reactions_count');
 
-            $table->string('kind')->nullable()->after('reactions_total');
+            $table->string('kind')->nullable()->after('reactions_total')->comment(MessageKind::stringifyCases());
             $table->smallInteger('raw_message_type')->nullable()->after('kind');
-            $table->string('source_kind')->nullable()->after('raw_message_type');
+            $table->string('source_kind')->nullable()->after('raw_message_type')->comment(MessageSourceKind::stringifyCases());
             $table->boolean('is_pinned')->default(value: false)->after('source_kind');
             $table->boolean('mentions_everyone')->default(value: false)->after('is_pinned');
             $table->smallInteger('mention_role_count')->default(0)->after('mentions_everyone');

--- a/app-modules/activity/database/migrations/2026_04_17_000002_create_moderation_events_table.php
+++ b/app-modules/activity/database/migrations/2026_04_17_000002_create_moderation_events_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Activity\Moderation\Enums\ModerationType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,7 +16,7 @@ return new class extends Migration
             $table->foreignUuid('tenant_id')->constrained('tenants');
             $table->foreignUuid('external_identity_id')->nullable()->constrained('external_identities');
             $table->foreignUuid('moderator_identity_id')->nullable()->constrained('external_identities');
-            $table->string('type');
+            $table->string('type')->comment(ModerationType::stringifyCases());
             $table->text('reason')->nullable();
             $table->foreignUuid('source_identity_id')->nullable()->constrained('external_identities');
             $table->uuid('source_message_id')->nullable();

--- a/app-modules/activity/database/migrations/2026_04_20_111057_create_fase3_activity_tables.php
+++ b/app-modules/activity/database/migrations/2026_04_20_111057_create_fase3_activity_tables.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Activity\Message\Enums\MembershipEventKind;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -50,7 +51,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('tenant_id')->constrained('tenants');
             $table->foreignUuid('external_identity_id')->constrained('external_identities');
-            $table->string('kind');
+            $table->string('kind')->comment(MembershipEventKind::stringifyCases());
             $table->timestampTz('occurred_at');
             $table->string('provider_message_id')->nullable();
             $table->jsonb('metadata')->nullable();

--- a/app-modules/activity/src/Message/Enums/MembershipEventKind.php
+++ b/app-modules/activity/src/Message/Enums/MembershipEventKind.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Message\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 /**
  * Canonical membership signals. Providers contribute their own mappings via
  * MessageActivityAdapter::extractMembershipEvent() — unknown string values are
@@ -12,6 +14,8 @@ namespace He4rt\Activity\Message\Enums;
  */
 enum MembershipEventKind: string
 {
+    use StringifyEnum;
+
     case UserJoin = 'user_join';
     case Boost = 'boost';
     case BoostTier1 = 'boost_tier_1';

--- a/app-modules/activity/src/Message/Enums/MessageKind.php
+++ b/app-modules/activity/src/Message/Enums/MessageKind.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Message\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum MessageKind: string
 {
+    use StringifyEnum;
+
     case Default = 'default';
     case Reply = 'reply';
     case ThreadCreated = 'thread_created';

--- a/app-modules/activity/src/Message/Enums/MessageSourceKind.php
+++ b/app-modules/activity/src/Message/Enums/MessageSourceKind.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Message\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum MessageSourceKind: string
 {
+    use StringifyEnum;
+
     case User = 'user';
     case Bot = 'bot';
     case Webhook = 'webhook';

--- a/app-modules/activity/src/Moderation/Enums/ModerationType.php
+++ b/app-modules/activity/src/Moderation/Enums/ModerationType.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
 enum ModerationType: string implements HasColor, HasLabel
 {
+    use StringifyEnum;
+
     case Ban = 'ban';
     case Unban = 'unban';
     case Mute = 'mute';

--- a/app-modules/activity/src/Tracking/Enums/ActivityStatus.php
+++ b/app-modules/activity/src/Tracking/Enums/ActivityStatus.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Tracking\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
 enum ActivityStatus: string implements HasColor, HasLabel
 {
+    use StringifyEnum;
+
     case Pending = 'pending';
     case AutoApproved = 'auto_approved';
     case InReview = 'in_review';

--- a/app-modules/activity/src/Tracking/Enums/ActivityType.php
+++ b/app-modules/activity/src/Tracking/Enums/ActivityType.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Tracking\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum ActivityType: string
 {
+    use StringifyEnum;
+
     case Article = 'article';
     case PrMerged = 'pr_merged';
     case Mentoring = 'mentoring';

--- a/app-modules/activity/src/Tracking/Enums/ValueTier.php
+++ b/app-modules/activity/src/Tracking/Enums/ValueTier.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace He4rt\Activity\Tracking\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
 enum ValueTier: string implements HasColor, HasLabel
 {
+    use StringifyEnum;
+
     case High = 'high';
     case Medium = 'medium';
     case Low = 'low';

--- a/app-modules/community/database/migrations/2023_01_28_202610_create_feedback_reviews_table.php
+++ b/app-modules/community/database/migrations/2023_01_28_202610_create_feedback_reviews_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Community\Feedback\Enums\ReviewTypeEnum;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -17,7 +18,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('feedback_id')->constrained('feedbacks')->cascadeOnDelete();
             $table->foreignUuid('staff_id')->constrained('users')->cascadeOnDelete();
-            $table->string('status');
+            $table->string('status')->comment(ReviewTypeEnum::stringifyCases());
             $table->text('reason')->nullable();
             $table->timestampTz('received_at');
             $table->timestampsTz();

--- a/app-modules/community/src/Feedback/Enums/ReviewTypeEnum.php
+++ b/app-modules/community/src/Feedback/Enums/ReviewTypeEnum.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Community\Feedback\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum ReviewTypeEnum: string
 {
+    use StringifyEnum;
+
     case APPROVED = 'approved';
     case DECLINED = 'declined';
 

--- a/app-modules/economy/database/migrations/2026_03_16_220000_create_wallets_table.php
+++ b/app-modules/economy/database/migrations/2026_03_16_220000_create_wallets_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Economy\Enums\Currency;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::create('wallets', static function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->uuidMorphs('owner');
-            $table->string('currency');
+            $table->string('currency')->comment(Currency::stringifyCases());
             $table->integer('balance')->default(0);
             $table->timestampsTz();
 

--- a/app-modules/economy/database/migrations/2026_03_16_220001_create_transactions_table.php
+++ b/app-modules/economy/database/migrations/2026_03_16_220001_create_transactions_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Economy\Enums\TransactionType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -13,7 +14,7 @@ return new class extends Migration
         Schema::create('transactions', static function (Blueprint $table): void {
             $table->uuid('id')->primary();
             $table->foreignUuid('wallet_id')->constrained('wallets')->cascadeOnDelete();
-            $table->string('type');
+            $table->string('type')->comment(TransactionType::stringifyCases());
             $table->integer('amount');
             $table->integer('balance_after');
             $table->nullableUuidMorphs('reference');

--- a/app-modules/economy/src/Enums/Currency.php
+++ b/app-modules/economy/src/Enums/Currency.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Economy\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum Currency: string
 {
+    use StringifyEnum;
+
     case Coin = 'coin';
     case Cash = 'cash';
 }

--- a/app-modules/economy/src/Enums/TransactionType.php
+++ b/app-modules/economy/src/Enums/TransactionType.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\Economy\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum TransactionType: string
 {
+    use StringifyEnum;
+
     case Reward = 'reward';
     case Transfer = 'transfer';
     case Purchase = 'purchase';

--- a/app-modules/identity/database/migrations/2023_01_18_210724_create_providers_table.php
+++ b/app-modules/identity/database/migrations/2023_01_18_210724_create_providers_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -17,7 +18,7 @@ return new class extends Migration
             Schema::create('providers', static function (Blueprint $table): void {
                 $table->uuid('id')->primary();
                 $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
-                $table->string('provider');
+                $table->string('provider')->comment(IdentityProvider::stringifyCases());
                 $table->string('provider_id');
                 $table->string('email')->nullable();
                 $table->string('avatar')->nullable();

--- a/app-modules/identity/database/migrations/2026_03_21_000001_migrate_providers_to_external_identities.php
+++ b/app-modules/identity/database/migrations/2026_03_21_000001_migrate_providers_to_external_identities.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use He4rt\Identity\ExternalIdentity\Enums\CredentialsType;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Crypt;
@@ -31,8 +33,8 @@ return new class extends Migration
         // 2. Add new columns to providers table
         // ──────────────────────────────────────────────
         Schema::table('providers', static function (Blueprint $table): void {
-            $table->string('type')->default('external')->after('model_id');
-            $table->string('credentials_type')->default('oauth2')->after('provider');
+            $table->string('type')->default('external')->after('model_id')->comment(IdentityType::stringifyCases());
+            $table->string('credentials_type')->default('oauth2')->after('provider')->comment(CredentialsType::stringifyCases());
             $table->text('credentials')->nullable()->after('credentials_type');
             $table->uuid('connected_by')->nullable()->after('provider_id');
             $table->timestampTz('connected_at')->nullable()->after('connected_by');

--- a/app-modules/identity/src/ExternalIdentity/Enums/CredentialsType.php
+++ b/app-modules/identity/src/ExternalIdentity/Enums/CredentialsType.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace He4rt\Identity\ExternalIdentity\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Contracts\HasLabel;
 
 enum CredentialsType: string implements HasLabel
 {
+    use StringifyEnum;
+
     case OAuth2 = 'oauth2';
     case ApiKey = 'api_key';
     case Basic = 'basic';

--- a/app-modules/identity/src/ExternalIdentity/Enums/IdentityProvider.php
+++ b/app-modules/identity/src/ExternalIdentity/Enums/IdentityProvider.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\Identity\ExternalIdentity\Enums;
 
 use App\Contracts\OAuthClientContract;
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasDescription;
@@ -19,6 +20,8 @@ use He4rt\IntegrationTwitch\OAuth\TwitchOAuthClient;
 
 enum IdentityProvider: string implements HasColor, HasDescription, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Discord = 'discord';
     case Twitch = 'twitch';
     case DevTo = 'devto';

--- a/app-modules/identity/src/ExternalIdentity/Enums/IdentityType.php
+++ b/app-modules/identity/src/ExternalIdentity/Enums/IdentityType.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace He4rt\Identity\ExternalIdentity\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
 enum IdentityType: string implements HasColor, HasLabel
 {
+    use StringifyEnum;
+
     case External = 'external';
 
     public function getLabel(): string

--- a/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
+++ b/app-modules/integration-discord/database/migrations/2026_05_19_200005_create_discord_member_role_history_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\IntegrationDiscord\Enums\RoleHistoryAction;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->foreignId('discord_member_id')->constrained('discord_members')->cascadeOnDelete();
             $table->foreignId('discord_role_id')->constrained('discord_roles')->cascadeOnDelete();
-            $table->string('action');
+            $table->string('action')->comment(RoleHistoryAction::stringifyCases());
             $table->timestampTz('occurred_at');
             $table->foreignId('source_event_log_id')->nullable()->constrained('discord_event_logs')->nullOnDelete();
             $table->timestampsTz();

--- a/app-modules/integration-discord/src/Enums/RoleHistoryAction.php
+++ b/app-modules/integration-discord/src/Enums/RoleHistoryAction.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationDiscord\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum RoleHistoryAction: string
 {
+    use StringifyEnum;
+
     case Assigned = 'assigned';
     case Removed = 'removed';
 }

--- a/app-modules/integration-github/database/migrations/2026_06_04_000002_create_github_contributions_table.php
+++ b/app-modules/integration-github/database/migrations/2026_06_04_000002_create_github_contributions_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\IntegrationGithub\Enums\ContributionType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -16,7 +17,7 @@ return new class extends Migration
             $table->string('repo');
             $table->string('actor_login');
             $table->unsignedBigInteger('actor_id')->nullable();
-            $table->string('type');
+            $table->string('type')->comment(ContributionType::stringifyCases());
             $table->string('external_ref');
             $table->string('target_ref')->nullable();
             $table->timestampTz('occurred_at');

--- a/app-modules/integration-github/src/Enums/ContributionType.php
+++ b/app-modules/integration-github/src/Enums/ContributionType.php
@@ -4,8 +4,12 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationGithub\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
+
 enum ContributionType: string
 {
+    use StringifyEnum;
+
     case Pr = 'pr';
     case Review = 'review';
     case Issue = 'issue';

--- a/app-modules/integration-twitch/database/migrations/2026_05_22_000001_create_twitch_subscriptions_table.php
+++ b/app-modules/integration-twitch/database/migrations/2026_05_22_000001_create_twitch_subscriptions_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\IntegrationTwitch\Enums\TwitchSubscriptionStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->id();
             $table->string('subscription_id')->unique();
             $table->string('type');
-            $table->string('status');
+            $table->string('status')->comment(TwitchSubscriptionStatus::stringifyCases());
             $table->string('broadcaster_user_id');
             $table->jsonb('condition');
             $table->string('transport')->default('webhook');

--- a/app-modules/integration-twitch/src/Enums/TwitchSubscriptionStatus.php
+++ b/app-modules/integration-twitch/src/Enums/TwitchSubscriptionStatus.php
@@ -4,11 +4,14 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationTwitch\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasLabel;
 
 enum TwitchSubscriptionStatus: string implements HasColor, HasLabel
 {
+    use StringifyEnum;
+
     case Enabled = 'enabled';
     case VerificationPending = 'webhook_callback_verification_pending';
     case VerificationFailed = 'webhook_callback_verification_failed';

--- a/app-modules/moderation/database/migrations/2026_05_02_000001_create_moderation_cases_table.php
+++ b/app-modules/moderation/database/migrations/2026_05_02_000001_create_moderation_cases_table.php
@@ -2,6 +2,12 @@
 
 declare(strict_types=1);
 
+use He4rt\Moderation\Enums\ActionType;
+use He4rt\Moderation\Enums\CaseSource;
+use He4rt\Moderation\Enums\CaseStatus;
+use He4rt\Moderation\Enums\Platform;
+use He4rt\Moderation\Enums\Severity;
+use He4rt\Moderation\Enums\ViolationType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -15,15 +21,15 @@ return new class extends Migration
             $table->string('content_type', 50);
             $table->string('content_id', 255);
             $table->jsonb('content_snapshot')->nullable();
-            $table->string('source_platform', 20);
-            $table->string('source', 20);
-            $table->string('status', 20)->default('pending');
+            $table->string('source_platform', 20)->comment(Platform::stringifyCases());
+            $table->string('source', 20)->comment(CaseSource::stringifyCases());
+            $table->string('status', 20)->default('pending')->comment(CaseStatus::stringifyCases());
             $table->integer('priority')->default(50);
-            $table->string('severity', 20)->nullable();
-            $table->string('violation_type', 30)->nullable();
+            $table->string('severity', 20)->nullable()->comment(Severity::stringifyCases());
+            $table->string('violation_type', 30)->nullable()->comment(ViolationType::stringifyCases());
             $table->jsonb('ai_scores')->nullable();
             $table->string('classifier_version', 50)->nullable();
-            $table->string('suggested_action', 30)->nullable();
+            $table->string('suggested_action', 30)->nullable()->comment(ActionType::stringifyCases());
             $table->foreignUuid('assigned_to')->nullable()->constrained('users')->nullOnDelete();
             $table->timestampTz('assigned_at')->nullable();
             $table->timestampTz('resolved_at')->nullable();

--- a/app-modules/moderation/database/migrations/2026_05_02_000002_create_moderation_reports_table.php
+++ b/app-modules/moderation/database/migrations/2026_05_02_000002_create_moderation_reports_table.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use He4rt\Moderation\Enums\Platform;
+use He4rt\Moderation\Enums\ViolationType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,9 +16,9 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('case_id')->constrained('moderation_cases')->cascadeOnDelete();
             $table->foreignUuid('reporter_id')->constrained('users')->cascadeOnDelete();
-            $table->string('reason', 30);
+            $table->string('reason', 30)->comment(ViolationType::stringifyCases());
             $table->text('details')->nullable();
-            $table->string('platform', 20);
+            $table->string('platform', 20)->comment(Platform::stringifyCases());
             $table->timestampTz('created_at')->useCurrent();
 
             $table->index(['case_id', 'reporter_id'], 'idx_reports_case_reporter');

--- a/app-modules/moderation/database/migrations/2026_05_02_000003_create_moderation_actions_table.php
+++ b/app-modules/moderation/database/migrations/2026_05_02_000003_create_moderation_actions_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Moderation\Enums\ActionType;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -14,7 +15,7 @@ return new class extends Migration
             $table->uuid('id')->primary();
             $table->foreignUuid('case_id')->constrained('moderation_cases')->cascadeOnDelete();
             $table->foreignUuid('moderator_id')->nullable()->constrained('users')->nullOnDelete();
-            $table->string('action_type', 30);
+            $table->string('action_type', 30)->comment(ActionType::stringifyCases());
             $table->jsonb('target_platforms');
             $table->string('duration', 20)->nullable();
             $table->text('reason')->nullable();

--- a/app-modules/moderation/database/migrations/2026_05_02_000004_create_moderation_appeals_table.php
+++ b/app-modules/moderation/database/migrations/2026_05_02_000004_create_moderation_appeals_table.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use He4rt\Moderation\Enums\AppealStatus;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -16,7 +17,7 @@ return new class extends Migration
             $table->foreignUuid('appellant_id')->constrained('users')->cascadeOnDelete();
             $table->string('reason_category', 50);
             $table->text('reason_text')->nullable();
-            $table->string('status', 20)->default('pending');
+            $table->string('status', 20)->default('pending')->comment(AppealStatus::stringifyCases());
             $table->foreignUuid('reviewer_id')->nullable()->constrained('users')->nullOnDelete();
             $table->text('reviewer_notes')->nullable();
             $table->timestampTz('resolved_at')->nullable();

--- a/app-modules/moderation/src/Enums/ActionType.php
+++ b/app-modules/moderation/src/Enums/ActionType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum ActionType: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Warn = 'warn';
     case Mute = 'mute';
     case Kick = 'kick';

--- a/app-modules/moderation/src/Enums/AppealStatus.php
+++ b/app-modules/moderation/src/Enums/AppealStatus.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum AppealStatus: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Pending = 'pending';
     case Reviewing = 'reviewing';
     case Upheld = 'upheld';

--- a/app-modules/moderation/src/Enums/CaseSource.php
+++ b/app-modules/moderation/src/Enums/CaseSource.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum CaseSource: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case UserReport = 'user_report';
     case AutoDetect = 'auto_detect';
     case RuleMatch = 'rule_match';

--- a/app-modules/moderation/src/Enums/CaseStatus.php
+++ b/app-modules/moderation/src/Enums/CaseStatus.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum CaseStatus: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Pending = 'pending';
     case Assigned = 'assigned';
     case Resolved = 'resolved';

--- a/app-modules/moderation/src/Enums/Platform.php
+++ b/app-modules/moderation/src/Enums/Platform.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum Platform: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Discord = 'discord';
     case Twitch = 'twitch';
     case GitHub = 'github';

--- a/app-modules/moderation/src/Enums/Severity.php
+++ b/app-modules/moderation/src/Enums/Severity.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum Severity: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Low = 'low';
     case Medium = 'medium';
     case High = 'high';

--- a/app-modules/moderation/src/Enums/ViolationType.php
+++ b/app-modules/moderation/src/Enums/ViolationType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Moderation\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum ViolationType: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Spam = 'spam';
     case Toxicity = 'toxicity';
     case Harassment = 'harassment';

--- a/app-modules/profile/database/migrations/2026_05_21_000000_create_user_profiles_table.php
+++ b/app-modules/profile/database/migrations/2026_05_21_000000_create_user_profiles_table.php
@@ -2,6 +2,8 @@
 
 declare(strict_types=1);
 
+use He4rt\Profile\Enums\SeniorityLevel;
+use He4rt\Profile\Enums\StartAvailability;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;
@@ -19,11 +21,11 @@ return new class extends Migration
             $table->date('birthdate')->nullable();
             $table->text('about')->nullable();
             $table->string('headline')->nullable();
-            $table->string('seniority_level', 30)->nullable();
+            $table->string('seniority_level', 30)->nullable()->comment(SeniorityLevel::stringifyCases());
             $table->smallInteger('years_experience')->nullable();
             $table->jsonb('social_links')->nullable();
             $table->boolean('available_for_proposals')->default(value: false);
-            $table->string('start_availability', 30)->nullable();
+            $table->string('start_availability', 30)->nullable()->comment(StartAvailability::stringifyCases());
             $table->timestampsTz();
 
             $table->unique(['user_id', 'tenant_id']);

--- a/app-modules/profile/src/Enums/SeniorityLevel.php
+++ b/app-modules/profile/src/Enums/SeniorityLevel.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Profile\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum SeniorityLevel: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Junior = 'junior';
     case Mid = 'mid';
     case Senior = 'senior';

--- a/app-modules/profile/src/Enums/StartAvailability.php
+++ b/app-modules/profile/src/Enums/StartAvailability.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\Profile\Enums;
 
+use App\Enums\Concerns\StringifyEnum;
 use Filament\Support\Colors\Color;
 use Filament\Support\Contracts\HasColor;
 use Filament\Support\Contracts\HasIcon;
@@ -12,6 +13,8 @@ use Filament\Support\Icons\Heroicon;
 
 enum StartAvailability: string implements HasColor, HasIcon, HasLabel
 {
+    use StringifyEnum;
+
     case Immediate = 'immediate';
     case OneWeek = '1_week';
     case TwoWeeks = '2_weeks';

--- a/app/Enums/Concerns/StringifyEnum.php
+++ b/app/Enums/Concerns/StringifyEnum.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Enums\Concerns;
+
+use BackedEnum;
+use UnitEnum;
+
+trait StringifyEnum
+{
+    public static function stringifyCases(string $context = 'Available enum cases'): string
+    {
+        $cases = collect(self::cases())
+            ->implode(fn (BackedEnum|UnitEnum $enum) => $enum->value, ', ');
+
+        return sprintf('%s: %s', $context, $cases);
+    }
+}


### PR DESCRIPTION
## Why

Enum-backed `string` columns in our migrations gave the database no hint about which values are valid — you had to open the PHP enum to know. This PR makes the schema self-documenting: every persisted enum column now carries a Postgres `COMMENT` listing its valid cases, generated from a single source of truth.

## What

- **New trait** `App\Enums\Concerns\StringifyEnum` exposing `stringifyCases()`, which renders `Available enum cases: a, b, c` from the enum's own cases.
- Applied the trait to **25 string-backed enums** that are actually persisted to the DB (verified via model `casts()` → table → migration).
- Added `->comment(Enum::stringifyCases())` to **28 migration columns** across those tables.

### Modules touched
`activity`, `moderation`, `identity`, `profile`, `community`, `economy`, `integration-discord`, `integration-twitch`, `integration-github`.

### Intentionally skipped (not persisted)
Pure logic/UI enums never stored in a column: `FilamentPanel`, `OAuthIntent`, `VoiceStatesEnum`, `SourceBot`, `TwitchEventSubType`, `SocialPlatform`, and the `docs` Discovery enums (`AdrStatus`, `DocumentTier`, `DocumentType`, `PlanStatus`).

## Guarantees

- **No behavior change** — defaults, column types, and nullability are untouched; only `->comment(...)` was appended.
- Comments only affect freshly-run migrations; existing databases are unaffected until re-migrated.

## Verification

- `vendor/bin/pint` — passed
- `php artisan migrate:fresh --env=testing` — all migrations run clean
- Confirmed comments land in Postgres with the correct format, e.g.:
  - `interactions.status` → `Available enum cases: pending, auto_approved, in_review, approved, rejected`
  - `external_identities.provider` → `Available enum cases: discord, twitch, devto, ...`
- PHPStan: no new errors introduced (the 4 pre-existing errors in `integration-whatsapp/WhatsAppEventLog.php` are unrelated to this PR).