### PR TITLE
fix: restore secondary indexes dropped by tenancy removal

### DIFF
--- a/app-modules/activity/database/migrations/2026_07_15_001258_recreate_activity_post_tenancy_indexes.php
+++ b/app-modules/activity/database/migrations/2026_07_15_001258_recreate_activity_post_tenancy_indexes.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Recreates the non-tenant equivalents of the secondary indexes dropped by
+ * `2026_07_07_000000_drop_multi_tenancy` for the activity-module tables. That
+ * migration collapsed the unique indexes correctly but removed every
+ * tenant-leading performance index without a replacement, leaving hot query
+ * paths (marketing dashboards, timeline feed) on sequential scans.
+ *
+ * Also adds the never-existing `voice_messages` partial index used by the
+ * marketing voice widgets, which always filter `state = 'joined'` over an
+ * `occurred_at` window.
+ *
+ * `CREATE INDEX CONCURRENTLY` avoids blocking the Discord bot's continuous
+ * writes during the build, and cannot run inside a transaction.
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    /**
+     * Index name => CREATE statement. Names are keys so `down()` cannot
+     * drift from `up()`.
+     *
+     * @var array<string, string>
+     */
+    private array $indexes = [
+        // messages: was messages_tenant_sent_at_idx (tenant_id, sent_at)
+        'messages_sent_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_sent_at_index ON messages (sent_at)',
+        // messages: was messages_tenant_channel_sent_at_idx (tenant_id, channel_id, sent_at)
+        'messages_channel_id_sent_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_channel_id_sent_at_index ON messages (channel_id, sent_at)',
+        // messages: was messages_tenant_kind_idx (tenant_id, kind)
+        'messages_kind_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_kind_index ON messages (kind)',
+        // voice_messages: net-new — marketing voice widgets always filter state = joined
+        'voice_messages_joined_occurred_at_index' => "CREATE INDEX CONCURRENTLY IF NOT EXISTS voice_messages_joined_occurred_at_index ON voice_messages (occurred_at) WHERE state = 'joined'",
+        // activity_timeline: was activity_timeline_tenant_feed_index (tenant_id, created_at)
+        'activity_timeline_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_created_at_index ON activity_timeline (created_at)',
+        // activity_timeline: was (tenant_id, parent_id, is_ignored, created_at)
+        'activity_timeline_feed_composite_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_feed_composite_index ON activity_timeline (parent_id, is_ignored, created_at)',
+        // activity_reactions: was activity_reactions_tenant_emoji_time_idx (tenant_id, emoji_key, created_at)
+        'activity_reactions_emoji_key_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_reactions_emoji_key_created_at_index ON activity_reactions (emoji_key, created_at)',
+        // message_mentions: was message_mentions_tenant_identity_idx (tenant_id, mentioned_identity_id)
+        'message_mentions_mentioned_identity_id_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_identity_id_index ON message_mentions (mentioned_identity_id)',
+        // message_mentions: was message_mentions_tenant_provider_idx (tenant_id, mentioned_provider_account_id)
+        'message_mentions_mentioned_provider_account_id_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_provider_account_id_index ON message_mentions (mentioned_provider_account_id)',
+        // message_embeds: was message_embeds_tenant_domain_idx (tenant_id, source_domain)
+        'message_embeds_source_domain_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_source_domain_index ON message_embeds (source_domain)',
+        // message_embeds: was message_embeds_tenant_kind_idx (tenant_id, kind)
+        'message_embeds_kind_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_kind_index ON message_embeds (kind)',
+        // membership_events: was membership_events_tenant_kind_time_idx (tenant_id, kind, occurred_at)
+        'membership_events_kind_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS membership_events_kind_occurred_at_index ON membership_events (kind, occurred_at)',
+        // moderation_events: was moderation_events_tenant_id_type_occurred_at_index
+        'moderation_events_type_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_events_type_occurred_at_index ON moderation_events (type, occurred_at)',
+        // interactions: was idx_interactions_tenant (tenant_id, occurred_at)
+        'interactions_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS interactions_occurred_at_index ON interactions (occurred_at)',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->indexes as $statement) {
+            DB::statement($statement);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (array_keys($this->indexes) as $index) {
+            DB::statement(sprintf('DROP INDEX CONCURRENTLY IF EXISTS %s', $index));
+        }
+    }
+};

--- a/app-modules/activity/database/migrations/2026_07_15_001258_recreate_activity_post_tenancy_indexes.php
+++ b/app-modules/activity/database/migrations/2026_07_15_001258_recreate_activity_post_tenancy_indexes.php
@@ -5,72 +5,31 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Recreates the non-tenant equivalents of the secondary indexes dropped by
- * `2026_07_07_000000_drop_multi_tenancy` for the activity-module tables. That
- * migration collapsed the unique indexes correctly but removed every
- * tenant-leading performance index without a replacement, leaving hot query
- * paths (marketing dashboards, timeline feed) on sequential scans.
- *
- * Also adds the never-existing `voice_messages` partial index used by the
- * marketing voice widgets, which always filter `state = 'joined'` over an
- * `occurred_at` window.
- *
- * `CREATE INDEX CONCURRENTLY` avoids blocking the Discord bot's continuous
- * writes during the build, and cannot run inside a transaction.
- */
 return new class extends Migration
 {
     public $withinTransaction = false;
 
-    /**
-     * Index name => CREATE statement. Names are keys so `down()` cannot
-     * drift from `up()`.
-     *
-     * @var array<string, string>
-     */
-    private array $indexes = [
-        // messages: was messages_tenant_sent_at_idx (tenant_id, sent_at)
-        'messages_sent_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_sent_at_index ON messages (sent_at)',
-        // messages: was messages_tenant_channel_sent_at_idx (tenant_id, channel_id, sent_at)
-        'messages_channel_id_sent_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_channel_id_sent_at_index ON messages (channel_id, sent_at)',
-        // messages: was messages_tenant_kind_idx (tenant_id, kind)
-        'messages_kind_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_kind_index ON messages (kind)',
-        // voice_messages: net-new — marketing voice widgets always filter state = joined
-        'voice_messages_joined_occurred_at_index' => "CREATE INDEX CONCURRENTLY IF NOT EXISTS voice_messages_joined_occurred_at_index ON voice_messages (occurred_at) WHERE state = 'joined'",
-        // activity_timeline: was activity_timeline_tenant_feed_index (tenant_id, created_at)
-        'activity_timeline_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_created_at_index ON activity_timeline (created_at)',
-        // activity_timeline: was (tenant_id, parent_id, is_ignored, created_at)
-        'activity_timeline_feed_composite_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_feed_composite_index ON activity_timeline (parent_id, is_ignored, created_at)',
-        // activity_reactions: was activity_reactions_tenant_emoji_time_idx (tenant_id, emoji_key, created_at)
-        'activity_reactions_emoji_key_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_reactions_emoji_key_created_at_index ON activity_reactions (emoji_key, created_at)',
-        // message_mentions: was message_mentions_tenant_identity_idx (tenant_id, mentioned_identity_id)
-        'message_mentions_mentioned_identity_id_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_identity_id_index ON message_mentions (mentioned_identity_id)',
-        // message_mentions: was message_mentions_tenant_provider_idx (tenant_id, mentioned_provider_account_id)
-        'message_mentions_mentioned_provider_account_id_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_provider_account_id_index ON message_mentions (mentioned_provider_account_id)',
-        // message_embeds: was message_embeds_tenant_domain_idx (tenant_id, source_domain)
-        'message_embeds_source_domain_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_source_domain_index ON message_embeds (source_domain)',
-        // message_embeds: was message_embeds_tenant_kind_idx (tenant_id, kind)
-        'message_embeds_kind_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_kind_index ON message_embeds (kind)',
-        // membership_events: was membership_events_tenant_kind_time_idx (tenant_id, kind, occurred_at)
-        'membership_events_kind_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS membership_events_kind_occurred_at_index ON membership_events (kind, occurred_at)',
-        // moderation_events: was moderation_events_tenant_id_type_occurred_at_index
-        'moderation_events_type_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_events_type_occurred_at_index ON moderation_events (type, occurred_at)',
-        // interactions: was idx_interactions_tenant (tenant_id, occurred_at)
-        'interactions_occurred_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS interactions_occurred_at_index ON interactions (occurred_at)',
-    ];
-
     public function up(): void
     {
-        foreach ($this->indexes as $statement) {
-            DB::statement($statement);
-        }
-    }
+        $statements = [
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_sent_at_index ON messages (sent_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_channel_id_sent_at_index ON messages (channel_id, sent_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS messages_kind_index ON messages (kind)',
+            "CREATE INDEX CONCURRENTLY IF NOT EXISTS voice_messages_joined_occurred_at_index ON voice_messages (occurred_at) WHERE state = 'joined'",
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_created_at_index ON activity_timeline (created_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_timeline_feed_composite_index ON activity_timeline (parent_id, is_ignored, created_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS activity_reactions_emoji_key_created_at_index ON activity_reactions (emoji_key, created_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_identity_id_index ON message_mentions (mentioned_identity_id)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_mentions_mentioned_provider_account_id_index ON message_mentions (mentioned_provider_account_id)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_source_domain_index ON message_embeds (source_domain)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS message_embeds_kind_index ON message_embeds (kind)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS membership_events_kind_occurred_at_index ON membership_events (kind, occurred_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_events_type_occurred_at_index ON moderation_events (type, occurred_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS interactions_occurred_at_index ON interactions (occurred_at)',
+        ];
 
-    public function down(): void
-    {
-        foreach (array_keys($this->indexes) as $index) {
-            DB::statement(sprintf('DROP INDEX CONCURRENTLY IF EXISTS %s', $index));
+        foreach ($statements as $statement) {
+            DB::statement($statement);
         }
     }
 };

--- a/app-modules/integration-github/database/migrations/2026_07_15_001019_restore_github_contributions_type_time_index.php
+++ b/app-modules/integration-github/database/migrations/2026_07_15_001019_restore_github_contributions_type_time_index.php
@@ -5,16 +5,6 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Restores `idx_github_contributions_type_time (type, occurred_at)`, dropped
- * by mistake in `2026_07_07_000000_drop_multi_tenancy`: the drop was labeled
- * "tenant time/type indexes", but this index never contained `tenant_id` —
- * the GitHub integration tables never carried tenancy at all. The original
- * definition lives in `2026_06_04_000002_create_github_contributions_table`.
- *
- * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
- * cannot run inside a transaction.
- */
 return new class extends Migration
 {
     public $withinTransaction = false;
@@ -22,10 +12,5 @@ return new class extends Migration
     public function up(): void
     {
         DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_github_contributions_type_time ON github_contributions (type, occurred_at)');
-    }
-
-    public function down(): void
-    {
-        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS idx_github_contributions_type_time');
     }
 };

--- a/app-modules/integration-github/database/migrations/2026_07_15_001019_restore_github_contributions_type_time_index.php
+++ b/app-modules/integration-github/database/migrations/2026_07_15_001019_restore_github_contributions_type_time_index.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Restores `idx_github_contributions_type_time (type, occurred_at)`, dropped
+ * by mistake in `2026_07_07_000000_drop_multi_tenancy`: the drop was labeled
+ * "tenant time/type indexes", but this index never contained `tenant_id` —
+ * the GitHub integration tables never carried tenancy at all. The original
+ * definition lives in `2026_06_04_000002_create_github_contributions_table`.
+ *
+ * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
+ * cannot run inside a transaction.
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_github_contributions_type_time ON github_contributions (type, occurred_at)');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS idx_github_contributions_type_time');
+    }
+};

--- a/app-modules/moderation/database/migrations/2026_07_15_001259_recreate_moderation_post_tenancy_indexes.php
+++ b/app-modules/moderation/database/migrations/2026_07_15_001259_recreate_moderation_post_tenancy_indexes.php
@@ -5,46 +5,20 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * Recreates the non-tenant equivalents of the moderation-module secondary
- * indexes dropped by `2026_07_07_000000_drop_multi_tenancy` without a
- * replacement: the queue ordering index on cases, the active-rules filter
- * (tenant_id was the trailing column, but the leading is_active predicate
- * lost its index too), and the audit-log date index.
- *
- * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
- * cannot run inside a transaction.
- */
 return new class extends Migration
 {
     public $withinTransaction = false;
 
-    /**
-     * Index name => CREATE statement. Names are keys so `down()` cannot
-     * drift from `up()`.
-     *
-     * @var array<string, string>
-     */
-    private array $indexes = [
-        // was idx_cases_queue (tenant_id, status, priority, created_at)
-        'moderation_cases_status_priority_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_cases_status_priority_created_at_index ON moderation_cases (status, priority, created_at)',
-        // was idx_rules_active (is_active, tenant_id)
-        'moderation_rules_is_active_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_rules_is_active_index ON moderation_rules (is_active)',
-        // was idx_audit_tenant_date (tenant_id, created_at)
-        'moderation_audit_log_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_audit_log_created_at_index ON moderation_audit_log (created_at)',
-    ];
-
     public function up(): void
     {
-        foreach ($this->indexes as $statement) {
-            DB::statement($statement);
-        }
-    }
+        $statements = [
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_cases_status_priority_created_at_index ON moderation_cases (status, priority, created_at)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_rules_is_active_index ON moderation_rules (is_active)',
+            'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_audit_log_created_at_index ON moderation_audit_log (created_at)',
+        ];
 
-    public function down(): void
-    {
-        foreach (array_keys($this->indexes) as $index) {
-            DB::statement(sprintf('DROP INDEX CONCURRENTLY IF EXISTS %s', $index));
+        foreach ($statements as $statement) {
+            DB::statement($statement);
         }
     }
 };

--- a/app-modules/moderation/database/migrations/2026_07_15_001259_recreate_moderation_post_tenancy_indexes.php
+++ b/app-modules/moderation/database/migrations/2026_07_15_001259_recreate_moderation_post_tenancy_indexes.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Recreates the non-tenant equivalents of the moderation-module secondary
+ * indexes dropped by `2026_07_07_000000_drop_multi_tenancy` without a
+ * replacement: the queue ordering index on cases, the active-rules filter
+ * (tenant_id was the trailing column, but the leading is_active predicate
+ * lost its index too), and the audit-log date index.
+ *
+ * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
+ * cannot run inside a transaction.
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    /**
+     * Index name => CREATE statement. Names are keys so `down()` cannot
+     * drift from `up()`.
+     *
+     * @var array<string, string>
+     */
+    private array $indexes = [
+        // was idx_cases_queue (tenant_id, status, priority, created_at)
+        'moderation_cases_status_priority_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_cases_status_priority_created_at_index ON moderation_cases (status, priority, created_at)',
+        // was idx_rules_active (is_active, tenant_id)
+        'moderation_rules_is_active_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_rules_is_active_index ON moderation_rules (is_active)',
+        // was idx_audit_tenant_date (tenant_id, created_at)
+        'moderation_audit_log_created_at_index' => 'CREATE INDEX CONCURRENTLY IF NOT EXISTS moderation_audit_log_created_at_index ON moderation_audit_log (created_at)',
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->indexes as $statement) {
+            DB::statement($statement);
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (array_keys($this->indexes) as $index) {
+            DB::statement(sprintf('DROP INDEX CONCURRENTLY IF EXISTS %s', $index));
+        }
+    }
+};

--- a/database/migrations/2026_07_15_001020_add_state_index_to_addresses.php
+++ b/database/migrations/2026_07_15_001020_add_state_index_to_addresses.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The marketing location dashboard (`MembersByState`,
+ * `CommunityActivityStats::locatedMembers`) filters `addresses` on
+ * `addressable_type = 'user'` and groups by `state`, but only the generic
+ * morph index `(addressable_type, addressable_id)` exists. This composite
+ * covers both the type predicate and the state grouping.
+ *
+ * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
+ * cannot run inside a transaction.
+ */
+return new class extends Migration
+{
+    public $withinTransaction = false;
+
+    public function up(): void
+    {
+        DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS addresses_addressable_type_state_index ON addresses (addressable_type, state)');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS addresses_addressable_type_state_index');
+    }
+};

--- a/database/migrations/2026_07_15_001020_add_state_index_to_addresses.php
+++ b/database/migrations/2026_07_15_001020_add_state_index_to_addresses.php
@@ -5,16 +5,6 @@ declare(strict_types=1);
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\DB;
 
-/**
- * The marketing location dashboard (`MembersByState`,
- * `CommunityActivityStats::locatedMembers`) filters `addresses` on
- * `addressable_type = 'user'` and groups by `state`, but only the generic
- * morph index `(addressable_type, addressable_id)` exists. This composite
- * covers both the type predicate and the state grouping.
- *
- * `CREATE INDEX CONCURRENTLY` avoids blocking writes during the build and
- * cannot run inside a transaction.
- */
 return new class extends Migration
 {
     public $withinTransaction = false;
@@ -22,10 +12,5 @@ return new class extends Migration
     public function up(): void
     {
         DB::statement('CREATE INDEX CONCURRENTLY IF NOT EXISTS addresses_addressable_type_state_index ON addresses (addressable_type, state)');
-    }
-
-    public function down(): void
-    {
-        DB::statement('DROP INDEX CONCURRENTLY IF EXISTS addresses_addressable_type_state_index');
     }
 };


### PR DESCRIPTION
## Contexto

O `drop_multi_tenancy` (#413) colapsou corretamente os índices **únicos**
tenant-scoped, mas dropou ~17 índices **secundários** (de performance) sob o
comentário _"no collapsed replacement needed"_ — sem nunca recriar o
equivalente sem `tenant_id`. Resultado: as páginas de **Marketing** do painel
admin rodam 7+ agregações por load como *sequential scans* sobre as maiores
tabelas do banco (`messages`, `voice_messages`, `activity_timeline`).

Dois achados extras da investigação:

1. **Bug no drop**: `idx_github_contributions_type_time (type, occurred_at)`
   nunca teve `tenant_id` (a integração GitHub nunca teve tenancy), mas foi
   dropado mesmo assim — o comentário na migration o rotula errado como
   índice de tenant.
2. **Colunas quentes nunca indexadas**: `voice_messages (occurred_at, state)`
   e `addresses (state)` nunca tiveram índice, mas os dashboards de marketing
   filtram por elas em todo load.

## O que muda

Quatro migrations puramente aditivas (uma por módulo dono da tabela):

| Módulo | Tabela | Índice novo |
|---|---|---|
| activity | messages | `(sent_at)`, `(channel_id, sent_at)`, `(kind)` |
| activity | voice_messages | parcial `(occurred_at) WHERE state = 'joined'` |
| activity | activity_timeline | `(created_at)`, `(parent_id, is_ignored, created_at)` |
| activity | activity_reactions | `(emoji_key, created_at)` |
| activity | message_mentions | `(mentioned_identity_id)`, `(mentioned_provider_account_id)` |
| activity | message_embeds | `(source_domain)`, `(kind)` |
| activity | membership_events | `(kind, occurred_at)` |
| activity | moderation_events | `(type, occurred_at)` |
| activity | interactions | `(occurred_at)` |
| moderation | moderation_cases | `(status, priority, created_at)` |
| moderation | moderation_rules | `(is_active)` |
| moderation | moderation_audit_log | `(created_at)` |
| integration-github | github_contributions | `(type, occurred_at)` — restaura o drop indevido |
| (app root) | addresses | `(addressable_type, state)` |

Não recriados: `twitch_subscriptions_tenant_id_index` (só tenant, nada sobra)
e o composto de `external_identities` (já coberto pelo standalone
`(model_type, model_id)`).

## Verificação

- `php artisan migrate` local: 19 índices criados, confirmados em
  `pg_indexes`; re-run é no-op (`IF NOT EXISTS`).
- `EXPLAIN` em `github_contributions` (única tabela local com volume):
  `Index Only Scan using idx_github_contributions_type_time`.
- Pint, PHPStan e Rector limpos na raiz; suíte `--filter=Marketing` verde
  (5 testes, 35 assertions).