### PR TITLE
fix(panel): ajustes de UI no perfil e sidebar

### DIFF
--- a/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
@@ -72,11 +72,11 @@
                     <img
                         src="{{ $avatarPreviewUrl }}"
                         alt="{{ $name }}"
-                        class="h-full w-full rounded-full border-4 border-white object-cover shadow-lg dark:border-gray-900"
+                        class="h-full w-full rounded-full border-4 border-white object-cover shadow-lg dark:border-gray-800"
                     />
                 @else
                     <div
-                        class="flex h-full w-full items-center justify-center rounded-full border-4 border-white bg-purple-600 text-2xl font-bold text-white shadow-lg sm:text-3xl dark:border-gray-900"
+                        class="flex h-full w-full items-center justify-center rounded-full border-4 border-white bg-purple-600 text-2xl font-bold text-white shadow-lg ring-1 ring-black/5 sm:text-3xl dark:border-gray-800 dark:ring-white/15"
                     >
                         {{ $initials }}
                     </div>

--- a/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-media-header.blade.php
@@ -59,10 +59,10 @@
     </div>
 
     {{-- Bottom section: avatar + fields --}}
-    <div class="relative px-6 pt-16 pb-6 sm:pt-18">
+    <div class="relative z-10 px-6 pt-16 pb-6 sm:pt-18">
         {{-- Avatar (overlapping cover) --}}
         <div
-            class="absolute -top-12 left-6 sm:-top-14"
+            class="absolute -top-12 left-6 z-20 sm:-top-14"
             x-data="{ hover: false }"
             @mouseenter="hover = true"
             @mouseleave="hover = false"

--- a/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
+++ b/app-modules/panel-app/resources/views/components/profile-preview-card.blade.php
@@ -100,11 +100,11 @@
                 <img
                     src="{{ $avatarPreviewUrl }}"
                     alt="{{ $name }}"
-                    class="h-16 w-16 rounded-full border-4 border-white object-cover shadow-md dark:border-gray-900"
+                    class="h-16 w-16 rounded-full border-4 border-white object-cover shadow-md dark:border-gray-800"
                 />
             @else
                 <div
-                    class="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white bg-purple-600 text-lg font-bold text-white shadow-md dark:border-gray-900"
+                    class="flex h-16 w-16 items-center justify-center rounded-full border-4 border-white bg-purple-600 text-lg font-bold text-white shadow-md ring-1 ring-black/5 dark:border-gray-800 dark:ring-white/15"
                 >
                     {{ $initials }}
                 </div>

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -47,3 +47,9 @@
         opacity: 0.35;
     }
 }
+
+/* Keep user avatar circle visible against dark sidebar
+   (default ui-avatars uses gray-950, which blends into dark mode) */
+.fi-sidebar .fi-user-avatar {
+    @apply ring-1 ring-gray-300 dark:ring-white/20;
+}

--- a/resources/css/filament/app/theme.css
+++ b/resources/css/filament/app/theme.css
@@ -53,3 +53,9 @@
 .fi-sidebar .fi-user-avatar {
     @apply ring-1 ring-gray-300 dark:ring-white/20;
 }
+
+/* Soft edge between sidebar navigation and main content
+   (same weight as Filament form input borders) */
+.fi-sidebar {
+    @apply border-e border-gray-200 dark:border-white/10;
+}


### PR DESCRIPTION
## Summary

- Corrige visibilidade do círculo de iniciais no dark mode (header e preview card do perfil)
- Evita que o hover de upload da capa fique por cima do avatar
- Melhora visibilidade do avatar no menu lateral no dark mode
- Adiciona borda discreta na sidebar, no mesmo peso das bordas dos inputs do form


**Antes:** no dark mode, o círculo das iniciais quase sumia no perfil; o hover de upload da capa cobria parte do avatar; o avatar do menu lateral ficava sem contorno visível; e não havia separação clara entre sidebar e conteúdo.
<img width="1906" height="907" alt="Captura de tela 2026-07-08 131101" src="https://github.com/user-attachments/assets/bfa3d0d3-0975-4d3d-b1d6-f02cc1ff067e" />

**Depois:** iniciais com borda/ring visível no header e no preview card; avatar sempre acima do hover da capa; contorno discreto no avatar do menu lateral; e borda suave na sidebar, no mesmo peso das bordas dos inputs do form.

<img width="1906" height="911" alt="Captura de tela 2026-07-08 130813" src="https://github.com/user-attachments/assets/5faa3fc0-7819-4aa6-9d91-552868f72c5f" />

## Commits

1. `fix(profile): keep initials avatar visible in dark mode preview card`
2. `fix(profile): keep initials avatar visible in dark mode header`
3. `fix(profile): keep avatar above cover upload hover overlay`
4. `fix(panel): keep sidebar user avatar visible in dark mode`
5. `style(panel): add subtle sidebar border` *(fácil de reverter isoladamente se necessário)*

## Test plan

- [ ] Abrir `/app/{tenant}/profile` em light e dark mode
- [ ] Sem foto: conferir se o círculo com iniciais aparece no header e no preview card
- [ ] Passar o mouse na capa: hover não deve cobrir o avatar
- [ ] No menu lateral: avatar do usuário visível no dark mode
- [ ] Conferir se a borda da sidebar está discreta (similar aos inputs do form)
