### PR TITLE
ci: sync pipeline gate into feat/squads

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,10 +1,8 @@
 name: Continuous Integration
 
 on:
-  push:
-    branches: [4.x]
   pull_request:
-    branches: [4.x]
+    branches: [4.x, feat/squads]
     types: [opened, reopened, synchronize, ready_for_review]
 
 concurrency:


### PR DESCRIPTION
## Summary
- Sync `4.x` → `feat/squads` so the integration branch is current before the squad-team starts work.
- Brings in #379: CI runs on PRs targeting `feat/squads` (Pint, Rector, PHPStan, Pest), and the `push` trigger is dropped (Forge deploys on push; `strict` required checks make the PR run the full gate).

Only delta between the branches — `feat/squads` had no independent commits yet, so this brings it level with `4.x`.