### PR TITLE
docs(docs):preencher páginas de introdução com dados da comunidade

### DIFF
--- a/docs/introduction/como-participar.md
+++ b/docs/introduction/como-participar.md
@@ -4,7 +4,7 @@ title: Como participar
 order: 5
 ---
 
-> ⚠️ Rascunho — revisar com a comunidade (datas/números/fatos são placeholders).
+
 
 # Como participar
 
@@ -15,12 +15,12 @@ passos para fazer parte da comunidade e começar a aprender e construir junto.
 
 O Discord é o ponto de encontro da comunidade. É lá que acontecem as conversas
 do dia a dia, os avisos e as reuniões.
-[a confirmar: link oficial de convite do servidor no Discord.]
+(https://discord.gg/he4rt)
 
 ## 2. Se apresente
 
-Depois de entrar, passe pelo canal de boas-vindas
-**[a confirmar: nome do canal]** e conte um pouco sobre você: o que faz, o que
+Depois de entrar, passe pelo canal de boas-vindas:
+ **apresentações** e conte um pouco sobre você: o que faz, o que
 está estudando e o que te trouxe até aqui. A comunidade adora conhecer gente
 nova.
 
@@ -34,7 +34,7 @@ conhecer pessoas e entrar no ritmo da comunidade. Veja os detalhes na página
 
 A He4rt mantém projetos open source feitos pela comunidade. Você pode contribuir
 com código, documentação, ideias ou ajudando outras pessoas.
-[a confirmar: link para os repositórios / organização no GitHub.]
+(https://github.com/orgs/he4rt/repositories)
 
 ## 5. Conecte sua conta na plataforma
 
@@ -45,8 +45,5 @@ pontos e desbloquear conquistas.
 ## Precisa de ajuda?
 
 Se ficar com qualquer dúvida, pergunte nos canais da comunidade — sempre tem
-alguém disposto a ajudar.
-[a confirmar: canal de suporte / dúvidas.]
-
-> Os links e nomes de canais acima são placeholders. Confirme cada um com a
-> comunidade antes de publicar esta página.
+alguém disposto a ajudar. 
+Canal de suporte / dúvidas: **fórum-de-ajuda**.

--- a/docs/introduction/marcos-e-conquistas.md
+++ b/docs/introduction/marcos-e-conquistas.md
@@ -4,7 +4,7 @@ title: Marcos e conquistas
 order: 2
 ---
 
-> ⚠️ Rascunho — revisar com a comunidade (datas/números/fatos são placeholders).
+
 
 # Marcos e conquistas
 
@@ -16,33 +16,32 @@ projetos que hoje conectam centenas de pessoas desenvolvedoras pelo Brasil.
 
 A He4rt nasceu da vontade de criar um espaço acolhedor onde quem está começando
 e quem já tem experiência pudessem aprender em conjunto, sem barreiras. O que
-começou como um grupo pequeno [a confirmar: ano de fundação] foi ganhando vida a
+começou como um grupo pequeno 2018 foi ganhando vida a
 cada conversa, live e projeto compartilhado.
 
 ## Linha do tempo
 
-> Os marcos abaixo são exemplos a serem validados com quem viveu cada um deles.
 
-- **[a confirmar: ano]** — Primeiros encontros e formação do núcleo da
+
+- 2018 — Primeiros encontros e formação do núcleo da
   comunidade.
-- **[a confirmar: ano]** — Lançamento do servidor no Discord como ponto central
+- 2018 — Lançamento do servidor no Discord como ponto central
   de convivência.
-- **[a confirmar: ano]** — Início das reuniões semanais abertas a toda a
+- 2018 — Início das reuniões semanais abertas a toda a
   comunidade.
-- **[a confirmar: ano]** — Primeiros projetos open source mantidos pela
+- 2020 — Primeiros projetos open source mantidos pela
   comunidade.
-- **[a confirmar: ano]** — Construção da plataforma he4rtdevs.com e do sistema de
+- 2020 — Construção da plataforma he4rtdevs.com e do sistema de
   gamificação.
 
 ## Em números
 
-> Todos os números abaixo são placeholders e precisam ser confirmados com dados
-> reais antes da publicação.
 
-- **[a confirmar]** pessoas na comunidade.
+
+- 25.040 pessoas na comunidade.
 - **[a confirmar]** reuniões semanais realizadas.
-- **[a confirmar]** projetos open source publicados.
-- **[a confirmar]** contribuidores ativos na plataforma.
+- 39 projetos open source publicados.
+- 21 contribuidores ativos na plataforma.
 
 ## O que vem por aí
 

--- a/docs/introduction/nossos-valores.md
+++ b/docs/introduction/nossos-valores.md
@@ -4,13 +4,11 @@ title: Nossos valores
 order: 4
 ---
 
-> ⚠️ Rascunho — revisar com a comunidade (datas/números/fatos são placeholders).
+
 
 # Nossos valores
 
-Mais do que código, a He4rt Developers é feita de pessoas. Os valores abaixo são
-uma proposta de como enxergamos a convivência na comunidade — e precisam ser
-revisados e aprovados por quem faz a He4rt acontecer.
+Mais do que código, a He4rt Developers é feita de pessoas. Os valores abaixo guiam como vivemos a convivência na comunidade.
 
 ## Acolhimento
 
@@ -32,13 +30,10 @@ aberta, o open source e o crédito a quem contribui.
 
 A He4rt é um espaço para todas as pessoas. Não há lugar para preconceito,
 assédio ou qualquer forma de discriminação.
-[a confirmar: link para o Código de Conduta oficial da comunidade.]
+(https://github.com/he4rt/docs/blob/main/subpage/code-of-conduct.md)
 
 ## Transparência
 
 Decisões importantes são discutidas abertamente com a comunidade. Esta própria
 documentação é um exemplo: tudo aqui pode ser revisado e melhorado.
 
-> Estes valores são um rascunho inicial. A redação final deve sair de uma
-> conversa com a comunidade — possivelmente referenciando um Código de Conduta
-> formal [a confirmar].

--- a/docs/introduction/reunioes-semanais.md
+++ b/docs/introduction/reunioes-semanais.md
@@ -4,7 +4,7 @@ title: Reuniões semanais
 order: 3
 ---
 
-> ⚠️ Rascunho — revisar com a comunidade (datas/números/fatos são placeholders).
+
 
 # Reuniões semanais
 
@@ -14,21 +14,20 @@ aprendizados, mostrar projetos e simplesmente estar junto.
 
 ## Quando acontecem
 
-As reuniões acontecem toda semana, **[a confirmar: dia da semana]** às
-**[a confirmar: horário, fuso de Brasília]**. O encontro é aberto a qualquer
+As reuniões acontecem toda semana, segunda-feira às
+22h, horário de Brasília. O encontro é aberto a qualquer
 pessoa da comunidade — não importa se você é iniciante ou já trabalha na área há
 anos.
 
 ## Onde acontecem
 
-Os encontros são realizados no **[a confirmar: canal de voz do Discord / outra
-plataforma]**. O link e os lembretes são divulgados nos canais da comunidade
+Os encontros são realizados no canal de voz **apresentações** do servidor 
+no Discord. O link e os lembretes são divulgados nos canais da comunidade
 antes de cada reunião.
 
 ## Como costuma ser
 
-> O formato abaixo é uma descrição plausível a ser validada com quem organiza os
-> encontros.
+
 
 - **Boas-vindas e novidades** — atualizações da comunidade e recados.
 - **Tema da semana** — alguém apresenta um assunto, projeto ou aprendizado.
@@ -40,6 +39,3 @@ antes de cada reunião.
 Não é preciso se inscrever nem preparar nada. Basta entrar no canal no horário
 combinado, ligar (ou não) o microfone e participar no seu ritmo. Quem preferir
 só ouvir também é muito bem-vindo.
-
-> Se você organiza ou participa das reuniões, ajude a confirmar dia, horário,
-> plataforma e formato para que esta página reflita a realidade da comunidade.


### PR DESCRIPTION
Preenche as 5 páginas de introdução da documentação (issue #336).
Dados levantados via documentação legada, Discord e GitHub da organização.
Pendente: query SQL para número de reuniões realizadas (a confirmar com a equipe).
Estimativas: número de projetos open source e contribuidores ativos baseados nos repositórios públicos de github.com/he4rt.