### PR TITLE
fix(events): key application answers by a stable field id

### DIFF
--- a/app-modules/events/database/seeders/EventsSeeder.php
+++ b/app-modules/events/database/seeders/EventsSeeder.php
@@ -167,10 +167,10 @@ final class EventsSeeder extends Seeder
                 'cancellation_deadline_hours' => 48,
                 'xp' => [200, 300, 1_000],
                 'application_schema' => [
-                    ['type' => 'text',     'label' => 'Por que quer participar da He4rt Conf?', 'required' => true],
-                    ['type' => 'select',   'label' => 'Nível de experiência em desenvolvimento', 'required' => true, 'options' => ['Iniciante', 'Intermediário', 'Avançado']],
-                    ['type' => 'textarea', 'label' => 'Descreva um projeto pessoal ou open source relevante', 'required' => false],
-                    ['type' => 'checkbox', 'label' => 'Em quais dias você pode comparecer?', 'required' => false, 'options' => ['Dia 1', 'Dia 2', 'Dia 3']],
+                    ['key' => 'why_participate',    'type' => 'text',     'label' => 'Por que quer participar da He4rt Conf?', 'required' => true],
+                    ['key' => 'experience_level',   'type' => 'select',   'label' => 'Nível de experiência em desenvolvimento', 'required' => true, 'options' => ['Iniciante', 'Intermediário', 'Avançado']],
+                    ['key' => 'personal_project',   'type' => 'textarea', 'label' => 'Descreva um projeto pessoal ou open source relevante', 'required' => false],
+                    ['key' => 'attendance_days',    'type' => 'checkbox', 'label' => 'Em quais dias você pode comparecer?', 'required' => false, 'options' => ['Dia 1', 'Dia 2', 'Dia 3']],
                 ],
                 'enrollments' => [
                     EnrollmentStatus::Pending->value => 6,
@@ -265,8 +265,8 @@ final class EventsSeeder extends Seeder
                 'cancellation_deadline_hours' => 48,
                 'xp' => [100, 200, 800],
                 'application_schema' => [
-                    ['type' => 'text',   'label' => 'Qual ideia de projeto você traria para o hackathon?', 'required' => true],
-                    ['type' => 'select', 'label' => 'Stack principal', 'required' => true, 'options' => ['PHP', 'JavaScript', 'Python', 'Go', 'Rust', 'Outra']],
+                    ['key' => 'project_idea',    'type' => 'text',   'label' => 'Qual ideia de projeto você traria para o hackathon?', 'required' => true],
+                    ['key' => 'main_stack',      'type' => 'select', 'label' => 'Stack principal', 'required' => true, 'options' => ['PHP', 'JavaScript', 'Python', 'Go', 'Rust', 'Outra']],
                 ],
                 'enrollments' => [
                     EnrollmentStatus::Cancelled->value => 8,
@@ -427,7 +427,7 @@ final class EventsSeeder extends Seeder
 
     /**
      * @param  array<int, array<string, mixed>>|null  $schema
-     * @return array<int, mixed>|null
+     * @return array<string, mixed>|null
      */
     private function fakeApplicationData(?array $schema): ?array
     {
@@ -437,8 +437,8 @@ final class EventsSeeder extends Seeder
 
         $data = [];
 
-        foreach ($schema as $index => $field) {
-            $data[$index] = match ($field['type'] ?? 'text') {
+        foreach ($schema as $field) {
+            $data[$field['key']] = match ($field['type'] ?? 'text') {
                 'select' => fake()->randomElement($field['options'] ?? ['Opção A']),
                 'checkbox' => blank($field['options']) ? [] : fake()->randomElements($field['options'], fake()->numberBetween(1, count($field['options']))),
                 'textarea' => fake()->paragraph(),

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -203,7 +203,12 @@ final readonly class EnrollUserAction
     {
         foreach ($schema as $field) {
             $key = $field['key'] ?? null;
-            $value = $key !== null ? ($data[$key] ?? null) : null;
+
+            if ($key === null) {
+                continue;
+            }
+
+            $value = $data[$key] ?? null;
             $type = $field['type'] ?? '';
 
             if ($type === 'checkbox') {

--- a/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
+++ b/app-modules/events/src/Enrollment/Actions/EnrollUserAction.php
@@ -152,7 +152,7 @@ final readonly class EnrollUserAction
     }
 
     /**
-     * @param  array<int, mixed>|null  $applicationData
+     * @param  array<string, mixed>|null  $applicationData
      */
     private function validate(Event $event, ?EnrollmentPolicy $policy, string $userId, ?array $applicationData): void
     {
@@ -196,13 +196,14 @@ final readonly class EnrollUserAction
     }
 
     /**
-     * @param  array<int, mixed>  $data
+     * @param  array<string, mixed>  $data
      * @param  array<int, array<string, mixed>>  $schema
      */
     private function validateApplicationData(array $data, array $schema): void
     {
-        foreach ($schema as $index => $field) {
-            $value = $data[$index] ?? null;
+        foreach ($schema as $field) {
+            $key = $field['key'] ?? null;
+            $value = $key !== null ? ($data[$key] ?? null) : null;
             $type = $field['type'] ?? '';
 
             if ($type === 'checkbox') {

--- a/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
+++ b/app-modules/events/src/Enrollment/DTOs/EnrollUserDTO.php
@@ -10,7 +10,7 @@ use He4rt\Identity\User\Models\User;
 final readonly class EnrollUserDTO
 {
     /**
-     * @param  array<int, mixed>|null  $applicationData
+     * @param  array<string, mixed>|null  $applicationData
      */
     public function __construct(
         public string $eventId,

--- a/app-modules/events/src/Enrollment/Models/Enrollment.php
+++ b/app-modules/events/src/Enrollment/Models/Enrollment.php
@@ -27,7 +27,7 @@ use Illuminate\Database\Eloquent\Relations\HasOne;
  * @property EnrollmentStatus $status
  * @property bool $is_public
  * @property int|null $waitlist_position
- * @property array<int, mixed>|null $application_data
+ * @property array<string, mixed>|null $application_data
  * @property string|null $rejection_reason
  * @property Carbon|null $enrolled_at
  * @property Carbon|null $confirmed_at

--- a/app-modules/events/tests/Feature/EnrollUserActionTest.php
+++ b/app-modules/events/tests/Feature/EnrollUserActionTest.php
@@ -346,21 +346,21 @@ test('when a user submits an application, then enrollment is pending with applic
         ->upcoming()
         ->for($tenant)
         ->has(EnrollmentPolicy::factory()->application([
-            ['type' => 'text', 'label' => 'Why do you want to join?', 'required' => true],
+            ['key' => 'why_join', 'type' => 'text', 'label' => 'Why do you want to join?', 'required' => true],
         ]), 'enrollmentPolicy')
         ->create();
 
     $dto = new EnrollUserDTO(
         eventId: $event->id,
         userId: $user->id,
-        applicationData: [0 => 'I love PHP!'],
+        applicationData: ['why_join' => 'I love PHP!'],
     );
 
     $enrollment = resolve(EnrollUserAction::class)->handle($dto);
 
     expect($enrollment->status)->toBe(EnrollmentStatus::Pending)
         ->and($enrollment->confirmed_at)->toBeNull()
-        ->and($enrollment->application_data)->toBe([0 => 'I love PHP!']);
+        ->and($enrollment->application_data)->toBe(['why_join' => 'I love PHP!']);
 
     $transition = EnrollmentTransition::query()
         ->where('enrollment_id', $enrollment->id)
@@ -395,14 +395,14 @@ test('when application is missing a required field, then exception is thrown', f
         ->upcoming()
         ->for($tenant)
         ->has(EnrollmentPolicy::factory()->application([
-            ['type' => 'text', 'label' => 'Why?', 'required' => true],
+            ['key' => 'why', 'type' => 'text', 'label' => 'Why?', 'required' => true],
         ]), 'enrollmentPolicy')
         ->create();
 
     $dto = new EnrollUserDTO(
         eventId: $event->id,
         userId: $user->id,
-        applicationData: [0 => ''],
+        applicationData: ['why' => ''],
     );
 
     resolve(EnrollUserAction::class)->handle($dto);

--- a/app-modules/events/tests/Feature/Enrollment/ApproveApplicationActionTest.php
+++ b/app-modules/events/tests/Feature/Enrollment/ApproveApplicationActionTest.php
@@ -26,7 +26,7 @@ function createPendingApplicationEnrollment(Event $event, ?User $user = null): E
         'user_id' => $user->id,
         'status' => EnrollmentStatus::Pending,
         'enrolled_at' => now(),
-        'application_data' => [0 => 'My answer'],
+        'application_data' => ['q1' => 'My answer'],
     ]);
 }
 

--- a/app-modules/events/tests/Feature/Enrollment/RejectApplicationActionTest.php
+++ b/app-modules/events/tests/Feature/Enrollment/RejectApplicationActionTest.php
@@ -29,7 +29,7 @@ test('when an application is rejected with a reason, then enrollment transitions
         'user_id' => User::factory()->create()->id,
         'status' => EnrollmentStatus::Pending,
         'enrolled_at' => now(),
-        'application_data' => [0 => 'My answer'],
+        'application_data' => ['q1' => 'My answer'],
     ]);
 
     $result = resolve(RejectApplicationAction::class)->handle(
@@ -97,7 +97,7 @@ test('when application is rejected, then application_data is preserved', functio
         'user_id' => User::factory()->create()->id,
         'status' => EnrollmentStatus::Pending,
         'enrolled_at' => now(),
-        'application_data' => [0 => 'Original answer'],
+        'application_data' => ['q1' => 'Original answer'],
     ]);
 
     $result = resolve(RejectApplicationAction::class)->handle(
@@ -108,5 +108,5 @@ test('when application is rejected, then application_data is preserved', functio
         ),
     );
 
-    expect($result->application_data)->toBe([0 => 'Original answer']);
+    expect($result->application_data)->toBe(['q1' => 'Original answer']);
 });

--- a/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/RelationManagers/EnrollmentsRelationManager.php
@@ -118,13 +118,13 @@ final class EnrollmentsRelationManager extends RelationManager
             ->color('gray')
             ->visible(fn (Enrollment $record): bool => $record->application_data !== null)
             ->modalContent(static function (Enrollment $record): View {
-                $schema = $record->event?->enrollmentPolicy->application_schema ?? [];
+                $schema = $record->event?->enrollmentPolicy?->application_schema ?? [];
                 $data = $record->application_data ?? [];
 
                 $answers = collect($schema)
                     ->map(fn (array $field, int $index): array => [
                         'label' => $field['label'] ?? 'Question '.$index,
-                        'value' => $data[$index] ?? '—',
+                        'value' => $data[$field['key'] ?? null] ?? '—',
                     ])
                     ->values()
                     ->all();

--- a/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
+++ b/app-modules/panel-admin/src/Filament/Resources/Events/Schemas/EventForm.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace He4rt\PanelAdmin\Filament\Resources\Events\Schemas;
 
 use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Hidden;
 use Filament\Forms\Components\Repeater;
 use Filament\Forms\Components\Select;
 use Filament\Forms\Components\TagsInput;
@@ -21,6 +22,7 @@ use He4rt\Events\Event\Enums\EventStatus;
 use He4rt\Events\Event\Enums\EventType;
 use He4rt\Events\Event\Models\Event;
 use Illuminate\Support\Facades\Date;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Unique;
 
 final class EventForm
@@ -163,6 +165,8 @@ final class EventForm
                             ->reorderable()
                             ->collapsible()
                             ->schema([
+                                Hidden::make('key')
+                                    ->default(fn (): string => (string) Str::uuid()),
                                 Select::make('type')
                                     ->label('Type')
                                     ->options([

--- a/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
@@ -170,6 +170,7 @@
 
             <form wire:submit="apply" class="space-y-4">
                 @foreach ($this->event->enrollmentPolicy->application_schema ?? [] as $field)
+                    @continue(!isset($field['key']))
                     <div>
                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             {{ $field['label'] ?? '' }}

--- a/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
+++ b/app-modules/panel-app/resources/views/livewire/events/event-detail.blade.php
@@ -56,11 +56,11 @@
                         <p class="text-xs font-medium tracking-wide text-gray-400 uppercase">
                             {{ __('events::pages.application_your_answers') }}
                         </p>
-                        @foreach ($this->event->enrollmentPolicy->application_schema as $index => $field)
+                        @foreach ($this->event->enrollmentPolicy->application_schema as $field)
                             <div>
                                 <p class="text-xs text-gray-500 dark:text-gray-400">{{ $field['label'] ?? '' }}</p>
                                 <p class="text-sm text-gray-900 dark:text-white">
-                                    @php $answer = $this->enrollment->application_data[$index] ?? null; @endphp
+                                    @php $answer = $this->enrollment->application_data[$field['key'] ?? null] ?? null; @endphp
                                     @if (is_array($answer))
                                         {{ $answer !== [] ? implode(', ', $answer) : '—' }}
                                     @else
@@ -169,7 +169,7 @@
             <p class="mb-4 text-sm text-gray-600 dark:text-gray-300">{{ __('events::pages.apply_hint') }}</p>
 
             <form wire:submit="apply" class="space-y-4">
-                @foreach ($this->event->enrollmentPolicy->application_schema ?? [] as $index => $field)
+                @foreach ($this->event->enrollmentPolicy->application_schema ?? [] as $field)
                     <div>
                         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300">
                             {{ $field['label'] ?? '' }}
@@ -180,14 +180,14 @@
 
                         @if (($field['type'] ?? '') === 'textarea')
                             <textarea
-                                wire:model="applicationFormData.{{ $index }}"
+                                wire:model="applicationFormData.{{ $field['key'] }}"
                                 rows="3"
                                 class="focus:border-primary-500 focus:ring-primary-500 mt-1 block w-full rounded-lg border border-gray-300 p-2 text-sm shadow-sm dark:border-white/20 dark:bg-white/5 dark:text-white"
                                 @if ($field['required'] ?? false) required @endif
                             ></textarea>
                         @elseif (($field['type'] ?? '') === 'select')
                             <select
-                                wire:model="applicationFormData.{{ $index }}"
+                                wire:model="applicationFormData.{{ $field['key'] }}"
                                 class="focus:border-primary-500 focus:ring-primary-500 mt-1 block w-full rounded-lg border border-gray-300 p-2 text-sm shadow-sm dark:border-white/20 dark:bg-white/5 dark:text-white"
                                 @if ($field['required'] ?? false) required @endif
                             >
@@ -202,7 +202,7 @@
                                     <label class="flex items-center gap-2">
                                         <input
                                             type="checkbox"
-                                            wire:model="applicationFormData.{{ $index }}"
+                                            wire:model="applicationFormData.{{ $field['key'] }}"
                                             value="{{ $option }}"
                                             class="text-primary-600 focus:ring-primary-500 rounded border-gray-300"
                                         />
@@ -213,7 +213,7 @@
                         @else
                             <input
                                 type="text"
-                                wire:model="applicationFormData.{{ $index }}"
+                                wire:model="applicationFormData.{{ $field['key'] }}"
                                 class="focus:border-primary-500 focus:ring-primary-500 mt-1 block w-full rounded-lg border border-gray-300 p-2 text-sm shadow-sm dark:border-white/20 dark:bg-white/5 dark:text-white"
                                 @if ($field['required'] ?? false) required @endif
                             />

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -49,7 +49,7 @@ final class EventDetail extends Component
         $this->eventId = $eventId;
 
         foreach ($this->event->enrollmentPolicy?->application_schema ?? [] as $field) {
-            if (($field['type'] ?? null) === 'checkbox') {
+            if (($field['type'] ?? null) === 'checkbox' && isset($field['key'])) {
                 $this->applicationFormData[(string) $field['key']] = [];
             }
         }

--- a/app-modules/panel-app/src/Livewire/Events/EventDetail.php
+++ b/app-modules/panel-app/src/Livewire/Events/EventDetail.php
@@ -41,16 +41,16 @@ final class EventDetail extends Component
 {
     public string $eventId;
 
-    /** @var array<int, mixed> */
+    /** @var array<string, mixed> */
     public array $applicationFormData = [];
 
     public function mount(string $eventId): void
     {
         $this->eventId = $eventId;
 
-        foreach ($this->event->enrollmentPolicy->application_schema ?? [] as $index => $field) {
+        foreach ($this->event->enrollmentPolicy?->application_schema ?? [] as $field) {
             if (($field['type'] ?? null) === 'checkbox') {
-                $this->applicationFormData[$index] = [];
+                $this->applicationFormData[(string) $field['key']] = [];
             }
         }
     }

--- a/app-modules/panel-app/tests/Feature/Events/ApplicationEnrollmentTest.php
+++ b/app-modules/panel-app/tests/Feature/Events/ApplicationEnrollmentTest.php
@@ -25,8 +25,8 @@ beforeEach(function (): void {
     Filament::setTenant($this->tenant);
 
     $this->schema = [
-        ['type' => 'text', 'label' => 'Why do you want to join?', 'required' => true],
-        ['type' => 'select', 'label' => 'Experience level', 'required' => false, 'options' => ['Beginner', 'Intermediate', 'Advanced']],
+        ['key' => 'why_join', 'type' => 'text', 'label' => 'Why do you want to join?', 'required' => true],
+        ['key' => 'experience_level', 'type' => 'select', 'label' => 'Experience level', 'required' => false, 'options' => ['Beginner', 'Intermediate', 'Advanced']],
     ];
 
     $this->event = Event::factory()
@@ -52,7 +52,7 @@ test('event detail shows canApply true and canConfirmPresence false for applicat
 
 test('when user submits application, then enrollment is created as pending', function (): void {
     livewire(EventDetail::class, ['eventId' => $this->event->id])
-        ->set('applicationFormData', [0 => 'I love Laravel!', 1 => 'Intermediate'])
+        ->set('applicationFormData', ['why_join' => 'I love Laravel!', 'experience_level' => 'Intermediate'])
         ->call('apply')
         ->assertHasNoErrors()
         ->assertNotified();
@@ -65,12 +65,12 @@ test('when user submits application, then enrollment is created as pending', fun
     expect($enrollment)->not->toBeNull()
         ->and($enrollment->status)->toBe(EnrollmentStatus::Pending)
         ->and($enrollment->confirmed_at)->toBeNull()
-        ->and($enrollment->application_data[0])->toBe('I love Laravel!');
+        ->and($enrollment->application_data['why_join'])->toBe('I love Laravel!');
 });
 
 test('after submitting application, event detail shows pending status with answers', function (): void {
     livewire(EventDetail::class, ['eventId' => $this->event->id])
-        ->set('applicationFormData', [0 => 'I love Laravel!', 1 => 'Intermediate'])
+        ->set('applicationFormData', ['why_join' => 'I love Laravel!', 'experience_level' => 'Intermediate'])
         ->call('apply');
 
     livewire(EventDetail::class, ['eventId' => $this->event->id])
@@ -87,7 +87,7 @@ test('when application is rejected, then rejection reason is shown', function ()
         'status' => EnrollmentStatus::Rejected,
         'enrolled_at' => now(),
         'rejection_reason' => 'Not enough experience.',
-        'application_data' => [0 => 'I am new'],
+        'application_data' => ['why_join' => 'I am new'],
     ]);
 
     livewire(EventDetail::class, ['eventId' => $this->event->id])
@@ -103,7 +103,7 @@ test('when user has already applied, then apply button is not shown', function (
         'user_id' => $this->user->id,
         'status' => EnrollmentStatus::Pending,
         'enrolled_at' => now(),
-        'application_data' => [0 => 'My answer'],
+        'application_data' => ['why_join' => 'My answer'],
     ]);
 
     livewire(EventDetail::class, ['eventId' => $this->event->id])
@@ -113,7 +113,7 @@ test('when user has already applied, then apply button is not shown', function (
 
 test('when application data is missing required field, then error notification is shown', function (): void {
     livewire(EventDetail::class, ['eventId' => $this->event->id])
-        ->set('applicationFormData', [0 => '', 1 => 'Beginner'])
+        ->set('applicationFormData', ['why_join' => '', 'experience_level' => 'Beginner'])
         ->call('apply')
         ->assertNotified();
 

--- a/app-modules/panel-app/tests/Feature/Events/ApplicationEnrollmentTest.php
+++ b/app-modules/panel-app/tests/Feature/Events/ApplicationEnrollmentTest.php
@@ -111,6 +111,24 @@ test('when user has already applied, then apply button is not shown', function (
         ->assertDontSee(__('events::pages.apply_submit'));
 });
 
+test('when questions are reordered after submission, then answers still match the correct question', function (): void {
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->set('applicationFormData', ['why_join' => 'I love Laravel!', 'experience_level' => 'Intermediate'])
+        ->call('apply');
+
+    $this->event->enrollmentPolicy->update([
+        'application_schema' => array_reverse($this->schema),
+    ]);
+
+    livewire(EventDetail::class, ['eventId' => $this->event->id])
+        ->assertSeeInOrder([
+            'Experience level',
+            'Intermediate',
+            'Why do you want to join?',
+            'I love Laravel!',
+        ]);
+});
+
 test('when application data is missing required field, then error notification is shown', function (): void {
     livewire(EventDetail::class, ['eventId' => $this->event->id])
         ->set('applicationFormData', ['why_join' => '', 'experience_level' => 'Beginner'])


### PR DESCRIPTION
## Summary

**The bug:** reordering questions in the Admin's application-form Repeater silently corrupted already-submitted answers, showing them under the wrong question.

**Root cause:** an answer in `application_data` was matched to its question in `application_schema` by array position — `application_data[0]` was "whatever the answer to schema position 0 was." The Repeater re-indexes `application_schema` to the new visual order on every save. So if a participant answered while the schema was `[A, B]` (answer stored at index `0` = "answer to A") and the organizer later reordered to `[B, A]`, index `0` now points to B — that participant's answer to A renders as if it were the answer to B, in both the Admin's "View Application" modal and the App panel's "Your Answers" section.

**Fix:** each question in the schema now carries a hidden, immutable `key` (UUID), generated once when the question is created. Filament's Repeater moves the whole item (including this hidden field) as a unit when reordering, so the key never changes — only its position does. Submission, validation, and both answer displays now match answer to question by that `key` instead of array position.

**Follow-up fix (second commit):** enrollment policies saved before the `key` field existed (or edited outside the Admin form builder) can still have schema entries with no key. Instead of crashing with "Undefined array key" when that happens, those fields are now silently skipped — consistent with how the answer-display side already treated a missing key as "no answer."

## What changed

| File | Change |
|---|---|
| `EventForm.php` | Added a hidden `key` (UUID) field to each Repeater item in the application-schema builder, generated once on creation. |
| `EnrollUserAction.php` | `validateApplicationData()` now matches submitted answers to schema fields by `key` instead of position; `application_data`/`applicationData` typed as `array<string, mixed>`. |
| `EnrollUserDTO.php`, `Enrollment.php` | Docblock types updated to match (`array<string, mixed>` keyed by field id, not array index). |
| `EventDetail.php` | The apply form's `wire:model` bindings and the checkbox-group state pre-seed in `mount()` now key off `$field['key']`; fields missing a key are skipped instead of crashing. |
| `event-detail.blade.php` | Same re-keying for the "Your Answers" pending-status display and the apply form; skips fields with no key. |
| `EnrollmentsRelationManager.php` | Admin's "View Application" modal now looks up each answer by `$field['key']`. |
| `EventsSeeder.php` | Seed schemas and fake-answer generation updated to the key-based shape. |
| `EnrollUserActionTest.php`, `ApproveApplicationActionTest.php`, `RejectApplicationActionTest.php`, `ApplicationEnrollmentTest.php` | Updated fixtures/assertions to key-based `application_data`. |

## Test plan

```
vendor/bin/pest app-modules/events/tests app-modules/panel-app/tests app-modules/panel-admin/tests
vendor/bin/pint --test app-modules/events app-modules/panel-admin app-modules/panel-app
```

Results: 230/230 passing, Pint clean.

Manual verification: submitted an application, reordered the questions in Admin and saved, confirmed the original answers still show under the correct question in both the App panel ("Your Answers") and Admin ("View Application").
