### PR TITLE
fix(profile): display nickname on profile card

### DIFF
--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -7,10 +7,10 @@
     'coverPreviewUrl' => null
 ])
 
-@php
-    $name = $user?->name ?? '';
+@php 
     $username = $user?->username ?? '';
     $nickname = $data['nickname'] ?? null;
+    $name = $nickname ?? $user?->name ?? '';
     $headline = $data['headline'] ?? null;
     $about = $data['about'] ?? null;
     $yearsExperience = $data['years_experience'] ?? null;

--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -10,7 +10,7 @@
 @php 
     $username = $user?->username ?? '';
     $nickname = $data['nickname'] ?? null;
-    $name = $nickname ?? $user?->name ?? '';
+    $name = $nickname ?? $user?->name ?? $username;
     $headline = $data['headline'] ?? null;
     $about = $data['about'] ?? null;
     $yearsExperience = $data['years_experience'] ?? null;


### PR DESCRIPTION
O que acontecia
O card do perfil no painel Filament sempre exibe o users.name (nome do Discord), ignorando o campo "Apelido" (user_profiles.nickname) preenchido pelo usuário.

Mudanças
profile-preview-card.blade.php: prioriza $nickname sobre $user->name na exibição do nome no card
