### PR TITLE
feat(portal): add Instagram to /redes social links

### DIFF
--- a/app-modules/portal/src/Livewire/SocialLinksPage.php
+++ b/app-modules/portal/src/Livewire/SocialLinksPage.php
@@ -24,6 +24,7 @@ final class SocialLinksPage extends Component
             new SocialLink('X (Twitter)', 'https://x.com/He4rtDevs', 'fab-x-twitter', '#FFFFFF'),
             new SocialLink('LinkedIn', 'https://www.linkedin.com/company/he4rt/', 'fab-linkedin', '#0A66C2'),
             new SocialLink('WhatsApp', 'https://chat.whatsapp.com/EBKjYxIodpe1x5LLExbTzK', 'fab-whatsapp', '#25D366'),
+            new SocialLink('Instagram', 'https://www.instagram.com/heartdevs/', 'fab-instagram', '#E4405F'),
             new SocialLink('GitHub', 'https://github.com/he4rt', 'fab-github', '#FFFFFF'),
         ];
     }

--- a/app-modules/portal/tests/Feature/SocialLinksPageTest.php
+++ b/app-modules/portal/tests/Feature/SocialLinksPageTest.php
@@ -14,7 +14,7 @@ it('resolve a rota nomeada social-links para /redes', function (): void {
     expect(route('social-links', absolute: false))->toBe('/redes');
 });
 
-it('renderiza os cinco links com rótulos e URLs corretas', function (): void {
+it('renderiza os seis links com rótulos e URLs corretas', function (): void {
     $assertion = get('/redes')
         ->assertOk();
 
@@ -28,8 +28,8 @@ it('renderiza os cinco links com rótulos e URLs corretas', function (): void {
 it('abre cada link externo em nova aba com rel seguro', function (): void {
     $html = get('/redes')->getContent();
 
-    expect(mb_substr_count($html, 'target="_blank"'))->toBe(5);
-    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(5);
+    expect(mb_substr_count($html, 'target="_blank"'))->toBe(6);
+    expect(mb_substr_count($html, 'rel="noopener noreferrer"'))->toBe(6);
 });
 
 it('exibe o logo He4rt animado', function (): void {
@@ -40,7 +40,7 @@ it('exibe o título e o acento de marca de cada link', function (): void {
     $html = get('/redes')->getContent();
 
     expect($html)->toContain('Escolha seu canal');
-    expect(mb_substr_count($html, '--accent:'))->toBe(5);
+    expect(mb_substr_count($html, '--accent:'))->toBe(6);
 });
 
 it('expõe o link de Redes sociais na navbar', function (): void {


### PR DESCRIPTION
## Contexto

A página de link-tree de redes sociais (`/redes`, módulo `portal`) foi introduzida no #340, mas ficou sem o perfil do **Instagram** ([@heartdevs](https://www.instagram.com/heartdevs/)). Este PR adiciona o link na mesma lista.

Arquivos afetados:
- `app-modules/portal/src/Livewire/SocialLinksPage.php` — novo `SocialLink` do Instagram entre WhatsApp e GitHub.
- `app-modules/portal/tests/Feature/SocialLinksPageTest.php` — contagens fixas atualizadas de 5 → 6 links.

## New

```php
+ new SocialLink('Instagram', 'https://www.instagram.com/heartdevs/', 'fab-instagram', '#E4405F'),
```
