### PR TITLE
feature(hero): add cta to /docs

### DIFF
--- a/app-modules/portal/resources/views/sections/hero.blade.php
+++ b/app-modules/portal/resources/views/sections/hero.blade.php
@@ -46,8 +46,32 @@
                     </span>
                 </div>
             </div>
-            <div class="flex min-w-0 flex-col items-center justify-center">
+            <div class="flex min-w-0 flex-col items-center justify-center gap-6">
                 <x-portal::terminal :stats="$this->terminalStats" />
+
+                <x-he4rt::card
+                    href="/docs"
+                    density="compact"
+                    class="h-auto w-full max-w-md shadow-lg lg:max-w-lg"
+                    aria-label="Abrir documentação da comunidade"
+                >
+                    <div class="flex items-center gap-4">
+                        <div class="text-primary flex h-12 w-12 shrink-0 items-center justify-center rounded-full border border-current/15 bg-current/8">
+                            <x-filament::icon icon="heroicon-o-light-bulb" class="h-6 w-6" />
+                        </div>
+
+                        <div class="min-w-0 flex-1">
+                            <p class="text-text-high text-base font-semibold">
+                                Novo por aqui?
+                            </p>
+                            <p class="text-text-medium text-sm">
+                                Confira nossa documentação e descubra como participar.
+                            </p>
+                        </div>
+
+                        <x-filament::icon icon="heroicon-o-chevron-right" class="text-primary h-5 w-5 shrink-0" />
+                    </div>
+                </x-he4rt::card>
             </div>
         </div>
     </div>


### PR DESCRIPTION
## Contexto

A página inicial da comunidade reúne diversos acessos importantes, porém o link para a documentação (`/docs`) não estava em destaque, o que pode dificultar que novos membros descobrissem um dos principais recursos da plataforma.

Este PR adiciona um **Call to Action (CTA)** para a documentação na landing page da comunidade, tornando o acesso mais visível e incentivando os usuários a explorarem os guias, tutoriais e demais conteúdos disponíveis.

### Arquivos afetados

- `app-modules/portal/resources/views/sections/hero.blade.php` — adiciona um CTA para `/docs` na landing page da comunidade.

### Alterações

- Novo botão/CTA direcionando para `/docs`.
- Ajuste da interface para destacar a documentação como um dos principais pontos de entrada da comunidade.

### ANTES
<img width="1919" height="866" alt="image" src="https://github.com/user-attachments/assets/0a40dd21-f36e-4721-93cc-38fba48b6281" />


### DEPOIS
<img width="1919" height="868" alt="image" src="https://github.com/user-attachments/assets/4f68c4ac-ab6d-4771-8dc0-7ac157fbabf2" />
