### PR TITLE
feat(squads): pivot squad_members + SquadRole + recorder de eventos (#355)

### DIFF
--- a/app-modules/squads/database/factories/SquadMemberFactory.php
+++ b/app-modules/squads/database/factories/SquadMemberFactory.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Database\Factories;
+
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMember;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SquadMember>
+ */
+final class SquadMemberFactory extends Factory
+{
+    protected $model = SquadMember::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => Tenant::factory(),
+            'squad_id' => Squad::factory(),
+            'user_id' => User::factory(),
+            'role' => SquadRole::Member,
+            'joined_at' => now(),
+            'left_at' => null,
+        ];
+    }
+}

--- a/app-modules/squads/database/factories/SquadMembershipEventFactory.php
+++ b/app-modules/squads/database/factories/SquadMembershipEventFactory.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Database\Factories;
+
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMembershipEvent;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<SquadMembershipEvent>
+ */
+final class SquadMembershipEventFactory extends Factory
+{
+    protected $model = SquadMembershipEvent::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'tenant_id' => Tenant::factory(),
+            'squad_id' => Squad::factory(),
+            'user_id' => User::factory(),
+            'actor_id' => null,
+            'action' => MembershipAction::Join,
+            'from_role' => null,
+            'to_role' => SquadRole::Member,
+            'reason' => null,
+            'metadata' => null,
+            'occurred_at' => now(),
+        ];
+    }
+}

--- a/app-modules/squads/database/migrations/2026_07_09_185733_create_squad_members_table.php
+++ b/app-modules/squads/database/migrations/2026_07_09_185733_create_squad_members_table.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('squad_members', static function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignUuid('squad_id')->constrained('squads')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('role', 30);
+            $table->timestampTz('joined_at');
+            $table->timestampTz('left_at')->nullable();
+            $table->timestampsTz();
+
+            $table->unique(['squad_id', 'user_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('squad_members');
+    }
+};

--- a/app-modules/squads/database/migrations/2026_07_09_185734_create_squad_membership_events_table.php
+++ b/app-modules/squads/database/migrations/2026_07_09_185734_create_squad_membership_events_table.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('squad_membership_events', static function (Blueprint $table): void {
+            $table->uuid('id')->primary();
+            $table->foreignUuid('tenant_id')->constrained('tenants')->cascadeOnDelete();
+            $table->foreignUuid('squad_id')->constrained('squads')->cascadeOnDelete();
+            $table->foreignUuid('user_id')->constrained('users')->cascadeOnDelete();
+            $table->foreignUuid('actor_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->string('action', 30);
+            $table->string('from_role', 30)->nullable();
+            $table->string('to_role', 30)->nullable();
+            $table->text('reason')->nullable();
+            $table->jsonb('metadata')->nullable();
+            $table->timestampTz('occurred_at');
+            $table->timestampsTz();
+
+            $table->index(['squad_id', 'occurred_at']);
+            $table->index(['user_id', 'occurred_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('squad_membership_events');
+    }
+};

--- a/app-modules/squads/src/Actions/RecordMembershipEvent.php
+++ b/app-modules/squads/src/Actions/RecordMembershipEvent.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Actions;
+
+use Carbon\CarbonInterface;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMembershipEvent;
+
+/**
+ * Appends one entry to the squad membership audit trail.
+ *
+ * Reused by every membership/role mutation in the module. The trail is
+ * append-only — this Action only ever creates events, never updates them.
+ */
+final class RecordMembershipEvent
+{
+    /**
+     * @param  array<string, mixed>  $metadata
+     */
+    public function handle(
+        Squad $squad,
+        User $subject,
+        MembershipAction $action,
+        ?SquadRole $fromRole = null,
+        ?SquadRole $toRole = null,
+        ?User $actor = null,
+        ?string $reason = null,
+        array $metadata = [],
+        ?CarbonInterface $occurredAt = null,
+    ): SquadMembershipEvent {
+        /** @var SquadMembershipEvent $event */
+        $event = SquadMembershipEvent::query()->create([
+            'tenant_id' => $squad->tenant_id,
+            'squad_id' => $squad->id,
+            'user_id' => $subject->id,
+            'actor_id' => $actor?->id,
+            'action' => $action,
+            'from_role' => $fromRole,
+            'to_role' => $toRole,
+            'reason' => $reason,
+            'metadata' => $metadata === [] ? null : $metadata,
+            'occurred_at' => $occurredAt ?? now(),
+        ]);
+
+        return $event;
+    }
+}

--- a/app-modules/squads/src/Enums/MembershipAction.php
+++ b/app-modules/squads/src/Enums/MembershipAction.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Enums;
+
+enum MembershipAction: string
+{
+    case Join = 'join';
+    case Leave = 'leave';
+    case Promote = 'promote';
+    case Demote = 'demote';
+}

--- a/app-modules/squads/src/Enums/SquadRole.php
+++ b/app-modules/squads/src/Enums/SquadRole.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Enums;
+
+enum SquadRole: string
+{
+    case Captain = 'captain';
+    case SubCaptain = 'sub_captain';
+    case Member = 'member';
+    case ExMember = 'ex_member';
+}

--- a/app-modules/squads/src/Exceptions/MembershipEventIsImmutable.php
+++ b/app-modules/squads/src/Exceptions/MembershipEventIsImmutable.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Exceptions;
+
+use Exception;
+
+final class MembershipEventIsImmutable extends Exception
+{
+    public static function make(): self
+    {
+        return new self('Squad membership events are append-only and cannot be updated or deleted.');
+    }
+}

--- a/app-modules/squads/src/Models/SquadMember.php
+++ b/app-modules/squads/src/Models/SquadMember.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Models;
+
+use Carbon\CarbonInterface;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Database\Factories\SquadMemberFactory;
+use He4rt\Squads\Enums\SquadRole;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\Pivot;
+
+/**
+ * @property string $id
+ * @property string $tenant_id
+ * @property string $squad_id
+ * @property string $user_id
+ * @property SquadRole $role
+ * @property CarbonInterface $joined_at
+ * @property CarbonInterface|null $left_at
+ * @property CarbonInterface|null $created_at
+ * @property CarbonInterface|null $updated_at
+ */
+#[UseFactory(factoryClass: SquadMemberFactory::class)]
+#[Table(name: 'squad_members')]
+final class SquadMember extends Pivot
+{
+    /** @use HasFactory<SquadMemberFactory> */
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'squad_id',
+        'user_id',
+        'role',
+        'joined_at',
+        'left_at',
+    ];
+
+    /**
+     * @return BelongsTo<Squad, $this>
+     */
+    public function squad(): BelongsTo
+    {
+        return $this->belongsTo(Squad::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * @return BelongsTo<Tenant, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'role' => SquadRole::class,
+            'joined_at' => 'datetime',
+            'left_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/squads/src/Models/SquadMembershipEvent.php
+++ b/app-modules/squads/src/Models/SquadMembershipEvent.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\Squads\Models;
+
+use Carbon\CarbonInterface;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Database\Factories\SquadMembershipEventFactory;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Exceptions\MembershipEventIsImmutable;
+use Illuminate\Database\Eloquent\Attributes\Table;
+use Illuminate\Database\Eloquent\Attributes\UseFactory;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property string $id
+ * @property string $tenant_id
+ * @property string $squad_id
+ * @property string $user_id
+ * @property string|null $actor_id
+ * @property MembershipAction $action
+ * @property SquadRole|null $from_role
+ * @property SquadRole|null $to_role
+ * @property string|null $reason
+ * @property array<string, mixed>|null $metadata
+ * @property CarbonInterface $occurred_at
+ * @property CarbonInterface|null $created_at
+ * @property CarbonInterface|null $updated_at
+ */
+#[UseFactory(factoryClass: SquadMembershipEventFactory::class)]
+#[Table(name: 'squad_membership_events')]
+final class SquadMembershipEvent extends Model
+{
+    /** @use HasFactory<SquadMembershipEventFactory> */
+    use HasFactory;
+    use HasUuids;
+
+    protected $fillable = [
+        'tenant_id',
+        'squad_id',
+        'user_id',
+        'actor_id',
+        'action',
+        'from_role',
+        'to_role',
+        'reason',
+        'metadata',
+        'occurred_at',
+    ];
+
+    /**
+     * @return BelongsTo<Squad, $this>
+     */
+    public function squad(): BelongsTo
+    {
+        return $this->belongsTo(Squad::class);
+    }
+
+    /**
+     * The membership subject (the person the event is about).
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Who caused the event; null when the actor is the system.
+     *
+     * @return BelongsTo<User, $this>
+     */
+    public function actor(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'actor_id');
+    }
+
+    /**
+     * @return BelongsTo<Tenant, $this>
+     */
+    public function tenant(): BelongsTo
+    {
+        return $this->belongsTo(Tenant::class);
+    }
+
+    /**
+     * The trail is append-only: once written, an event is never updated or deleted.
+     */
+    protected static function booted(): void
+    {
+        self::updating(static fn (): never => throw MembershipEventIsImmutable::make());
+        self::deleting(static fn (): never => throw MembershipEventIsImmutable::make());
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'action' => MembershipAction::class,
+            'from_role' => SquadRole::class,
+            'to_role' => SquadRole::class,
+            'metadata' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+}

--- a/app-modules/squads/tests/Feature/RecordMembershipEventTest.php
+++ b/app-modules/squads/tests/Feature/RecordMembershipEventTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\CarbonImmutable;
+use He4rt\Identity\Tenant\Models\Tenant;
+use He4rt\Identity\User\Models\User;
+use He4rt\Squads\Actions\RecordMembershipEvent;
+use He4rt\Squads\Enums\MembershipAction;
+use He4rt\Squads\Enums\SquadRole;
+use He4rt\Squads\Models\Squad;
+use He4rt\Squads\Models\SquadMembershipEvent;
+
+test('records a membership transition with action, roles, actor and occurred_at', function (): void {
+    $tenant = Tenant::factory()->create();
+    $squad = Squad::factory()->recycle($tenant)->create();
+    $subject = User::factory()->create();
+    $actor = User::factory()->create();
+    $occurredAt = CarbonImmutable::parse('2026-07-09 12:00:00');
+
+    $event = resolve(RecordMembershipEvent::class)->handle(
+        squad: $squad,
+        subject: $subject,
+        action: MembershipAction::Promote,
+        fromRole: SquadRole::Member,
+        toRole: SquadRole::SubCaptain,
+        actor: $actor,
+        reason: 'Elected off-system.',
+        occurredAt: $occurredAt,
+    );
+
+    expect($event)->toBeInstanceOf(SquadMembershipEvent::class)
+        ->and($event->tenant_id)->toBe($squad->tenant_id)
+        ->and($event->squad_id)->toBe($squad->id)
+        ->and($event->user_id)->toBe($subject->id)
+        ->and($event->actor_id)->toBe($actor->id)
+        ->and($event->action)->toBe(MembershipAction::Promote)
+        ->and($event->from_role)->toBe(SquadRole::Member)
+        ->and($event->to_role)->toBe(SquadRole::SubCaptain)
+        ->and($event->reason)->toBe('Elected off-system.')
+        ->and($event->occurred_at->equalTo($occurredAt))->toBeTrue();
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'squad_id' => $squad->id,
+        'user_id' => $subject->id,
+        'actor_id' => $actor->id,
+        'action' => 'promote',
+        'from_role' => 'member',
+        'to_role' => 'sub_captain',
+    ]);
+});
+
+test('records a system event when there is no actor', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    $event = resolve(RecordMembershipEvent::class)->handle(
+        squad: $squad,
+        subject: $subject,
+        action: MembershipAction::Join,
+        toRole: SquadRole::Member,
+    );
+
+    expect($event->actor_id)->toBeNull()
+        ->and($event->from_role)->toBeNull()
+        ->and($event->to_role)->toBe(SquadRole::Member)
+        ->and($event->metadata)->toBeNull()
+        ->and($event->occurred_at)->not->toBeNull();
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'id' => $event->id,
+        'actor_id' => null,
+        'action' => 'join',
+    ]);
+});
+
+test('stores structured metadata as jsonb', function (): void {
+    $squad = Squad::factory()->create();
+    $subject = User::factory()->create();
+
+    $event = resolve(RecordMembershipEvent::class)->handle(
+        squad: $squad,
+        subject: $subject,
+        action: MembershipAction::Leave,
+        fromRole: SquadRole::Member,
+        toRole: SquadRole::ExMember,
+        metadata: ['source' => 'discord', 'removed_by_head' => true],
+    );
+
+    expect($event->fresh()->metadata)
+        ->toBe(['source' => 'discord', 'removed_by_head' => true]);
+});

--- a/app-modules/squads/tests/Feature/SquadMembershipEventImmutabilityTest.php
+++ b/app-modules/squads/tests/Feature/SquadMembershipEventImmutabilityTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Squads\Exceptions\MembershipEventIsImmutable;
+use He4rt\Squads\Models\SquadMembershipEvent;
+
+test('a recorded membership event cannot be updated', function (): void {
+    $event = SquadMembershipEvent::factory()->create();
+
+    try {
+        $event->update(['reason' => 'tampered']);
+        $this->fail('Expected the membership event to be immutable.');
+    } catch (MembershipEventIsImmutable) {
+        // expected
+    }
+
+    expect($event->fresh()->reason)->toBeNull();
+});
+
+test('a recorded membership event cannot be deleted', function (): void {
+    $event = SquadMembershipEvent::factory()->create();
+
+    try {
+        $event->delete();
+        $this->fail('Expected the membership event to be immutable.');
+    } catch (MembershipEventIsImmutable) {
+        // expected
+    }
+
+    $this->assertDatabaseHas('squad_membership_events', [
+        'id' => $event->id,
+    ]);
+});


### PR DESCRIPTION
## Parent
#342 · Closes #355 · Desbloqueada por #354 (merged)

## O que construir
Pivot de membros, papéis in-squad e o **recorder** da trilha append-only de eventos de membership — módulo profundo reusado por todas as mutações (S3/S6/S8/S9/S10).

## O que este PR entrega

**Migrations** (via `artisan make:migration --module=squads`, datas `Tz`, jsonb)
- `squad_members` — `id` uuid, FKs `tenant_id`/`squad_id`/`user_id`, `role`, `joined_at`, `left_at?`, `UNIQUE (squad_id, user_id)`
- `squad_membership_events` (append-only) — `actor_id?` (nullOnDelete = sistema), `action`, `from_role?`/`to_role?`, `reason?`, `metadata jsonb?`, `occurred_at`; índices `(squad_id, occurred_at)` e `(user_id, occurred_at)`

**Enums** — `SquadRole` (`captain`/`sub_captain`/`member`/`ex_member`), `MembershipAction` (`join`/`leave`/`promote`/`demote`)

**Models** — `SquadMember` (Pivot + `HasUuids`) e `SquadMembershipEvent`, com PHPDoc `@property` sincronizado, `#[Table]`, `#[UseFactory]` e casts de enum/data. O evento é **imutável no próprio model** (`booted()` barra update/delete via `MembershipEventIsImmutable`), garantindo o append-only.

**Recorder** — `RecordMembershipEvent` (Action): grava um evento por mutação, `actor` nulo = sistema, `occurredAt` default `now()`, `tenant_id` derivado do squad.

**Factories + Tests** — `SquadMemberFactory`, `SquadMembershipEventFactory`, e testes do recorder (transição completa, evento de sistema, metadata jsonb) + imutabilidade (update e delete).

## Critérios de aceite
- [x] Migrations + PHPDoc sincronizado (datas `Tz`, jsonb)
- [x] Enums `SquadRole` e `MembershipAction`
- [x] Recorder grava evento com `action`, `from_role`/`to_role`, `actor_id`, `occurred_at`
- [x] Eventos são append-only (nunca update/delete)
- [x] Teste do recorder

## Decisões de escopo (worth a look)
- **Índices parciais deferidos.** A ADR-0002 prevê `UNIQUE (squad_id) WHERE role='captain'` e a exclusividade `UNIQUE (tenant_id, user_id) WHERE role IN (...)` em `squad_members`. O #355 pede só `UNIQUE (squad_id, user_id)`, então **não** incluí os parciais aqui — eles pertencem às issues de join/exclusividade/liderança que introduzem as Actions que mantêm essas invariantes. Fácil de adicionar agora se preferirem cravar na criação da tabela.
- **`metadata` cast `'array'`** seguindo o precedente do repo (`activity/MembershipEvent` e outros); não há gate `NoLooseArrayCasts` nesta linha.

## Testes
- `pest app-modules/squads` → **21 passed / 48 assertions**
- `pint` ✅ · `phpstan` (src) ✅ · `rector` ✅
- Validado localmente também contra a `4.x` (#402): rector named-args = 0 mudanças no módulo. O sync `feat/squads ← 4.x` fica como PR separado (padrão #404); este PR traz só o #355.

## BDD
```gherkin
# language: pt
Funcionalidade: Pivot de membros e trilha de eventos
  Cenário: Recorder registra uma transição
    Dado um squad e um usuário
    Quando ocorre uma mutação de membership (ex.: join)
    Então um squad_membership_event é gravado com action, papéis from/to, ator e occurred_at

  Cenário: A trilha é imutável
    Dado um evento de membership já gravado
    Quando qualquer fluxo do módulo é executado
    Então o evento existente nunca é atualizado nem removido
```
