### PR TITLE
chore(bot-discord): link libdave for voice

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@
 /storage/debugbar
 /storage/pail
 /vendor
+/.cache
 Homestead.json
 Homestead.yaml
 *.local

--- a/Makefile
+++ b/Makefile
@@ -95,6 +95,13 @@ import-db: ## Import a PostgreSQL dump file (usage: make import-db file=path/to/
 bot: ## Run the Discord bot
 	@php artisan bot:boot
 
+# Fixes the boot error "failed to initialize voice class /
+# LibDaveNotFoundException: libdave is required but could not be loaded" — since
+# 2026-03-01 Discord mandates the DAVE E2EE protocol for voice.
+.PHONY: libdave
+libdave: ## Link libdave (DAVE E2EE) into the Discord bot voice probe path
+	@mkdir -p "$(CURDIR)/.cache" && ln -sfn "$${LIBDAVE_HOME:-$$HOME/.local/lib/libdave}" "$(CURDIR)/.cache/libdave"
+
 .PHONY: truncate
 truncate: ## Truncate laravel.log file
 	@truncate -s 0 storage/logs/laravel.log


### PR DESCRIPTION
## Summary
- Add a `make libdave` target that symlinks the libdave (DAVE E2EE) install into the `.cache/libdave` probe path, so the Discord bot boots without the `failed to initialize voice class / LibDaveNotFoundException` error (DAVE is mandatory for voice since 2026-03-01).
- Symlinking the probe path avoids relying on `DISCORDPHP_DAVE_LIBRARY`, which the Forge daemon (Supervisor ignores shell rc) and `config:cache` (skips `.env`) both defeat.
- gitignore `/.cache` (machine-local, like `/vendor`).

Deploy: run `make libdave` after `composer install` in the Forge deploy script.