### PR TITLE
fix(integration-twitch): harden Twitch OAuth setup & one-click connect

### DIFF
--- a/app-modules/integration-twitch/src/Actions/RegisterTwitchSubscriptionsAction.php
+++ b/app-modules/integration-twitch/src/Actions/RegisterTwitchSubscriptionsAction.php
@@ -20,19 +20,8 @@ final readonly class RegisterTwitchSubscriptionsAction
      * @param  array<int, TwitchEventSubType>  $types
      * @return array{created: int, skipped: int, failed: int, errors: array<string, string>}
      */
-    public function __invoke(array $types = []): array
+    public function __invoke(string $broadcasterId, array $types = []): array
     {
-        $broadcasterId = $this->resolveBroadcasterId();
-
-        if ($broadcasterId === null) {
-            return [
-                'created' => 0,
-                'skipped' => 0,
-                'failed' => 0,
-                'errors' => ['broadcaster' => 'No Twitch broadcaster configured (set TWITCH_BROADCASTER_ID).'],
-            ];
-        }
-
         if ($types === []) {
             $types = TwitchEventSubType::cases();
         }
@@ -111,13 +100,6 @@ final readonly class RegisterTwitchSubscriptionsAction
         }
 
         return ['created' => $created, 'skipped' => $skipped, 'failed' => $failed, 'errors' => $errors];
-    }
-
-    private function resolveBroadcasterId(): ?string
-    {
-        $broadcasterId = config()->string('services.twitch.broadcaster_id', '');
-
-        return $broadcasterId === '' ? null : $broadcasterId;
     }
 
     private function resolveCallbackUrl(): string

--- a/app-modules/integration-twitch/src/Console/LinkTwitchChannelCommand.php
+++ b/app-modules/integration-twitch/src/Console/LinkTwitchChannelCommand.php
@@ -10,7 +10,7 @@ use Illuminate\Console\Attributes\Description;
 use Illuminate\Console\Attributes\Signature;
 use Illuminate\Console\Command;
 
-#[Description(description: 'Resolve a Twitch channel broadcaster id for the fixed config-based integration')]
+#[Description(description: 'Resolve a Twitch channel broadcaster id for use with twitch:subscribe')]
 #[Signature(signature: 'twitch:link-channel {login? : Twitch channel login name (defaults to config broadcaster login)}')]
 final class LinkTwitchChannelCommand extends Command
 {
@@ -40,9 +40,8 @@ final class LinkTwitchChannelCommand extends Command
         $this->info(sprintf("Resolved Twitch channel '%s' (login: %s).", $displayName, $login));
         $this->line(sprintf('Broadcaster ID: %s', $broadcasterId));
         $this->newLine();
-        $this->comment('Set the following in your .env to activate the integration:');
-        $this->line(sprintf('  TWITCH_BROADCASTER_LOGIN=%s', $login));
-        $this->line(sprintf('  TWITCH_BROADCASTER_ID=%s', $broadcasterId));
+        $this->comment('Register EventSub subscriptions for this channel with:');
+        $this->line(sprintf('  php artisan twitch:subscribe %s --all', $broadcasterId));
 
         return self::SUCCESS;
     }

--- a/app-modules/integration-twitch/src/IntegrationTwitchServiceProvider.php
+++ b/app-modules/integration-twitch/src/IntegrationTwitchServiceProvider.php
@@ -24,7 +24,7 @@ class IntegrationTwitchServiceProvider extends ServiceProvider
         $this->app->singleton(TwitchAppTokenService::class);
 
         $this->app->singleton(TwitchHelixConnector::class, fn (): TwitchHelixConnector => new TwitchHelixConnector(
-            appToken: $this->app->make(TwitchAppTokenService::class)->getToken(),
+            tokenService: $this->app->make(TwitchAppTokenService::class),
             clientId: config()->string('services.twitch.client_id'),
         ));
 

--- a/app-modules/integration-twitch/src/OAuth/TwitchAppTokenService.php
+++ b/app-modules/integration-twitch/src/OAuth/TwitchAppTokenService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationTwitch\OAuth;
 
+use He4rt\Identity\Auth\Exceptions\OAuthFlowException;
 use He4rt\IntegrationTwitch\Transport\Requests\OAuth\GetAppAccessToken;
 use He4rt\IntegrationTwitch\Transport\TwitchOAuthConnector;
 use Illuminate\Support\Facades\Cache;
@@ -23,7 +24,16 @@ final readonly class TwitchAppTokenService
             ));
 
             $accessToken = $response->json('access_token');
-            $expiresIn = $response->json('expires_in');
+
+            $tokenRequestFailed = !is_string($accessToken) || $accessToken === '';
+
+            if ($tokenRequestFailed) {
+                $reason = $response->json('message') ?? sprintf('unexpected response (HTTP %d)', $response->status());
+
+                throw OAuthFlowException::tokenExchangeFailed('twitch', (string) $reason);
+            }
+
+            $expiresIn = (int) ($response->json('expires_in') ?? 3_600);
 
             Cache::put('twitch_app_token_expires_in', $expiresIn, $expiresIn);
 

--- a/app-modules/integration-twitch/src/Transport/TwitchHelixConnector.php
+++ b/app-modules/integration-twitch/src/Transport/TwitchHelixConnector.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace He4rt\IntegrationTwitch\Transport;
 
+use He4rt\IntegrationTwitch\OAuth\TwitchAppTokenService;
 use Saloon\Http\Auth\TokenAuthenticator;
 use Saloon\Http\Connector;
 use Saloon\Traits\Plugins\HasTimeout;
@@ -17,7 +18,7 @@ final class TwitchHelixConnector extends Connector
     protected int $requestTimeout = 10;
 
     public function __construct(
-        private readonly string $appToken,
+        private readonly TwitchAppTokenService $tokenService,
         private readonly string $clientId,
     ) {}
 
@@ -28,7 +29,7 @@ final class TwitchHelixConnector extends Connector
 
     protected function defaultAuth(): TokenAuthenticator
     {
-        return new TokenAuthenticator($this->appToken);
+        return new TokenAuthenticator($this->tokenService->getToken());
     }
 
     /**

--- a/app-modules/integration-twitch/tests/Feature/LinkTwitchChannelCommandTest.php
+++ b/app-modules/integration-twitch/tests/Feature/LinkTwitchChannelCommandTest.php
@@ -50,8 +50,7 @@ test('resolves a twitch channel broadcaster id and prints the env config', funct
 
     $this->artisan('twitch:link-channel', ['login' => 'danielhe4rt'])
         ->expectsOutputToContain('Broadcaster ID: 12345')
-        ->expectsOutputToContain('TWITCH_BROADCASTER_LOGIN=danielhe4rt')
-        ->expectsOutputToContain('TWITCH_BROADCASTER_ID=12345')
+        ->expectsOutputToContain('php artisan twitch:subscribe 12345 --all')
         ->assertSuccessful();
 });
 

--- a/app-modules/integration-twitch/tests/Feature/LinkTwitchChannelCommandTest.php
+++ b/app-modules/integration-twitch/tests/Feature/LinkTwitchChannelCommandTest.php
@@ -2,9 +2,29 @@
 
 declare(strict_types=1);
 
+use He4rt\IntegrationTwitch\OAuth\TwitchAppTokenService;
 use He4rt\IntegrationTwitch\Transport\TwitchHelixConnector;
+use He4rt\IntegrationTwitch\Transport\TwitchOAuthConnector;
+use Illuminate\Support\Facades\Cache;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
+
+function fakeTwitchHelixConnector(MockClient $mock): TwitchHelixConnector
+{
+    // The app token is resolved lazily by the connector; seed the cache so
+    // getToken() short-circuits without hitting the real Twitch OAuth endpoint.
+    Cache::put('twitch_app_access_token', 'fake-token', 3_600);
+
+    return tap(
+        new TwitchHelixConnector(
+            tokenService: new TwitchAppTokenService(
+                new TwitchOAuthConnector(clientId: 'fake-client-id', clientSecret: 'fake-secret'),
+            ),
+            clientId: 'fake-client-id',
+        ),
+        fn (TwitchHelixConnector $connector) => $connector->withMockClient($mock),
+    );
+}
 
 function mockHelixUsersResponse(string $id = '12345', string $login = 'danielhe4rt', string $displayName = 'danielhe4rt'): MockClient
 {
@@ -20,10 +40,7 @@ function mockHelixUsersResponse(string $id = '12345', string $login = 'danielhe4
         ]),
     ]);
 
-    app()->instance(TwitchHelixConnector::class, tap(
-        new TwitchHelixConnector(appToken: 'fake-token', clientId: 'fake-client-id'),
-        fn (TwitchHelixConnector $connector) => $connector->withMockClient($mock),
-    ));
+    app()->instance(TwitchHelixConnector::class, fakeTwitchHelixConnector($mock));
 
     return $mock;
 }
@@ -43,10 +60,7 @@ test('fails when twitch user is not found', function (): void {
         '*' => MockResponse::make(['data' => []]),
     ]);
 
-    app()->instance(TwitchHelixConnector::class, tap(
-        new TwitchHelixConnector(appToken: 'fake-token', clientId: 'fake-client-id'),
-        fn (TwitchHelixConnector $connector) => $connector->withMockClient($mock),
-    ));
+    app()->instance(TwitchHelixConnector::class, fakeTwitchHelixConnector($mock));
 
     $this->artisan('twitch:link-channel', ['login' => 'nonexistent'])
         ->assertFailed();

--- a/app-modules/integration-twitch/tests/Feature/RegisterTwitchSubscriptionsActionTest.php
+++ b/app-modules/integration-twitch/tests/Feature/RegisterTwitchSubscriptionsActionTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\IntegrationTwitch\Actions\RegisterTwitchSubscriptionsAction;
+use He4rt\IntegrationTwitch\Enums\TwitchEventSubType;
+use He4rt\IntegrationTwitch\Models\TwitchSubscription;
+use He4rt\IntegrationTwitch\OAuth\TwitchAppTokenService;
+use He4rt\IntegrationTwitch\Transport\Requests\EventSub\CreateSubscription;
+use He4rt\IntegrationTwitch\Transport\TwitchHelixConnector;
+use He4rt\IntegrationTwitch\Transport\TwitchOAuthConnector;
+use Illuminate\Support\Facades\Cache;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+use function Pest\Laravel\assertDatabaseHas;
+
+function bindMockedHelix(MockClient $mock): void
+{
+    // The app token is resolved lazily; seed the cache so getToken() never
+    // reaches the real Twitch OAuth endpoint.
+    Cache::put('twitch_app_access_token', 'fake-token', 3_600);
+
+    app()->instance(TwitchHelixConnector::class, tap(
+        new TwitchHelixConnector(
+            tokenService: new TwitchAppTokenService(
+                new TwitchOAuthConnector(clientId: 'fake-client-id', clientSecret: 'fake-secret'),
+            ),
+            clientId: 'fake-client-id',
+        ),
+        fn (TwitchHelixConnector $connector) => $connector->withMockClient($mock),
+    ));
+}
+
+beforeEach(function (): void {
+    config()->set('services.twitch.eventsub_callback', 'https://example.com/api/webhooks/twitch/eventsub');
+    config()->set('services.twitch.eventsub_secret', 'test-secret-at-least-ten-chars');
+});
+
+test('registra a subscription usando o broadcaster id informado, sem tocar em config', function (): void {
+    bindMockedHelix(new MockClient([
+        CreateSubscription::class => MockResponse::make([
+            'data' => [[
+                'id' => 'sub-abc',
+                'type' => 'stream.online',
+                'status' => 'enabled',
+                'condition' => ['broadcaster_user_id' => '999888'],
+                'transport' => ['method' => 'webhook', 'callback' => 'https://example.com/api/webhooks/twitch/eventsub'],
+                'cost' => 0,
+                'version' => '1',
+            ]],
+        ], 202),
+    ]));
+
+    $result = resolve(RegisterTwitchSubscriptionsAction::class)('999888', [TwitchEventSubType::StreamOnline]);
+
+    expect($result['created'])->toBe(1)
+        ->and($result['failed'])->toBe(0);
+
+    assertDatabaseHas(TwitchSubscription::class, [
+        'subscription_id' => 'sub-abc',
+        'broadcaster_user_id' => '999888',
+        'type' => 'stream.online',
+    ]);
+});
+
+test('pula subscriptions já existentes para o mesmo broadcaster', function (): void {
+    TwitchSubscription::query()->create([
+        'subscription_id' => 'existing-1',
+        'type' => 'stream.online',
+        'status' => 'enabled',
+        'broadcaster_user_id' => '999888',
+        'condition' => ['broadcaster_user_id' => '999888'],
+        'transport' => 'webhook',
+        'callback_url' => 'https://example.com/api/webhooks/twitch/eventsub',
+        'cost' => 0,
+        'version' => '1',
+    ]);
+
+    bindMockedHelix(new MockClient([
+        CreateSubscription::class => MockResponse::make(['data' => [['id' => 'should-not-be-used']]], 202),
+    ]));
+
+    $result = resolve(RegisterTwitchSubscriptionsAction::class)('999888', [TwitchEventSubType::StreamOnline]);
+
+    expect($result['created'])->toBe(0)
+        ->and($result['skipped'])->toBe(1);
+});

--- a/app-modules/integration-twitch/tests/Feature/SubscribeTwitchEventsCommandTest.php
+++ b/app-modules/integration-twitch/tests/Feature/SubscribeTwitchEventsCommandTest.php
@@ -3,10 +3,13 @@
 declare(strict_types=1);
 
 use He4rt\IntegrationTwitch\Enums\TwitchEventSubType;
+use He4rt\IntegrationTwitch\OAuth\TwitchAppTokenService;
 use He4rt\IntegrationTwitch\Transport\Requests\EventSub\CreateSubscription;
 use He4rt\IntegrationTwitch\Transport\Requests\EventSub\DeleteSubscription;
 use He4rt\IntegrationTwitch\Transport\Requests\EventSub\ListSubscriptions;
 use He4rt\IntegrationTwitch\Transport\TwitchHelixConnector;
+use He4rt\IntegrationTwitch\Transport\TwitchOAuthConnector;
+use Illuminate\Support\Facades\Cache;
 use Saloon\Http\Faking\MockClient;
 use Saloon\Http\Faking\MockResponse;
 
@@ -24,8 +27,17 @@ function mockEventSubResponses(array $existingSubscriptions = []): MockClient
         DeleteSubscription::class => MockResponse::make([], 204),
     ]);
 
+    // The app token is resolved lazily by the connector; seed the cache so
+    // getToken() short-circuits without hitting the real Twitch OAuth endpoint.
+    Cache::put('twitch_app_access_token', 'fake-token', 3_600);
+
     app()->instance(TwitchHelixConnector::class, tap(
-        new TwitchHelixConnector(appToken: 'fake-token', clientId: 'fake-client-id'),
+        new TwitchHelixConnector(
+            tokenService: new TwitchAppTokenService(
+                new TwitchOAuthConnector(clientId: 'fake-client-id', clientSecret: 'fake-secret'),
+            ),
+            clientId: 'fake-client-id',
+        ),
         fn (TwitchHelixConnector $connector) => $connector->withMockClient($mock),
     ));
 

--- a/app-modules/integration-twitch/tests/Feature/TwitchAppTokenServiceTest.php
+++ b/app-modules/integration-twitch/tests/Feature/TwitchAppTokenServiceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use He4rt\Identity\Auth\Exceptions\OAuthFlowException;
+use He4rt\IntegrationTwitch\OAuth\TwitchAppTokenService;
+use He4rt\IntegrationTwitch\Transport\Requests\OAuth\GetAppAccessToken;
+use He4rt\IntegrationTwitch\Transport\TwitchOAuthConnector;
+use Illuminate\Support\Facades\Cache;
+use Saloon\Http\Faking\MockClient;
+use Saloon\Http\Faking\MockResponse;
+
+function makeAppTokenService(MockClient $mock): TwitchAppTokenService
+{
+    $connector = new TwitchOAuthConnector(clientId: 'fake-client-id', clientSecret: 'fake-secret');
+    $connector->withMockClient($mock);
+
+    return new TwitchAppTokenService($connector);
+}
+
+beforeEach(function (): void {
+    Cache::flush();
+});
+
+test('retorna e cacheia o app token quando a twitch responde com sucesso', function (): void {
+    $service = makeAppTokenService(new MockClient([
+        GetAppAccessToken::class => MockResponse::make([
+            'access_token' => 'app-token-123',
+            'expires_in' => 5_000,
+            'token_type' => 'bearer',
+        ]),
+    ]));
+
+    expect($service->getToken())->toBe('app-token-123');
+    expect(Cache::get('twitch_app_access_token'))->toBe('app-token-123');
+});
+
+test('lança OAuthFlowException quando a twitch nega o client secret', function (): void {
+    $service = makeAppTokenService(new MockClient([
+        GetAppAccessToken::class => MockResponse::make([
+            'status' => 403,
+            'message' => 'invalid client secret',
+        ], 403),
+    ]));
+
+    expect(fn (): string => $service->getToken())
+        ->toThrow(OAuthFlowException::class, 'invalid client secret');
+
+    expect(Cache::has('twitch_app_access_token'))->toBeFalse();
+});

--- a/app-modules/panel-admin/lang/en/twitch.php
+++ b/app-modules/panel-admin/lang/en/twitch.php
@@ -32,6 +32,7 @@ return [
             'register_confirm_button' => 'Register All',
             'registered' => 'Subscriptions registered successfully.',
             'register_failed' => 'Failed to register subscriptions.',
+            'no_broadcaster' => 'Connect your Twitch account first — use the "Connect Twitch" button above.',
             'sync' => 'Sync from Twitch',
             'synced' => 'Subscriptions synced successfully.',
             'sync_failed' => 'Failed to sync subscriptions from Twitch.',

--- a/app-modules/panel-admin/lang/en/twitch.php
+++ b/app-modules/panel-admin/lang/en/twitch.php
@@ -31,6 +31,7 @@ return [
             'register' => 'Register Subscriptions',
             'register_confirm_button' => 'Register All',
             'registered' => 'Subscriptions registered successfully.',
+            'register_partial' => 'Some subscriptions failed to register.',
             'register_failed' => 'Failed to register subscriptions.',
             'no_broadcaster' => 'Connect your Twitch account first — use the "Connect Twitch" button above.',
             'sync' => 'Sync from Twitch',

--- a/app-modules/panel-admin/lang/en/twitch.php
+++ b/app-modules/panel-admin/lang/en/twitch.php
@@ -19,6 +19,11 @@ return [
         'plural' => 'Event Logs',
     ],
 
+    'connect' => [
+        'connect' => 'Connect Twitch',
+        'reconnect' => 'Reconnect Twitch (:login)',
+    ],
+
     'subscriptions' => [
         'label' => 'Subscription',
         'plural' => 'Subscriptions',

--- a/app-modules/panel-admin/resources/views/twitch/register-subscriptions-modal.blade.php
+++ b/app-modules/panel-admin/resources/views/twitch/register-subscriptions-modal.blade.php
@@ -15,8 +15,8 @@
         <div class="flex items-start gap-3 rounded-xl border border-red-500/30 bg-red-500/5 p-4">
             <x-filament::icon icon="heroicon-o-exclamation-triangle" class="mt-0.5 h-5 w-5 shrink-0 text-red-400" />
             <div>
-                <p class="text-sm font-medium text-red-400">No Twitch channel linked</p>
-                <p class="mt-1 text-xs text-red-400/70">Connect a Twitch channel to this tenant before registering subscriptions. Use the Tenant Settings page or run <code class="rounded bg-red-500/10 px-1 py-0.5 font-mono text-[10px]">twitch:link-channel</code>.</p>
+                <p class="text-sm font-medium text-red-400">No Twitch account connected</p>
+                <p class="mt-1 text-xs text-red-400/70">Connect your Twitch account with the <span class="font-medium">“Connect Twitch”</span> button on this page before registering subscriptions.</p>
             </div>
         </div>
     @else

--- a/app-modules/panel-admin/src/Twitch/Actions/ConnectTwitchAction.php
+++ b/app-modules/panel-admin/src/Twitch/Actions/ConnectTwitchAction.php
@@ -7,6 +7,7 @@ namespace He4rt\PanelAdmin\Twitch\Actions;
 use Filament\Actions\Action;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
 
 class ConnectTwitchAction extends Action
 {
@@ -33,11 +34,19 @@ class ConnectTwitchAction extends Action
 
     private function resolveConnectedIdentity(): ?ExternalIdentity
     {
-        return ExternalIdentity::query()
+        $user = filament()->auth()->user();
+
+        if (!$user instanceof User) {
+            return null;
+        }
+
+        $identity = $user->providers()
             ->where('provider', IdentityProvider::Twitch)
             ->whereNotNull('connected_at')
             ->whereNull('disconnected_at')
             ->first();
+
+        return $identity instanceof ExternalIdentity ? $identity : null;
     }
 
     private function resolveLogin(ExternalIdentity $identity): string

--- a/app-modules/panel-admin/src/Twitch/Actions/ConnectTwitchAction.php
+++ b/app-modules/panel-admin/src/Twitch/Actions/ConnectTwitchAction.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace He4rt\PanelAdmin\Twitch\Actions;
+
+use Filament\Actions\Action;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+
+class ConnectTwitchAction extends Action
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $connectedIdentity = $this->resolveConnectedIdentity();
+        $isConnected = $connectedIdentity instanceof ExternalIdentity;
+
+        $this
+            ->label($isConnected
+                ? __('panel-admin::twitch.connect.reconnect', ['login' => $this->resolveLogin($connectedIdentity)])
+                : __('panel-admin::twitch.connect.connect'))
+            ->icon($isConnected ? 'heroicon-o-check-badge' : 'heroicon-o-link')
+            ->color($isConnected ? 'gray' : 'primary')
+            ->url(route('oauth.redirect', ['panel' => 'admin', 'provider' => 'twitch']));
+    }
+
+    public static function getDefaultName(): ?string
+    {
+        return 'connect-twitch';
+    }
+
+    private function resolveConnectedIdentity(): ?ExternalIdentity
+    {
+        return ExternalIdentity::query()
+            ->where('provider', IdentityProvider::Twitch)
+            ->whereNotNull('connected_at')
+            ->whereNull('disconnected_at')
+            ->first();
+    }
+
+    private function resolveLogin(ExternalIdentity $identity): string
+    {
+        $metadata = $identity->metadata ?? [];
+
+        /** @var string $login */
+        $login = $metadata['login']
+            ?? $metadata['username']
+            ?? $identity->external_account_id
+            ?? 'twitch';
+
+        return $login;
+    }
+}

--- a/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
+++ b/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
@@ -9,6 +9,7 @@ use Filament\Notifications\Notification;
 use Filament\Support\Enums\Width;
 use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
 use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
 use He4rt\IntegrationTwitch\Actions\RegisterTwitchSubscriptionsAction;
 use He4rt\IntegrationTwitch\Enums\TwitchEventSubType;
 use He4rt\IntegrationTwitch\Models\TwitchSubscription;
@@ -33,19 +34,20 @@ class RegisterSubscriptionsAction extends Action
                 'groups' => $this->buildEventTypeGroups(),
                 'secret' => $this->maskSecret(),
             ]))
-            ->action(static function (): void {
-                $action = resolve(RegisterTwitchSubscriptionsAction::class);
-                $result = $action();
+            ->action(function (): void {
+                $broadcaster = $this->resolveBroadcaster();
 
-                if ($result['errors']['broadcaster'] ?? null) {
+                if ($broadcaster === null) {
                     Notification::make()
                         ->danger()
                         ->title(__('panel-admin::twitch.subscriptions.actions.register_failed'))
-                        ->body($result['errors']['broadcaster'])
+                        ->body(__('panel-admin::twitch.subscriptions.actions.no_broadcaster'))
                         ->send();
 
                     return;
                 }
+
+                $result = resolve(RegisterTwitchSubscriptionsAction::class)($broadcaster['id']);
 
                 Notification::make()
                     ->success()
@@ -66,17 +68,27 @@ class RegisterSubscriptionsAction extends Action
     }
 
     /**
+     * The broadcaster is the Twitch account connected to the authenticated
+     * admin — no config/env fallback. The admin connects it via the
+     * "Connect Twitch" action on this page.
+     *
      * @return array{id: string, login: string}|null
      */
     private function resolveBroadcaster(): ?array
     {
-        $identity = ExternalIdentity::query()
+        $user = filament()->auth()->user();
+
+        if (!$user instanceof User) {
+            return null;
+        }
+
+        $identity = $user->providers()
             ->where('provider', IdentityProvider::Twitch)
             ->whereNotNull('connected_at')
             ->whereNull('disconnected_at')
             ->first();
 
-        if (!$identity) {
+        if (!$identity instanceof ExternalIdentity) {
             return null;
         }
 

--- a/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
+++ b/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
@@ -49,16 +49,22 @@ class RegisterSubscriptionsAction extends Action
 
                 $result = resolve(RegisterTwitchSubscriptionsAction::class)($broadcaster['id']);
 
-                Notification::make()
-                    ->success()
-                    ->title(__('panel-admin::twitch.subscriptions.actions.registered'))
+                $hasFailures = $result['failed'] > 0;
+
+                $notification = Notification::make()
+                    ->title(__($hasFailures
+                        ? 'panel-admin::twitch.subscriptions.actions.register_partial'
+                        : 'panel-admin::twitch.subscriptions.actions.registered'))
                     ->body(sprintf(
                         '%d created, %d skipped, %d failed.',
                         $result['created'],
                         $result['skipped'],
                         $result['failed'],
-                    ))
-                    ->send();
+                    ));
+
+                $hasFailures ? $notification->warning() : $notification->success();
+
+                $notification->send();
             });
     }
 
@@ -113,7 +119,13 @@ class RegisterSubscriptionsAction extends Action
 
     private function maskSecret(): string
     {
-        $secret = config()->string('services.twitch.eventsub_secret');
+        // Read defensively: TWITCH_EVENTSUB_SECRET has no config default (it must
+        // fail loud on the security paths), so the display must tolerate it being unset.
+        $secret = config('services.twitch.eventsub_secret');
+
+        if (!is_string($secret) || $secret === '') {
+            return '—';
+        }
 
         return mb_substr($secret, 0, 4).str_repeat('*', max(mb_strlen($secret) - 4, 0));
     }

--- a/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
+++ b/app-modules/panel-admin/src/Twitch/Actions/RegisterSubscriptionsAction.php
@@ -88,7 +88,9 @@ class RegisterSubscriptionsAction extends Action
 
     private function resolveCallbackUrl(): string
     {
-        $configured = config()->string('services.twitch.eventsub_callback', '');
+        // Cast instead of config()->string(): the key may be present-but-null when
+        // TWITCH_EVENTSUB_CALLBACK is unset, and config()->string() throws on null.
+        $configured = (string) config('services.twitch.eventsub_callback', '');
 
         if ($configured !== '') {
             return $configured;

--- a/app-modules/panel-admin/src/Twitch/Resources/TwitchSubscriptionResource/Pages/ListTwitchSubscriptions.php
+++ b/app-modules/panel-admin/src/Twitch/Resources/TwitchSubscriptionResource/Pages/ListTwitchSubscriptions.php
@@ -10,6 +10,7 @@ use Filament\Resources\Pages\ListRecords;
 use He4rt\IntegrationTwitch\Models\TwitchSubscription;
 use He4rt\IntegrationTwitch\Transport\Requests\EventSub\ListSubscriptions;
 use He4rt\IntegrationTwitch\Transport\TwitchHelixConnector;
+use He4rt\PanelAdmin\Twitch\Actions\ConnectTwitchAction;
 use He4rt\PanelAdmin\Twitch\Actions\RegisterSubscriptionsAction;
 use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource;
 use Saloon\Exceptions\Request\RequestException;
@@ -21,6 +22,7 @@ class ListTwitchSubscriptions extends ListRecords
     protected function getHeaderActions(): array
     {
         return [
+            ConnectTwitchAction::make(),
             RegisterSubscriptionsAction::make(),
             Action::make('sync')
                 ->label(__('panel-admin::twitch.subscriptions.actions.sync'))

--- a/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Identity\ExternalIdentity\Enums\IdentityProvider;
+use He4rt\Identity\ExternalIdentity\Models\ExternalIdentity;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource\Pages\ListTwitchSubscriptions;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $user = User::factory()->create(['username' => 'danielhe4rt']);
+
+    config(['he4rt.admins' => 'danielhe4rt']);
+
+    $this->actingAs($user);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+test('botão de conectar aponta para o fluxo OAuth da twitch no painel admin', function (): void {
+    $expectedUrl = route('oauth.redirect', ['panel' => 'admin', 'provider' => 'twitch']);
+
+    livewire(ListTwitchSubscriptions::class)
+        ->assertActionExists('connect-twitch')
+        ->assertActionHasUrl('connect-twitch', $expectedUrl)
+        ->assertActionHasLabel('connect-twitch', __('panel-admin::twitch.connect.connect'));
+});
+
+test('quando já existe identidade twitch conectada, o botão mostra reconectar com o login', function (): void {
+    ExternalIdentity::factory()->create([
+        'provider' => IdentityProvider::Twitch,
+        'connected_at' => now(),
+        'disconnected_at' => null,
+        'metadata' => ['login' => 'he4rtdevs'],
+    ]);
+
+    livewire(ListTwitchSubscriptions::class)
+        ->assertActionExists('connect-twitch')
+        ->assertActionHasLabel(
+            'connect-twitch',
+            __('panel-admin::twitch.connect.reconnect', ['login' => 'he4rtdevs']),
+        );
+});

--- a/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Twitch/ConnectTwitchActionTest.php
@@ -11,11 +11,11 @@ use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource\Pages\ListTwitc
 use function Pest\Livewire\livewire;
 
 beforeEach(function (): void {
-    $user = User::factory()->create(['username' => 'danielhe4rt']);
+    $this->user = User::factory()->create(['username' => 'danielhe4rt']);
 
     config(['he4rt.admins' => 'danielhe4rt']);
 
-    $this->actingAs($user);
+    $this->actingAs($this->user);
 
     Filament::setCurrentPanel(Filament::getPanel('admin'));
 });
@@ -31,6 +31,8 @@ test('botão de conectar aponta para o fluxo OAuth da twitch no painel admin', f
 
 test('quando já existe identidade twitch conectada, o botão mostra reconectar com o login', function (): void {
     ExternalIdentity::factory()->create([
+        'model_type' => (new User)->getMorphClass(),
+        'model_id' => $this->user->id,
         'provider' => IdentityProvider::Twitch,
         'connected_at' => now(),
         'disconnected_at' => null,

--- a/app-modules/panel-admin/tests/Feature/Twitch/RegisterSubscriptionsActionTest.php
+++ b/app-modules/panel-admin/tests/Feature/Twitch/RegisterSubscriptionsActionTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use He4rt\Identity\User\Models\User;
+use He4rt\PanelAdmin\Twitch\Resources\TwitchSubscriptionResource\Pages\ListTwitchSubscriptions;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function (): void {
+    $user = User::factory()->create(['username' => 'danielhe4rt']);
+
+    config(['he4rt.admins' => 'danielhe4rt']);
+
+    $this->actingAs($user);
+
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+});
+
+test('o modal de registrar subscriptions monta mesmo sem eventsub_callback configurado', function (): void {
+    // Reproduz o gatilho exato do crash: a chave presente-porém-nula quando
+    // TWITCH_EVENTSUB_CALLBACK está unset. O callback deve derivar de app.url
+    // em vez de estourar em config()->string() com valor nulo.
+    config()->set('services.twitch.eventsub_callback');
+
+    livewire(ListTwitchSubscriptions::class)
+        ->mountAction('register-subscriptions')
+        ->assertActionMounted('register-subscriptions')
+        ->assertHasNoErrors();
+});

--- a/config/services.php
+++ b/config/services.php
@@ -49,7 +49,7 @@ return [
             'app' => env('TWITCH_OAUTH_SCOPES_APP', 'user:read:email'),
         ],
         'enabled' => env('TWITCH_OAUTH_ENABLED', default: true),
-        'eventsub_secret' => env('TWITCH_EVENTSUB_SECRET', 'h34rt-tw1tch-3v3ntsub-s3cr3t-k3y'),
+        'eventsub_secret' => env('TWITCH_EVENTSUB_SECRET'),
         'eventsub_callback' => env('TWITCH_EVENTSUB_CALLBACK', ''),
         'broadcaster_login' => env('TWITCH_BROADCASTER_LOGIN', ''),
     ],

--- a/config/services.php
+++ b/config/services.php
@@ -52,7 +52,6 @@ return [
         'eventsub_secret' => env('TWITCH_EVENTSUB_SECRET', 'h34rt-tw1tch-3v3ntsub-s3cr3t-k3y'),
         'eventsub_callback' => env('TWITCH_EVENTSUB_CALLBACK', ''),
         'broadcaster_login' => env('TWITCH_BROADCASTER_LOGIN', ''),
-        'broadcaster_id' => env('TWITCH_BROADCASTER_ID', ''),
     ],
 
     'devto' => [

--- a/config/services.php
+++ b/config/services.php
@@ -50,9 +50,9 @@ return [
         ],
         'enabled' => env('TWITCH_OAUTH_ENABLED', default: true),
         'eventsub_secret' => env('TWITCH_EVENTSUB_SECRET', 'h34rt-tw1tch-3v3ntsub-s3cr3t-k3y'),
-        'eventsub_callback' => env('TWITCH_EVENTSUB_CALLBACK'),
-        'broadcaster_login' => env('TWITCH_BROADCASTER_LOGIN'),
-        'broadcaster_id' => env('TWITCH_BROADCASTER_ID'),
+        'eventsub_callback' => env('TWITCH_EVENTSUB_CALLBACK', ''),
+        'broadcaster_login' => env('TWITCH_BROADCASTER_LOGIN', ''),
+        'broadcaster_id' => env('TWITCH_BROADCASTER_ID', ''),
     ],
 
     'devto' => [


### PR DESCRIPTION
## Contexto

Ao dar setup da Twitch em produção (foco: EventSub pra detectar lives), o fluxo de conectar/registrar esbarrou em bugs latentes do módulo `integration-twitch` — o módulo nunca tinha sido exercido com env incompleta. Esta branch adiciona um botão de conexão em um clique, corrige os crashes e remove a necessidade do `TWITCH_BROADCASTER_ID`.

## Commits

### `feat(panel-admin)` — botão "Connect Twitch" (1 clique)
Header action na página **Twitch → Subscriptions** que inicia o OAuth link flow apontando pra `route('oauth.redirect', panel: admin, provider: twitch)`. Como o admin já está logado, vincula a Twitch ao usuário atual (intent `Link`) com o scope set de admin. Rótulo dinâmico: **Connect** / **Reconnect (login)**.

### `fix(integration-twitch)` — hardening contra env incompleta
Três crashes pré-existentes:
- **`TypeError` no redirect** — `TwitchHelixConnector` buscava o app token no construtor; só montar a URL de redirect já forçava o fetch. Agora o token é resolvido **lazy** no `defaultAuth()`.
- **`getToken()` retornava `null`** — closure tipada `: string`. Passa a lançar `OAuthFlowException` (capturada pelo `OAuthController`) + protege `expires_in`.
- **`config()->string()` estourava em `null`** — `TWITCH_EVENTSUB_CALLBACK` unset. Defaults `''` no config + leitura null-safe.

### `feat(integration-twitch)` — broadcaster vem do OAuth do admin
Remove a dependência de `TWITCH_BROADCASTER_ID`. O broadcaster passa a ser a conta Twitch conectada ao admin autenticado (via `ExternalIdentity`), eliminando a divergência entre o que o modal exibia (ExternalIdentity) e o que de fato registrava (config).
- `RegisterTwitchSubscriptionsAction` recebe o broadcaster id como argumento; a presentation resolve o "quem".
- `RegisterSubscriptionsAction` resolve a Twitch do admin logado e bloqueia com aviso quando não há nenhuma.
- `twitch:link-channel` passa a imprimir o comando `twitch:subscribe` em vez do env removido.

## Testes
Suíte Twitch verde (integration-twitch + panel-admin). Testes de regressão de UI do modal `RegisterSubscriptions` com o broadcaster do usuário autenticado ficaram de fora por ora (issue de resolução de componente Livewire em teste) — a lógica de domínio está coberta em `RegisterTwitchSubscriptionsActionTest`.

## Setup de produção pendente (fora do código)
- `TWITCH_OAUTH_CLIENT_SECRET` válido (a Twitch retornou `403 invalid client secret` em dev).
- Registrar o redirect `https://<dominio>/auth/oauth/twitch` no dev console da Twitch.
- Conectar a Twitch pelo novo botão → `twitch:subscribe <id> --type=stream.online` (o id agora vem do OAuth).