### PR TITLE
ci: gate feat/squads PRs, drop push trigger

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,8 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [4.x]
   pull_request:
-    branches: [4.x]
+    branches: [4.x, feat/squads]
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## Summary
- Run the CI pipeline on PRs targeting `feat/squads` so the long-term integration branch gets the same required checks (Pint, Rector, PHPStan, Pest) as `4.x`.
- Drop the `push` trigger entirely — Forge deploys on push, so a post-merge CI run can't gate anything. With `strict` required status checks now enforced in the ruleset, the PR run is the complete merge gate.