### PR TITLE
ci: rollout auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,20 @@
+name: Dependabot auto-merge
+
+on:
+  # zizmor: ignore[dangerous-triggers] — no PR code is executed, only metadata + API calls
+  pull_request_target:
+    branches: [4.x]
+
+permissions: {}
+
+jobs:
+  automerge:
+    name: Auto-merge Dependabot patch & minor
+    runs-on: ubuntu-latest
+    if: github.repository == 'he4rt/heartdevs.com' && github.event.pull_request.user.login == 'dependabot[bot]'
+    timeout-minutes: 5
+    permissions:
+      contents: write # squash-merge the PR
+      pull-requests: write # approve the PR
+    steps:
+      - uses: he4rt/.github/actions/dependabot-automerge@a22dd1afda63cd7a33308c3965c09064c518b304 # main


### PR DESCRIPTION
## Summary
- Add a caller workflow that reuses `he4rt/.github/actions/dependabot-automerge` to approve and squash-merge Dependabot **github-actions** patch/minor PRs. Majors and other ecosystems stay manual.
- Mirrors how this repo already consumes `he4rt/.github/actions/auto-assign`.

## Requires
- Org/repo setting **Allow GitHub Actions to create and approve pull requests** must be enabled (used by the approve step).