### PR TITLE
fix(hero): add terminal component a default height

### DIFF
--- a/app-modules/portal/resources/views/components/terminal.blade.php
+++ b/app-modules/portal/resources/views/components/terminal.blade.php
@@ -61,18 +61,27 @@
             <span class="ml-2 text-xs text-gray-500">he4rt@dev ~</span>
         </div>
 
-        <div class="flex w-full flex-col gap-0.5 p-4 font-mono text-xs leading-tight sm:text-sm">
-            <template x-for="(line, i) in lines.slice(0, visible)" :key="i">
-                <div
-                    x-show="i < visible"
-                    x-transition:enter="transition duration-150"
-                    x-transition:enter-start="opacity-0 translate-y-1"
-                    x-transition:enter-end="opacity-100 translate-y-0"
-                    :class="[colorClass(line.type), line.type === 'blank' ? 'h-2' : '']"
-                >
-                    <span x-text="line.text"></span>
-                </div>
-            </template>
+        <div class="relative p-4 font-mono text-xs leading-tight sm:text-sm">
+            <div class="pointer-events-none invisible flex w-full flex-col gap-0.5" aria-hidden="true">
+                <template x-for="(line, i) in lines" :key="`ghost-${i}`">
+                    <div :class="[line.type === 'blank' ? 'h-2' : '']">
+                        <span x-text="line.text || ' '"></span>
+                    </div>
+                </template>
+            </div>
+
+            <div class="absolute inset-4 flex w-[calc(100%-2rem)] flex-col gap-0.5">
+                <template x-for="(line, i) in lines.slice(0, visible)" :key="i">
+                    <div
+                        x-transition:enter="transition duration-150"
+                        x-transition:enter-start="opacity-0 translate-y-1"
+                        x-transition:enter-end="opacity-100 translate-y-0"
+                        :class="[colorClass(line.type), line.type === 'blank' ? 'h-2' : '']"
+                    >
+                        <span x-text="line.text"></span>
+                    </div>
+                </template>
+            </div>
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Contexto

O componente de terminal iniciava com uma altura reduzida e aumentava gradualmente conforme a animação dos comandos era executada. Esse comportamento causava mudanças de layout (layout shift), prejudicando a experiência visual da página.

Este PR corrige a altura inicial do componente para que ela permaneça estável durante toda a animação.

### Arquivos afetados

- `app-modules/portal/resource/view/components/terminal.blade.php` — ajuste da altura inicial do componente de terminal.

### Alterações

- Definida uma altura inicial consistente para o terminal.
- Evitado o aumento progressivo da altura durante a animação dos comandos.
- Reduzido o layout shift, proporcionando uma experiência visual mais estável.

### ANTES
<img width="1280" height="579" alt="agora" src="https://github.com/user-attachments/assets/88b02cf5-c854-4073-bc85-31f2e91559aa" />


### DEPOIS
<img width="1280" height="579" alt="fix_terminal" src="https://github.com/user-attachments/assets/942aa745-4780-49cb-bd37-fb61219333a5" />
