### PR TITLE
feat(portal): refine retrospective repo slides

### DIFF
--- a/app-modules/portal/resources/views/components/retro/slides/panorama.blade.php
+++ b/app-modules/portal/resources/views/components/retro/slides/panorama.blade.php
@@ -6,7 +6,7 @@
         <p class="sec-sub" data-anim>
             <b style="color: var(--text)">{{ $meta['people'] }} pessoas</b> somaram
             <b style="color: var(--text)">{{ $meta['total'] }} interações</b>
-            em {{ number_format($meta['changed_files'], 0, ',', '.') }} arquivos tocados.
+            em {{ $meta['repos'] }} @choice('repositório|repositórios', $meta['repos']).
         </p>
         <div class="stats" data-anim style="margin-top: 24px">
             <div class="stat">

--- a/app-modules/portal/resources/views/components/retro/slides/repo.blade.php
+++ b/app-modules/portal/resources/views/components/retro/slides/repo.blade.php
@@ -44,11 +44,9 @@
             @endif
         </div>
         <div style="display: flex; flex-direction: column; gap: 10px">
-            @forelse ($repo['prs'] as $pr)
+            @foreach ($repo['prs'] as $pr)
                 <div data-anim><x-portal::retro.pr-row :pr="$pr" /></div>
-            @empty
-                <p class="sec-sub">Sem PRs nesse recorte — a atividade veio de reviews, issues e comentários.</p>
-            @endforelse
+            @endforeach
         </div>
     </div>
 </section>

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -269,6 +269,10 @@ final readonly class CommunityRetrospective
                     ],
                 ];
             })
+            // Só entram na retrospectiva repos com ao menos 1 PR no recorte;
+            // atividade só de review/issue/comentário some do card (mas segue
+            // contando em meta/people/highlights).
+            ->filter(fn (array $repo): bool => $repo['metrics']['prs'] > 0)
             ->values()
             ->all());
     }

--- a/app-modules/portal/src/Retrospective/CommunityRetrospective.php
+++ b/app-modules/portal/src/Retrospective/CommunityRetrospective.php
@@ -63,6 +63,8 @@ final readonly class CommunityRetrospective
             ->values()
             ->all();
 
+        $repos = $this->repos($contributions);
+
         return [
             'period' => ['since' => $this->filters->since->toDateString(), 'until' => $this->filters->until->toDateString()],
             'meta' => [
@@ -78,10 +80,12 @@ final readonly class CommunityRetrospective
                 'additions' => $this->sumMeta($contributions, 'additions'),
                 'deletions' => $this->sumMeta($contributions, 'deletions'),
                 'changed_files' => $this->sumMeta($contributions, 'changed_files'),
+                // Repos exibidos = só os com PR no recorte (mesmo universo dos cards).
+                'repos' => count($repos),
                 'total' => $contributions->count(),
             ],
             'people' => $people,
-            'repos' => $this->repos($contributions),
+            'repos' => $repos,
             'highlights' => $this->highlights($contributions),
         ];
     }

--- a/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
@@ -199,8 +199,20 @@ it('esconde da lista repos sem PR no recorte mas mantém suas contribuições na
     $data = ($this->build)();
 
     expect(collect($data['repos'])->pluck('full_name')->all())->toBe(['he4rt/com-pr'])
-        ->and($data['meta']['reviews'])->toBe(1); // review segue contando nas stats gerais
+        ->and($data['meta']['reviews'])->toBe(1) // review segue contando nas stats gerais
+        ->and($data['meta']['repos'])->toBe(1); // panorama conta só repos com PR
 });
+
+it('o panorama pluraliza repositórios conforme a contagem', function (int $repos, string $expected): void {
+    $meta = ['people' => 1, 'total' => 1, 'prs' => 1, 'prs_merged' => 1, 'prs_unmerged' => 0, 'reviews' => 0, 'issues' => 0, 'comments' => 0, 'review_comments' => 0, 'commits' => 0, 'additions' => 1, 'deletions' => 0, 'changed_files' => 1, 'repos' => $repos];
+
+    $html = Blade::render('<x-portal::retro.slides.panorama :meta="$meta" />', ['meta' => $meta]);
+
+    expect($html)->toContain($expected);
+})->with([
+    'singular' => [1, 'em 1 repositório.'],
+    'plural' => [3, 'em 3 repositórios.'],
+]);
 
 it('aplica filtros de tipo, repo, desfecho e pessoa', function (): void {
     contribution(['actor_login' => 'maria', 'repo' => 'he4rt/a', 'type' => ContributionType::Pr, 'external_ref' => 'pr:1', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'merged', 'merged' => true]]);

--- a/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
+++ b/app-modules/portal/tests/Feature/CommunityRetrospectiveTest.php
@@ -192,6 +192,16 @@ it('agrupa PRs por repositório e lista destaques por linhas mudadas', function 
         ->and($data['highlights'][0]['repo'])->toBe('he4rt/heartdevs.com');
 });
 
+it('esconde da lista repos sem PR no recorte mas mantém suas contribuições nas stats', function (): void {
+    contribution(['actor_login' => 'maria', 'repo' => 'he4rt/com-pr', 'type' => ContributionType::Pr, 'external_ref' => 'pr:1', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'merged', 'merged' => true, 'title' => 't', 'url' => 'u', 'additions' => 5, 'deletions' => 1, 'changed_files' => 1]]);
+    contribution(['actor_login' => 'joao', 'repo' => 'he4rt/so-review', 'type' => ContributionType::Review, 'external_ref' => 'review:1', 'occurred_at' => '2026-06-02']);
+
+    $data = ($this->build)();
+
+    expect(collect($data['repos'])->pluck('full_name')->all())->toBe(['he4rt/com-pr'])
+        ->and($data['meta']['reviews'])->toBe(1); // review segue contando nas stats gerais
+});
+
 it('aplica filtros de tipo, repo, desfecho e pessoa', function (): void {
     contribution(['actor_login' => 'maria', 'repo' => 'he4rt/a', 'type' => ContributionType::Pr, 'external_ref' => 'pr:1', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'merged', 'merged' => true]]);
     contribution(['actor_login' => 'maria', 'repo' => 'he4rt/a', 'type' => ContributionType::Pr, 'external_ref' => 'pr:2', 'occurred_at' => '2026-06-02', 'metadata' => ['state' => 'open', 'merged' => false]]);


### PR DESCRIPTION
## Summary
- Esconde da retrospectiva os repos sem PR no recorte (só review/issue/comentário): o card some, mas as contribuições seguem contando em `meta`/`people`/`highlights`.
- Remove o empty-state morto "Sem PRs nesse recorte…" do card de repo.
- Panorama passa a mostrar "em N repositório(s)" (repos com PR = cards exibidos) no lugar de "N arquivos tocados"; plural via `@choice`.

## Test plan
- [x] `php artisan test --compact --filter=CommunityRetrospective` (30 passed)
- [x] Abrir `/comunidade/retrospectiva` num recorte com repo só de review/issue/comentário (ex.: `gvieira18/sycorax`) → card sumiu, stats gerais iguais
- [x] Panorama: contagem de repositórios bate com o nº de cards e pluraliza (1 → "repositório", N → "repositórios")