### PR TITLE
feat(integration-github): add repository purpose filtering

### DIFF
--- a/app-modules/integration-github/database/factories/GithubRepositoryFactory.php
+++ b/app-modules/integration-github/database/factories/GithubRepositoryFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\IntegrationGithub\Database\Factories;
 
 use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\IntegrationGithub\Enums\PurposeType;
 use He4rt\IntegrationGithub\Models\GithubRepository;
 use Illuminate\Database\Eloquent\Factories\Factory;
 
@@ -25,6 +26,7 @@ final class GithubRepositoryFactory extends Factory
             'full_name' => 'he4rt/'.fake()->unique()->slug(2),
             'enabled' => true,
             'last_backfilled_at' => null,
+            'purpose' => PurposeType::Contributions->value,
         ];
     }
 

--- a/app-modules/integration-github/database/migrations/2026_06_24_125428_add_purpose_to_github_repositories_table.php
+++ b/app-modules/integration-github/database/migrations/2026_06_24_125428_add_purpose_to_github_repositories_table.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('github_repositories', static function (Blueprint $table): void {
+            $table->string('purpose')->default('contributions');
+        });
+    }
+};

--- a/app-modules/integration-github/database/migrations/2026_06_24_125428_add_purpose_to_github_repositories_table.php
+++ b/app-modules/integration-github/database/migrations/2026_06_24_125428_add_purpose_to_github_repositories_table.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -11,7 +12,9 @@ return new class extends Migration
     public function up(): void
     {
         Schema::table('github_repositories', static function (Blueprint $table): void {
-            $table->string('purpose')->default('contributions');
+            $table->string('purpose')->nullable();
         });
+
+        DB::table('github_repositories')->update(['purpose' => 'contributions']);
     }
 };

--- a/app-modules/integration-github/src/Enums/PurposeType.php
+++ b/app-modules/integration-github/src/Enums/PurposeType.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\IntegrationGithub\Enums;
+
+enum PurposeType: string
+{
+    case Contributions = 'contributions';
+    case Challenge = 'challenge';
+}

--- a/app-modules/integration-github/src/Models/GithubRepository.php
+++ b/app-modules/integration-github/src/Models/GithubRepository.php
@@ -21,6 +21,7 @@ use Illuminate\Support\Str;
  * @property string $tenant_id
  * @property string $full_name
  * @property bool $enabled
+ * @property string $purpose
  * @property CarbonInterface|null $last_backfilled_at
  * @property CarbonInterface|null $created_at
  * @property CarbonInterface|null $updated_at

--- a/app-modules/integration-github/src/Models/GithubRepository.php
+++ b/app-modules/integration-github/src/Models/GithubRepository.php
@@ -77,6 +77,7 @@ final class GithubRepository extends Model
         return [
             'enabled' => 'boolean',
             'last_backfilled_at' => 'datetime',
+            'purpose' => PurposeType::class,
         ];
     }
 }

--- a/app-modules/integration-github/src/Models/GithubRepository.php
+++ b/app-modules/integration-github/src/Models/GithubRepository.php
@@ -7,6 +7,7 @@ namespace He4rt\IntegrationGithub\Models;
 use Carbon\CarbonInterface;
 use He4rt\Identity\Tenant\Models\Tenant;
 use He4rt\IntegrationGithub\Database\Factories\GithubRepositoryFactory;
+use He4rt\IntegrationGithub\Enums\PurposeType;
 use Illuminate\Database\Eloquent\Attributes\Table;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;

--- a/app-modules/integration-github/src/Models/GithubRepository.php
+++ b/app-modules/integration-github/src/Models/GithubRepository.php
@@ -21,7 +21,7 @@ use Illuminate\Support\Str;
  * @property string $tenant_id
  * @property string $full_name
  * @property bool $enabled
- * @property string $purpose
+ * @property PurposeType $purpose
  * @property CarbonInterface|null $last_backfilled_at
  * @property CarbonInterface|null $created_at
  * @property CarbonInterface|null $updated_at

--- a/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
+++ b/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
@@ -56,6 +56,7 @@ final readonly class ProjectGithubEvent
         return array_values(GithubRepository::query()
             ->enabled()
             ->where('full_name', $repo)
+            ->where('purpose', 'contributions')
             ->pluck('tenant_id')
             ->map(static fn (mixed $tenantId): string => (string) $tenantId)
             ->all());

--- a/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
+++ b/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
@@ -7,6 +7,7 @@ namespace He4rt\IntegrationGithub\Webhook;
 use He4rt\IntegrationGithub\Contributions\DTOs\NewContributionDTO;
 use He4rt\IntegrationGithub\Contributions\RecordContribution;
 use He4rt\IntegrationGithub\Enums\ContributionType;
+use He4rt\IntegrationGithub\Enums\PurposeType;
 use He4rt\IntegrationGithub\Models\GithubRepository;
 use Illuminate\Support\Str;
 
@@ -56,7 +57,7 @@ final readonly class ProjectGithubEvent
         return array_values(GithubRepository::query()
             ->enabled()
             ->where('full_name', $repo)
-            ->where('purpose', 'contributions')
+            ->where('purpose', PurposeType::Contributions->value)
             ->pluck('tenant_id')
             ->map(static fn (mixed $tenantId): string => (string) $tenantId)
             ->all());

--- a/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
+++ b/app-modules/integration-github/src/Webhook/ProjectGithubEvent.php
@@ -57,7 +57,7 @@ final readonly class ProjectGithubEvent
         return array_values(GithubRepository::query()
             ->enabled()
             ->where('full_name', $repo)
-            ->where('purpose', PurposeType::Contributions->value)
+            ->where('purpose', PurposeType::Contributions)
             ->pluck('tenant_id')
             ->map(static fn (mixed $tenantId): string => (string) $tenantId)
             ->all());

--- a/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
+++ b/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
@@ -159,3 +159,41 @@ it('projeta issues e pushes (commits)', function (): void {
     expect(GithubContribution::query()->where('external_ref', 'issue:10')->exists())->toBeTrue()
         ->and(GithubContribution::query()->where('external_ref', 'commit:sha1')->exists())->toBeTrue();
 });
+
+it('grava no lake mas NÃO projeta contribuição para repo de challenge', function (): void {
+    Event::fake([GithubContributionRecorded::class]);
+
+    GithubRepository::factory()->create([
+        'full_name' => 'he4rt/heartdevs.com',
+        'purpose' => 'challenge',
+    ]);
+
+    postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();
+
+    expect(GithubEventLog::query()->count())->toBe(1)
+        ->and(GithubContribution::query()->count())->toBe(0);
+
+    Event::assertNotDispatched(GithubContributionRecorded::class);
+});
+
+it('grava no lake e projeta a contribuição para repo de contributions, emitindo o evento', function (): void {
+    Event::fake([GithubContributionRecorded::class]);
+
+    $repo = GithubRepository::factory()->create([
+        'full_name' => 'he4rt/heartdevs.com',
+        'purpose' => 'contributions',
+    ]);
+
+    postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();
+
+    expect(GithubEventLog::query()->count())->toBe(1);
+
+    $contribution = GithubContribution::query()->where('external_ref', 'pr:1')->sole();
+
+    expect($contribution->type)->toBe(ContributionType::Pr)
+        ->and($contribution->tenant_id)->toBe($repo->tenant_id)
+        ->and($contribution->actor_login)->toBe('maria')
+        ->and($contribution->metadata['additions'])->toBe(5);
+
+    Event::assertDispatched(GithubContributionRecorded::class);
+});

--- a/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
+++ b/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
@@ -3,6 +3,7 @@
 declare(strict_types=1);
 
 use He4rt\IntegrationGithub\Enums\ContributionType;
+use He4rt\IntegrationGithub\Enums\PurposeType;
 use He4rt\IntegrationGithub\Events\GithubContributionRecorded;
 use He4rt\IntegrationGithub\Models\GithubContribution;
 use He4rt\IntegrationGithub\Models\GithubEventLog;
@@ -165,7 +166,7 @@ it('grava no lake mas NÃO projeta contribuição para repo de challenge', funct
 
     GithubRepository::factory()->create([
         'full_name' => 'he4rt/heartdevs.com',
-        'purpose' => 'challenge',
+        'purpose' => PurposeType::Challenge->value,
     ]);
 
     postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();
@@ -181,7 +182,7 @@ it('grava no lake e projeta a contribuição para repo de contributions, emitind
 
     $repo = GithubRepository::factory()->create([
         'full_name' => 'he4rt/heartdevs.com',
-        'purpose' => 'contributions',
+        'purpose' => PurposeType::Contributions->value,
     ]);
 
     postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();

--- a/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
+++ b/app-modules/integration-github/tests/Feature/GithubWebhookTest.php
@@ -166,7 +166,7 @@ it('grava no lake mas NÃO projeta contribuição para repo de challenge', funct
 
     GithubRepository::factory()->create([
         'full_name' => 'he4rt/heartdevs.com',
-        'purpose' => PurposeType::Challenge->value,
+        'purpose' => PurposeType::Challenge,
     ]);
 
     postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();
@@ -182,7 +182,7 @@ it('grava no lake e projeta a contribuição para repo de contributions, emitind
 
     $repo = GithubRepository::factory()->create([
         'full_name' => 'he4rt/heartdevs.com',
-        'purpose' => PurposeType::Contributions->value,
+        'purpose' => PurposeType::Contributions,
     ]);
 
     postGithubWebhook('pull_request', prWebhookPayload())->assertSuccessful();


### PR DESCRIPTION
## Contexto

- Foi adicionado o campo `purpose` em `github_repositories`
- `contributions` definido como valor padrão
- Filtro colocado impedindo que repositórios com `purpose = challenge` gerem contribuições
- Mantém o comportamento atual para repositórios com `purpose = contributions`
- Adiciona testes para os dois cenários (`contributions` e `challenge`)

Closes #344